### PR TITLE
Improve CSS for message responses

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -6,6 +6,8 @@ import {
   useToast,
   useClipboard,
   useColorModeValue,
+  Text,
+  Box,
 } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkMermaid from "remark-mermaidjs";
@@ -17,9 +19,9 @@ import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
 import oneDark from "react-syntax-highlighter/dist/esm/styles/prism/one-dark";
 import oneLight from "react-syntax-highlighter/dist/esm/styles/prism/one-light";
 
-type PreHeaderProps = { children: ReactNode; code: string };
+type PreHeaderProps = { language: string; children: ReactNode; code: string };
 
-function PreHeader({ children, code }: PreHeaderProps) {
+function PreHeader({ language, children, code }: PreHeaderProps) {
   const { onCopy } = useClipboard(code);
   const toast = useToast();
 
@@ -39,11 +41,17 @@ function PreHeader({ children, code }: PreHeaderProps) {
     <>
       <Flex
         bg={useColorModeValue("gray.200", "gray.600")}
-        justify="end"
+        alignItems="center"
+        justify="space-between"
         align="center"
         borderTopLeftRadius="md"
         borderTopRightRadius="md"
       >
+        <Box pl={2}>
+          <Text as="code" fontSize="xs">
+            {language}
+          </Text>
+        </Box>
         <ButtonGroup isAttached pr={2}>
           <IconButton
             size="sm"
@@ -75,7 +83,7 @@ const Markdown = ({ previewCode, children }: MarkdownProps) => {
         code({ node, inline, className, children, ...props }) {
           if (inline) {
             return (
-              <code className={className} {...props}>
+              <code className="inline-code" {...props}>
                 {children}
               </code>
             );
@@ -102,7 +110,7 @@ const Markdown = ({ previewCode, children }: MarkdownProps) => {
               <SyntaxHighlighter
                 children={code}
                 language={language}
-                PreTag={(props) => <PreHeader {...props} code={code} />}
+                PreTag={(props) => <PreHeader {...props} code={code} language={language} />}
                 style={useColorModeValue(oneLight, oneDark)}
                 showLineNumbers={true}
                 wrapLongLines={true}

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -12,7 +12,7 @@
 
 .message-text p {
   margin-bottom: 0.5em;
-  line-height: 1.4;
+  line-height: 1.6;
 }
 
 .message-text ul,
@@ -32,6 +32,20 @@
 .message-text kbd {
   padding: 5px;
   border-radius: 6px;
+}
+
+/* Wrap inline code in backticks and make bold */
+.message-text .inline-code::before {
+  content: "`";
+  font-size: 0.9em;
+}
+.message-text .inline-code {
+  font-weight: bold;
+  font-size: 0.9em;
+}
+.message-text .inline-code::after {
+  content: "`";
+  font-size: 0.9em;
 }
 
 .message-text pre {


### PR DESCRIPTION
Made some fixes to the message response CSS:

- Adds backticks and bold to inline code
- Adds language name to header of styled code blocks
- Improves spacing with paragraphs

<img width="1276" alt="Screenshot 2023-04-27 at 7 22 30 PM" src="https://user-images.githubusercontent.com/427398/235011163-2ed41ff0-7fcc-48b1-8cae-520d702057d5.png">
