### PR TITLE
Add Download icon and feature to code blocks

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -12,7 +12,7 @@ import {
 import ReactMarkdown from "react-markdown";
 import remarkMermaid from "remark-mermaidjs";
 import remarkGfm from "remark-gfm";
-import { TbCopy } from "react-icons/tb";
+import { TbCopy, TbDownload } from "react-icons/tb";
 
 import { PrismAsyncLight as SyntaxHighlighter } from "react-syntax-highlighter";
 // We need both a light and dark theme
@@ -30,6 +30,24 @@ function PreHeader({ language, children, code }: PreHeaderProps) {
     toast({
       title: "Copied to Clipboard",
       description: "Code was copied to your clipboard.",
+      status: "info",
+      duration: 3000,
+      position: "top",
+      isClosable: true,
+    });
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([code], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.setAttribute("download", "code.txt");
+    anchor.setAttribute("href", url);
+    anchor.click();
+
+    toast({
+      title: "Downloaded",
+      description: "Code was downloaded as a file",
       status: "info",
       duration: 3000,
       position: "top",
@@ -55,9 +73,21 @@ function PreHeader({ language, children, code }: PreHeaderProps) {
         <ButtonGroup isAttached pr={2}>
           <IconButton
             size="sm"
+            aria-label="Download code"
+            title="Download code"
+            icon={<TbDownload />}
+            color="gray.600"
+            _dark={{ color: "gray.300" }}
+            variant="ghost"
+            onClick={handleDownload}
+          />
+          <IconButton
+            size="sm"
             aria-label="Copy to Clipboard"
             title="Copy to Clipboard"
             icon={<TbCopy />}
+            color="gray.600"
+            _dark={{ color: "gray.300" }}
             variant="ghost"
             onClick={handleCopy}
           />

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { AIChatMessage, BaseChatMessage } from "langchain/schema";
 import { Avatar, Box, Card, Flex, IconButton, useClipboard, useToast } from "@chakra-ui/react";
 import { CgCloseO } from "react-icons/cg";
@@ -15,7 +14,6 @@ type MessagesViewProps = {
 };
 
 function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
-  const [isMouseOver, setIsMouseOver] = useState(false);
   const { onCopy } = useClipboard(message.text);
   const toast = useToast();
   const isAI = message instanceof AIChatMessage;
@@ -33,12 +31,7 @@ function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
   };
 
   return (
-    <Card
-      p={6}
-      my={6}
-      onMouseEnter={() => setIsMouseOver(true)}
-      onMouseLeave={() => setIsMouseOver(false)}
-    >
+    <Card p={6} my={6}>
       <Flex>
         <Box pr={6}>
           {isAI ? (
@@ -59,7 +52,6 @@ function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
             title="Copy to Clipboard"
             icon={<TbCopy />}
             onClick={() => handleCopy()}
-            isDisabled={!isMouseOver}
             color="gray.600"
             _dark={{ color: "gray.300" }}
             variant="ghost"
@@ -70,7 +62,6 @@ function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
               title="Delete"
               icon={<CgCloseO />}
               variant="ghost"
-              isDisabled={!isMouseOver}
               color="gray.600"
               _dark={{ color: "gray.300" }}
               onClick={onDeleteClick && (() => onDeleteClick())}


### PR DESCRIPTION
Add the ability to download a code block in a response:

<img width="1065" alt="Screenshot 2023-04-28 at 2 30 46 PM" src="https://user-images.githubusercontent.com/427398/235226139-ec5ad86a-ea15-4f72-a33d-84cd16d8f4c9.png">

I removed the hover state logic for the other icon buttons on a message to match what this does.  I didn't want to drill that hover state all the way down into the header (I could if you want, but it seemed overkill).

I'm using `code.txt` for the filename in all cases vs. `code.ts` or `code.yml`, etc.  I could do the latter, but I'd have to bundle a ton of language to extension data, which seemed overkill too.

See what you think.  I think being able to grab this as a file is nice in addition to using it from clipboard (different use cases).