### PR TITLE
Reduce re-renders of markdown in messages

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 import {
   Flex,
   ButtonGroup,
@@ -60,12 +60,12 @@ function PreHeader({ children, code }: PreHeaderProps) {
   );
 }
 
-type MarkdownWithMermaidProps = {
+type MarkdownProps = {
   previewCode?: boolean;
   children: string;
 };
 
-const MarkdownWithMermaid = ({ previewCode, children }: MarkdownWithMermaidProps) => {
+const Markdown = ({ previewCode, children }: MarkdownProps) => {
   return (
     <ReactMarkdown
       className="message-text"
@@ -115,4 +115,5 @@ const MarkdownWithMermaid = ({ previewCode, children }: MarkdownWithMermaidProps
   );
 };
 
-export default MarkdownWithMermaid;
+// Don't re-render Markdown unless we have to
+export default memo(Markdown);

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -13,7 +13,7 @@ import {
 import { CgCloseO } from "react-icons/cg";
 import { TbCopy } from "react-icons/tb";
 
-import MarkdownWithMermaid from "./MarkdownWithMermaid";
+import Markdown from "./Markdown";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 
@@ -40,6 +40,7 @@ function MessageView({ message, loading, onDeleteClick }: MessagesViewProps) {
       isClosable: true,
     });
   };
+
   return (
     <Card
       p={6}
@@ -58,7 +59,7 @@ function MessageView({ message, loading, onDeleteClick }: MessagesViewProps) {
 
         <Box flex="1" maxWidth="100%" overflow="hidden" mt={1}>
           {/* Messages are being rendered in Markdown format */}
-          <MarkdownWithMermaid previewCode={!loading}>{message.text}</MarkdownWithMermaid>
+          <Markdown previewCode={!loading}>{message.text}</Markdown>
         </Box>
 
         <Flex flexDir={{ base: "column-reverse", md: "row" }} justify="start">


### PR DESCRIPTION
I noticed that the HTML/Mermaid live renderings were constantly being re-rendered when I was moving my mouse over/out-of a message.  This is due to the state change on the message with the mouse handler.

Using ChatCraft (ha!) I discovered that I can memoize the whole markdown component, and only re-render it when its direct props change vs. parent props.  This works via [`React.memo()`](https://react.dev/reference/react/memo), which I'd never heard of (I've only ever known about `useMemo()` as a hook).

I've also renamed the component, since it's now doing more than Markdown + Mermaid (i.e., it's a general purpose `Markdown` renderer now). 