### PR TITLE
Allow up-arrow to copy previous message into prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,6 +174,7 @@ function App() {
               singleMessageMode={singleMessageMode}
               onSingleMessageModeChange={setSingleMessageMode}
               isLoading={loading}
+              previousMessage={messages.slice(-1).pop()?.text}
             />
           </Box>
         </Box>


### PR DESCRIPTION
This adds support for pressing the Up Arrow in the prompt and getting the previous message copied into the textarea (kind of like up-arrow in a shell).  I tried doing multi-up/down to scroll through the other messages, but because we have line breaks in prompts, it becomes impossible to know if an up/down is meant to scroll through the message or scroll to next.

I think this is useful as is for being able to copy what AI wrote and alter it to build the next prompt.