### PR TITLE
API Key startup UX

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,27 +11,11 @@ import { useSettings } from "./hooks/use-settings";
 import useMessages from "./hooks/use-messages";
 
 function App() {
-  const { isOpen: isExpanded, onToggle: toggleExpanded } = useDisclosure();
   const { messages, setMessages, removeMessage } = useMessages();
   const [singleMessageMode, setSingleMessageMode] = useState(false);
   const { settings } = useSettings();
+  const { isOpen: isExpanded, onToggle: toggleExpanded } = useDisclosure();
   const [loading, setLoading] = useState(false);
-  const [openai_api_key] = useState(() => {
-    // getting stored value
-    const saved = localStorage.getItem("openai_api_key");
-    if (!saved || saved.length === 0) {
-      // get it from user via input func
-      const key = prompt("Please enter your OpenAI API key");
-      // save it
-      if (key) {
-        localStorage.setItem("openai_api_key", JSON.stringify(key));
-        return key;
-      }
-    } else {
-      return JSON.parse(saved);
-    }
-    return "";
-  });
   const messageListRef = useRef<HTMLDivElement>(null);
   const toast = useToast();
 
@@ -71,7 +55,7 @@ function App() {
     try {
       // Send chat history to API
       const chat = new ChatOpenAI({
-        openAIApiKey: openai_api_key,
+        openAIApiKey: settings.apiKey,
         temperature: 0,
         streaming: true,
         modelName: settings.model,
@@ -131,7 +115,7 @@ function App() {
               singleMessageMode={singleMessageMode}
               onSingleMessageModeChange={setSingleMessageMode}
               isLoading={loading}
-              previousMessage={messages.slice(-1).pop()?.text}
+              previousMessage={messages.at(-1)?.text}
             />
           </Box>
         </Box>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,8 @@ import {
   ButtonGroup,
   Flex,
   IconButton,
+  Link,
+  Text,
   useColorMode,
   useColorModeValue,
   useDisclosure,
@@ -19,10 +21,14 @@ function Header() {
     <Flex
       w="100%"
       bg={useColorModeValue("white", "gray.700")}
-      justifyContent="end"
+      justify="space-between"
+      align="center"
       borderBottom="1px"
       borderColor={useColorModeValue("gray.200", "gray.500")}
     >
+      <Text pl={4} fontWeight="bold" color={useColorModeValue("blue.600", "blue.200")}>
+        <Link href="/">&lt;ChatCraft /&gt;</Link>
+      </Text>
       <ButtonGroup isAttached pr={2}>
         <IconButton
           as="a"

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -43,3 +43,7 @@
   display: block;
   overflow-x: auto;
 }
+
+.message-text a {
+  text-decoration: underline;
+}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -19,6 +19,7 @@ import {
   Kbd,
 } from "@chakra-ui/react";
 
+import RevealablePasswordInput from "./RevealablePasswordInput";
 import { useSettings } from "../hooks/use-settings";
 import { isMac } from "../utils";
 
@@ -47,11 +48,12 @@ function PreferencesModal({ isOpen, onClose }: PreferencesModalProps) {
                     size="xs"
                     colorScheme="red"
                     onClick={() => setSettings({ ...settings, apiKey: undefined })}
+                    isDisabled={!settings.apiKey}
                   >
                     Remove
                   </Button>
                 </FormLabel>
-                <Input
+                <RevealablePasswordInput
                   type="password"
                   value={settings.apiKey || ""}
                   onChange={(e) => setSettings({ ...settings, apiKey: e.target.value })}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -1,4 +1,5 @@
 import {
+  Button,
   FormControl,
   FormLabel,
   FormHelperText,
@@ -39,8 +40,22 @@ function PreferencesModal({ isOpen, onClose }: PreferencesModalProps) {
           <ModalBody>
             <VStack gap={2}>
               <FormControl>
-                <FormLabel>OpenAI API Key</FormLabel>
-                <Input type="password" placeholder="TODO..." />
+                <FormLabel>
+                  OpenAI API Key{" "}
+                  <Button
+                    ml={2}
+                    size="xs"
+                    colorScheme="red"
+                    onClick={() => setSettings({ ...settings, apiKey: undefined })}
+                  >
+                    Remove
+                  </Button>
+                </FormLabel>
+                <Input
+                  type="password"
+                  value={settings.apiKey || ""}
+                  onChange={(e) => setSettings({ ...settings, apiKey: e.target.value })}
+                />
                 <FormHelperText>Your API Key is stored in browser storage</FormHelperText>
               </FormControl>
 

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -6,13 +6,20 @@ import {
   chakra,
   Checkbox,
   Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Link,
   IconButton,
   Kbd,
   Text,
   Textarea,
   useColorModeValue,
+  HStack,
 } from "@chakra-ui/react";
-import { CgChevronUpO, CgChevronDownO } from "react-icons/cg";
+import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
+
 import { AutoResizingTextarea } from "./AutoResizingTextarea";
 
 import { useSettings } from "../hooks/use-settings";
@@ -75,7 +82,7 @@ function PromptForm({
   const [prompt, setPrompt] = useState("");
   // Has the user started typing?
   const [isDirty, setIsDirty] = useState(false);
-  const { settings } = useSettings();
+  const { settings, setSettings } = useSettings();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // If the user clears the prompt, allow up-arrow again
@@ -93,8 +100,8 @@ function PromptForm({
     }
   }, [isLoading, textareaRef]);
 
-  // Handle form submission
-  const handleSubmit = async (e: FormEvent) => {
+  // Handle prompt form submission
+  const handlePromptSubmit = (e: FormEvent) => {
     e.preventDefault();
     const value = prompt.trim();
     if (!value.length) {
@@ -102,6 +109,17 @@ function PromptForm({
     }
 
     onPrompt(value);
+  };
+
+  // Handle API key form submission
+  const handleApiKeySubmit = (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const data = new FormData(e.target as HTMLFormElement);
+    const apiKey = data.get("api-key");
+
+    if (typeof apiKey === "string") {
+      setSettings({ ...settings, apiKey: apiKey.trim() });
+    }
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -120,11 +138,11 @@ function PromptForm({
         // Deal with Enter key based on user preference
         if (settings.enterBehaviour === "newline") {
           if ((isMac() && e.metaKey) || (isWindows() && e.ctrlKey)) {
-            handleSubmit(e);
+            handlePromptSubmit(e);
           }
         } else if (settings.enterBehaviour === "send") {
           if (!e.shiftKey && prompt.length) {
-            handleSubmit(e);
+            handlePromptSubmit(e);
           }
         }
         break;
@@ -151,60 +169,106 @@ function PromptForm({
         </ButtonGroup>
       </Flex>
 
-      <chakra.form onSubmit={handleSubmit} h="100%" pb={2}>
-        <Flex pb={isExpanded ? 8 : 0} flexDir="column" h="100%">
-          <Box flex={isExpanded ? "1" : undefined} mt={2} pb={2}>
-            {isExpanded ? (
-              <Textarea
-                ref={textareaRef}
-                h="100%"
-                resize="none"
-                disabled={isLoading}
-                onKeyDown={handleKeyDown}
-                autoFocus={true}
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                bg={useColorModeValue("white", "gray.700")}
-                placeholder="Type your question"
-              />
-            ) : (
-              <AutoResizingTextarea
-                ref={textareaRef}
-                onKeyDown={handleKeyDown}
-                autoFocus={true}
-                value={prompt}
-                onChange={(e) => setPrompt(e.target.value)}
-                bg={useColorModeValue("white", "gray.700")}
-                placeholder="Type your question"
-              />
-            )}
-          </Box>
+      {/* If we have an API Key in storage, show the chat form;
+          otherwise give the user a form to enter their API key. */}
+      {settings.apiKey ? (
+        <chakra.form onSubmit={handlePromptSubmit} h="100%" pb={2}>
+          <Flex pb={isExpanded ? 8 : 0} flexDir="column" h="100%">
+            <Box flex={isExpanded ? "1" : undefined} mt={2} pb={2}>
+              {isExpanded ? (
+                <Textarea
+                  ref={textareaRef}
+                  h="100%"
+                  resize="none"
+                  disabled={isLoading}
+                  onKeyDown={handleKeyDown}
+                  autoFocus={true}
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  bg={useColorModeValue("white", "gray.700")}
+                  placeholder="Type your question"
+                />
+              ) : (
+                <AutoResizingTextarea
+                  ref={textareaRef}
+                  onKeyDown={handleKeyDown}
+                  autoFocus={true}
+                  value={prompt}
+                  onChange={(e) => setPrompt(e.target.value)}
+                  bg={useColorModeValue("white", "gray.700")}
+                  placeholder="Type your question"
+                />
+              )}
+            </Box>
 
-          <Flex gap={1} justify={"space-between"} align="center">
-            <Checkbox
-              isDisabled={isLoading}
-              checked={singleMessageMode}
-              onChange={(e) => onSingleMessageModeChange(e.target.checked)}
-            >
-              Single Message Mode
-            </Checkbox>
-            <ButtonGroup>
-              <Button onClick={onClear} variant="outline" size="sm">
-                Clear Chat
-              </Button>
-              <Button
-                type="submit"
-                size="sm"
-                isDisabled={isLoading || !prompt.length}
-                isLoading={isLoading}
-                loadingText="Loading"
+            <Flex gap={1} justify={"space-between"} align="center">
+              <Checkbox
+                isDisabled={isLoading}
+                checked={singleMessageMode}
+                onChange={(e) => onSingleMessageModeChange(e.target.checked)}
               >
-                Send
-              </Button>
-            </ButtonGroup>
+                Single Message Mode
+              </Checkbox>
+              <ButtonGroup>
+                <Button onClick={onClear} variant="outline" size="sm">
+                  Clear Chat
+                </Button>
+                <Button
+                  type="submit"
+                  size="sm"
+                  isDisabled={isLoading || !prompt.length}
+                  isLoading={isLoading}
+                  loadingText="Loading"
+                >
+                  Send
+                </Button>
+              </ButtonGroup>
+            </Flex>
           </Flex>
-        </Flex>
-      </chakra.form>
+        </chakra.form>
+      ) : (
+        <chakra.form onSubmit={handleApiKeySubmit} h="100%" pb={2}>
+          <FormControl>
+            <FormLabel>
+              <HStack>
+                <CgInfo />
+                <Text>
+                  ChatCraft requires an{" "}
+                  <Link
+                    href="https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety"
+                    textDecoration="underline"
+                  >
+                    OpenAI API Key
+                  </Link>
+                  {"."}
+                </Text>
+              </HStack>
+            </FormLabel>
+            <Flex>
+              <Input
+                flex="1"
+                type="password"
+                name="api-key"
+                bg={useColorModeValue("white", "gray.700")}
+                required
+                autoFocus
+              />
+              <Button ml={2} type="submit">
+                Save
+              </Button>
+            </Flex>
+            <FormHelperText>
+              Your API Key will be stored offline in your browser's{" "}
+              <Link
+                href="https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage"
+                textDecoration="underline"
+              >
+                local storage
+              </Link>
+            </FormHelperText>
+          </FormControl>
+        </chakra.form>
+      )}
     </Box>
   );
 }

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -21,6 +21,7 @@ import {
 import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
 
 import { AutoResizingTextarea } from "./AutoResizingTextarea";
+import RevealablePasswordInput from "./RevealablePasswordInput";
 
 import { useSettings } from "../hooks/use-settings";
 import { isMac, isWindows } from "../utils";
@@ -180,7 +181,7 @@ function PromptForm({
                   ref={textareaRef}
                   h="100%"
                   resize="none"
-                  disabled={isLoading}
+                  isDisabled={isLoading}
                   onKeyDown={handleKeyDown}
                   autoFocus={true}
                   value={prompt}
@@ -192,6 +193,7 @@ function PromptForm({
                 <AutoResizingTextarea
                   ref={textareaRef}
                   onKeyDown={handleKeyDown}
+                  isDisabled={isLoading}
                   autoFocus={true}
                   value={prompt}
                   onChange={(e) => setPrompt(e.target.value)}
@@ -210,7 +212,7 @@ function PromptForm({
                 Single Message Mode
               </Checkbox>
               <ButtonGroup>
-                <Button onClick={onClear} variant="outline" size="sm">
+                <Button onClick={onClear} variant="outline" size="sm" isDisabled={isLoading}>
                   Clear Chat
                 </Button>
                 <Button
@@ -233,19 +235,18 @@ function PromptForm({
               <HStack>
                 <CgInfo />
                 <Text>
-                  ChatCraft requires an{" "}
+                  Please enter your{" "}
                   <Link
                     href="https://help.openai.com/en/articles/5112595-best-practices-for-api-key-safety"
                     textDecoration="underline"
                   >
                     OpenAI API Key
                   </Link>
-                  {"."}
                 </Text>
               </HStack>
             </FormLabel>
             <Flex>
-              <Input
+              <RevealablePasswordInput
                 flex="1"
                 type="password"
                 name="api-key"
@@ -253,7 +254,7 @@ function PromptForm({
                 required
                 autoFocus
               />
-              <Button ml={2} type="submit">
+              <Button ml={3} type="submit">
                 Save
               </Button>
             </Flex>

--- a/src/components/RevealablePasswordInput.tsx
+++ b/src/components/RevealablePasswordInput.tsx
@@ -1,0 +1,21 @@
+import { useState, type ComponentPropsWithRef } from "react";
+import { Input, InputGroup, InputRightElement, Button } from "@chakra-ui/react";
+
+type RevealablePasswordInputProps = ComponentPropsWithRef<typeof Input>;
+
+function RevealablePasswordInput(props: RevealablePasswordInputProps) {
+  const [show, setShow] = useState(false);
+
+  return (
+    <InputGroup size="md">
+      <Input {...props} pr="4.5rem" type={show ? "text" : "password"} />
+      <InputRightElement width="4.5rem">
+        <Button variant="ghost" h="1.75rem" size="sm" onClick={() => setShow(!show)}>
+          {show ? "Hide" : "Show"}
+        </Button>
+      </InputRightElement>
+    </InputGroup>
+  );
+}
+
+export default RevealablePasswordInput;

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -1,5 +1,7 @@
 import { AIChatMessage, BaseChatMessage, HumanChatMessage } from "langchain/schema";
 import { useLocalStorage } from "react-use";
+import { useSettings } from "./use-settings";
+import { useEffect, useState } from "react";
 
 const obj2msg = (obj: { role: string; content: string }): BaseChatMessage =>
   obj.role === "user" ? new HumanChatMessage(obj.content) : new AIChatMessage(obj.content);
@@ -9,12 +11,26 @@ const msg2obj = (msg: BaseChatMessage): { role: string; content: string } =>
     ? { role: "user", content: msg.text }
     : { role: "assistant", content: msg.text };
 
-const initialMessages: BaseChatMessage[] = [
-  new AIChatMessage("I am a helpful assistant! How can I help?"),
-];
+const greetingMessage: BaseChatMessage = new AIChatMessage(
+  "I am a helpful assistant! How can I help?"
+);
+
+const instructionMessage: BaseChatMessage =
+  new AIChatMessage(`I am a helpful assistant! Before I can help, you need to enter an
+[OpenAI API Key](https://platform.openai.com/account/api-keys). Here's an example of what
+an API Key looks like:
+
+\`sk-tVqEo67MxnfAAPQ68iuVT#ClbkFJkUz4oUblcvyUUxrg4T0\` (this is just an example).
+
+Enter your API Key below to begin chatting!`);
+
+const initialMessages = (hasApiKey: boolean): BaseChatMessage[] =>
+  hasApiKey ? [greetingMessage] : [instructionMessage];
 
 function useMessages() {
-  const [messages, setMessages] = useLocalStorage<BaseChatMessage[]>("messages", initialMessages, {
+  const { settings } = useSettings();
+  const hasApiKey = !!settings.apiKey;
+  const [storage, setStorage] = useLocalStorage<BaseChatMessage[]>("messages", [greetingMessage], {
     raw: false,
     serializer(value: BaseChatMessage[]) {
       return JSON.stringify(value.map(msg2obj));
@@ -23,15 +39,38 @@ function useMessages() {
       return JSON.parse(value).map(obj2msg);
     },
   });
+  const [messages, setMessages] = useState<BaseChatMessage[]>(
+    storage || initialMessages(hasApiKey)
+  );
+
+  // When the user enters an API Key (or removes it), update first message
+  useEffect(() => {
+    if (!hasApiKey && messages.length >= 1 && messages[0] !== instructionMessage) {
+      setMessages([instructionMessage]);
+      return;
+    }
+
+    // Replace the instructions when an api key is added if necessary
+    if (hasApiKey && messages[0] === instructionMessage) {
+      const newMessages = [greetingMessage, ...messages.slice(1)];
+      setMessages(newMessages);
+    }
+  }, [hasApiKey, messages]);
+
+  // Update localStorage when the messages change
+  useEffect(() => {
+    setStorage(messages);
+  }, [setStorage, messages]);
 
   return {
-    messages: messages || initialMessages,
+    messages: messages,
     setMessages(messages?: BaseChatMessage[]) {
       // Allow clearing existing messages back to the initial message list
-      setMessages(messages || initialMessages);
+      const newMessages = messages || initialMessages(hasApiKey);
+      setMessages(newMessages);
     },
     removeMessage(message: BaseChatMessage) {
-      setMessages((messages || initialMessages).filter((m) => m !== message));
+      setMessages((messages || initialMessages(hasApiKey)).filter((m) => m !== message));
     },
   };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,6 +6,7 @@ type EnterBehaviour = "send" | "newline";
 
 // Settings
 type Settings = {
+  apiKey?: string;
   model: GptModel;
   enterBehaviour: EnterBehaviour;
 };


### PR DESCRIPTION
This alters the startup logic to check for an API Key in local storage (using `useLocalStorage()` from [react-use](https://github.com/streamich/react-use/blob/master/docs/useLocalStorage.md)), and if it's missing, we show a splash screen with form to enter.  The replaces the sync `prompt()` browser flow.

I'd like to include a way to delete the API key from storage via the UI, but getting it to work how I wanted was more work than I want to do this morning.

To test, remove your API key from local storage and refresh:

<img width="1084" alt="Screenshot 2023-04-24 at 9 32 51 AM" src="https://user-images.githubusercontent.com/427398/234012561-be67ed25-27e3-4a91-a53b-7846f7a041b8.png">
