### PR TITLE
Autoscroll improvements

### DIFF
--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -93,10 +93,8 @@ function PromptForm({
     }
   }, [prompt, setIsDirty]);
 
-  // Clear the form when loading finishes and focus the textarea again
   useEffect(() => {
     if (!isLoading) {
-      setPrompt("");
       textareaRef.current?.focus();
     }
   }, [isLoading, textareaRef]);
@@ -109,6 +107,7 @@ function PromptForm({
       return;
     }
 
+    setPrompt("");
     onPrompt(value);
   };
 
@@ -187,7 +186,7 @@ function PromptForm({
                   value={prompt}
                   onChange={(e) => setPrompt(e.target.value)}
                   bg={useColorModeValue("white", "gray.700")}
-                  placeholder="Type your question"
+                  placeholder={!isLoading ? "Type your question" : undefined}
                 />
               ) : (
                 <AutoResizingTextarea
@@ -198,7 +197,7 @@ function PromptForm({
                   value={prompt}
                   onChange={(e) => setPrompt(e.target.value)}
                   bg={useColorModeValue("white", "gray.700")}
-                  placeholder="Type your question"
+                  placeholder={!isLoading ? "Type your question" : undefined}
                 />
               )}
             </Box>


### PR DESCRIPTION
One thing that I haven't liked is how the autoscrolling forces me to wait until the whole response is streamed in before I can scroll up.

This fix alters the way that works, letting the user pause autoscroll during loading:

- if you do nothing, it autoscrolls like before
- if you scroll up, it stops autoscrolling and shows a button to start following again.  The button vanishes when it's done loading, and autoscroll is re-enabled (i.e., for next time)
- if while autoscrolling is disabled, you manually scroll back to the bottom, it gets re-enabled and continues

<img width="1105" alt="Screenshot 2023-04-27 at 9 25 54 AM" src="https://user-images.githubusercontent.com/427398/234876650-dac50fa8-ad99-42ac-b72c-9d58d324086d.png">

This was a lot smoother last night when I wrote this before the syntax highlighting PR landed.  We should see if we can optimize it a bit.