### PR TITLE
Don't precache all Prism languages in service worker

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,6 +3,38 @@ import react from "@vitejs/plugin-react";
 import wasm from "vite-plugin-wasm";
 import { VitePWA } from "vite-plugin-pwa";
 
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// For syntax highlighting, we use https://github.com/react-syntax-highlighter/react-syntax-highlighter#async-build
+// It includes 180+ languages defined as .js files.  We only want to pre-cache
+// some of these in our service worker.  See full list in:
+// https://github.com/react-syntax-highlighter/react-syntax-highlighter/tree/master/src/languages/prism
+const prismLanguagesDir = "node_modules/react-syntax-highlighter/dist/esm/languages/prism";
+const includedLanguages = ["css.js", "javascript.js", "typescript.js"];
+
+// bash.js -> assets/bash-*.js
+const filenameToGlob = (prefix: string, filename: string) => {
+  const [basename, extname] = filename.split(".");
+  return join(prefix, `${basename}-*.${extname}`);
+};
+
+// Language glob patterns to include
+function buildLanguageGlobPatterns(prefix: string) {
+  return includedLanguages.map((filename) => filenameToGlob(prefix, filename));
+}
+
+// Language glob patterns to exclude
+function buildLanguageIgnoreGlobPatterns(prefix: string) {
+  const languageFiles = readdirSync(prismLanguagesDir);
+
+  // Turn ['bash.js', ...] into ['assets/bash-*.js', ...]
+  // filtering out the languages we want to bundle.
+  return languageFiles
+    .filter((filename) => !includedLanguages.includes(filename))
+    .map((filename) => filenameToGlob(prefix, filename));
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
@@ -28,7 +60,12 @@ export default defineConfig({
         display: "standalone",
       },
       workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg}"],
+        // Ignore all Prism languages we don't explicitly include as part of `includedLanguages`
+        globIgnores: buildLanguageIgnoreGlobPatterns("**/assets/"),
+        globPatterns: [
+          "**/*.{js,css,html,ico,png,svg}",
+          ...buildLanguageGlobPatterns("**/assets/"),
+        ],
       },
     }),
   ],


### PR DESCRIPTION
Fixes #27.

Previously, told the service worker (via Workbox) to precache everything under `build/**/*.js`.  This included all 180 Prism language files (used for syntax highlighting).

This PR changes our Vite PWA build such that we first build include and ignore patterns for all the languages, and explicitly exclude them all, then add back in only the ones defined in  `includedLanguages`.  Currently that means: CSS, JS, TS.  Adding more languages is as simple as adding more to that array.

The entire set of language files is still included in the static build (see `build/assets/*`), so they can be loaded on-demand at runtime.

With this change, the number of files being precached in the service worker's cache goes from 318 to 19.  It's possible we'll want to add more as we use this.