### PR TITLE
Refactor messages storage/state into useMessages() hook

### DIFF
--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BaseChatMessage } from "langchain/schema";
+import { AIChatMessage, BaseChatMessage } from "langchain/schema";
 import {
   Avatar,
   Box,
@@ -26,8 +26,7 @@ function MessageView({ message, onDeleteClick }: MessagesViewProps) {
   const [isMouseOver, setIsMouseOver] = useState(false);
   const { onCopy } = useClipboard(message.text);
   const toast = useToast();
-
-  const isAI = message._getType() === "ai";
+  const isAI = message instanceof AIChatMessage;
 
   const handleCopy = () => {
     onCopy();

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -5,7 +5,7 @@ import Message from "./Message";
 
 type MessagesViewProps = {
   messages: BaseChatMessage[];
-  onRemoveMessage: (index: number) => void;
+  onRemoveMessage: (message: BaseChatMessage) => void;
   singleMessageMode: boolean;
 };
 
@@ -18,15 +18,12 @@ function MessageView({ messages, onRemoveMessage, singleMessageMode }: MessagesV
       <Collapse in={!singleMessageMode} animateOpacity>
         {messages.map((message: BaseChatMessage, index: number) => {
           return (
-            <Message key={index} message={message} onDeleteClick={() => onRemoveMessage(index)} />
+            <Message key={index} message={message} onDeleteClick={() => onRemoveMessage(message)} />
           );
         })}
       </Collapse>
       {singleMessageMode && lastMessage && (
-        <Message
-          message={lastMessage}
-          onDeleteClick={() => onRemoveMessage(messages.indexOf(lastMessage))}
-        />
+        <Message message={lastMessage} onDeleteClick={() => onRemoveMessage(lastMessage)} />
       )}
     </Box>
   );

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -1,0 +1,39 @@
+import { AIChatMessage, BaseChatMessage, HumanChatMessage } from "langchain/schema";
+import { useLocalStorage } from "react-use";
+
+const obj2msg = (obj: { role: string; content: string }): BaseChatMessage =>
+  obj.role === "user" ? new HumanChatMessage(obj.content) : new AIChatMessage(obj.content);
+
+const msg2obj = (msg: BaseChatMessage): { role: string; content: string } =>
+  msg instanceof HumanChatMessage
+    ? { role: "user", content: msg.text }
+    : { role: "assistant", content: msg.text };
+
+const initialMessages: BaseChatMessage[] = [
+  new AIChatMessage("I am a helpful assistant! How can I help?"),
+];
+
+function useMessages() {
+  const [messages, setMessages] = useLocalStorage<BaseChatMessage[]>("messages", initialMessages, {
+    raw: false,
+    serializer(value: BaseChatMessage[]) {
+      return JSON.stringify(value.map(msg2obj));
+    },
+    deserializer(value: string) {
+      return JSON.parse(value).map(obj2msg);
+    },
+  });
+
+  return {
+    messages: messages || initialMessages,
+    setMessages(messages?: BaseChatMessage[]) {
+      // Allow clearing existing messages back to the initial message list
+      setMessages(messages || initialMessages);
+    },
+    removeMessage(message: BaseChatMessage) {
+      setMessages((messages || initialMessages).filter((m) => m !== message));
+    },
+  };
+}
+
+export default useMessages;


### PR DESCRIPTION
This refactors the storage and state logic for `messages` into its own custom hook called `useMessages()`.  The hook deals with serializing/deserializing between types, get/put to localStorage, initial messages etc.  This cleans up `App.tsx` quite a bit.

I think that there is likely some optimization that could happen in `onPrompt()`, where it calls `setMessages()` so many times.  However, I didn't want to complicate this change by breaking things.  Maybe we can reduce re-renders there later.