### PR TITLE
Add ability to count and display token count, with pref

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,9 @@ import useChatOpenAI from "./hooks/use-chat-openai";
 
 function App() {
   // When chatting with OpenAI, a streaming message is returned during loading
-  const { streamingMessage, callChatApi } = useChatOpenAI();
+  const { streamingMessage, callChatApi, getTokenCount } = useChatOpenAI();
   // Messages are all the static, previous messages in the chat
-  const { messages, setMessages, removeMessage } = useMessages();
+  const { messages, tokenCount, setMessages, removeMessage } = useMessages();
   // Whether to include the whole message chat history or just the last response
   const [singleMessageMode, setSingleMessageMode] = useState(false);
   const { isOpen: isExpanded, onToggle: toggleExpanded } = useDisclosure();
@@ -160,6 +160,7 @@ function App() {
               onSingleMessageModeChange={setSingleMessageMode}
               isLoading={loading}
               previousMessage={messages.at(-1)?.text}
+              tokenCount={tokenCount}
             />
           </Box>
         </Box>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,9 @@ import useChatOpenAI from "./hooks/use-chat-openai";
 
 function App() {
   // When chatting with OpenAI, a streaming message is returned during loading
-  const { streamingMessage, callChatApi, getTokenCount } = useChatOpenAI();
+  const { streamingMessage, callChatApi, getTokenInfo } = useChatOpenAI();
   // Messages are all the static, previous messages in the chat
-  const { messages, tokenCount, setMessages, removeMessage } = useMessages();
+  const { messages, tokenInfo, setMessages, removeMessage } = useMessages();
   // Whether to include the whole message chat history or just the last response
   const [singleMessageMode, setSingleMessageMode] = useState(false);
   const { isOpen: isExpanded, onToggle: toggleExpanded } = useDisclosure();
@@ -160,7 +160,7 @@ function App() {
               onSingleMessageModeChange={setSingleMessageMode}
               isLoading={loading}
               previousMessage={messages.at(-1)?.text}
-              tokenCount={tokenCount}
+              tokenInfo={tokenInfo}
             />
           </Box>
         </Box>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -17,6 +17,7 @@ import {
   Select,
   Kbd,
   Checkbox,
+  Link,
 } from "@chakra-ui/react";
 
 import RevealablePasswordInput from "./RevealablePasswordInput";
@@ -68,9 +69,22 @@ function PreferencesModal({ isOpen, onClose }: PreferencesModalProps) {
                   onChange={(e) => setSettings({ ...settings, model: e.target.value as GptModel })}
                 >
                   <option value="gpt-4">GPT-4</option>
-                  <option value="gpt-3.5-turbo">ChatGPT (gpt-3.5-turbo)</option>
+                  <option value="gpt-3.5-turbo">ChatGPT (GPT-3.5-turbo)</option>
                 </Select>
-                <FormHelperText>NOTE: not all accounts have access to GPT-4</FormHelperText>
+                <FormHelperText>
+                  See{" "}
+                  <Link
+                    href="https://platform.openai.com/docs/models/gpt-4"
+                    textDecoration="underline"
+                  >
+                    docs
+                  </Link>{" "}
+                  and{" "}
+                  <Link href="https://openai.com/pricing" textDecoration="underline">
+                    pricing
+                  </Link>
+                  . NOTE: not all accounts have access to GPT-4
+                </FormHelperText>
               </FormControl>
 
               <FormControl>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -16,6 +16,7 @@ import {
   Stack,
   Select,
   Kbd,
+  Checkbox,
 } from "@chakra-ui/react";
 
 import RevealablePasswordInput from "./RevealablePasswordInput";
@@ -90,6 +91,15 @@ function PreferencesModal({ isOpen, onClose }: PreferencesModalProps) {
                     </Radio>
                   </Stack>
                 </RadioGroup>
+              </FormControl>
+
+              <FormControl>
+                <Checkbox
+                  isChecked={settings.countTokens}
+                  onChange={(e) => setSettings({ ...settings, countTokens: e.target.checked })}
+                >
+                  Track and Display Messages Token Count
+                </Checkbox>
               </FormControl>
             </VStack>
           </ModalBody>

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -23,7 +23,7 @@ import AutoResizingTextarea from "./AutoResizingTextarea";
 import RevealablePasswordInput from "./RevealablePasswordInput";
 
 import { useSettings } from "../hooks/use-settings";
-import { isMac, isWindows, formatNumber } from "../utils";
+import { isMac, isWindows, formatNumber, formatCurrency } from "../utils";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -68,7 +68,7 @@ type PromptFormProps = {
   onSingleMessageModeChange: (value: boolean) => void;
   isLoading: boolean;
   previousMessage?: string;
-  tokenCount?: number;
+  tokenInfo?: TokenInfo;
 };
 
 function PromptForm({
@@ -80,7 +80,7 @@ function PromptForm({
   onSingleMessageModeChange,
   isLoading,
   previousMessage,
-  tokenCount,
+  tokenInfo,
 }: PromptFormProps) {
   const [prompt, setPrompt] = useState("");
   // Has the user started typing?
@@ -161,7 +161,13 @@ function PromptForm({
         <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
 
         <HStack>
-          {tokenCount && <Tag size="sm">{formatNumber(tokenCount)} Tokens</Tag>}
+          {
+            /* Only bother with cost if it's $0.01 or more */
+            tokenInfo?.cost && tokenInfo?.cost >= 0.01 && (
+              <Tag size="sm">{formatCurrency(tokenInfo.cost)}</Tag>
+            )
+          }
+          {tokenInfo?.count && <Tag size="sm">{formatNumber(tokenInfo.count)} Tokens</Tag>}
 
           <ButtonGroup isAttached>
             <IconButton

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -15,6 +15,7 @@ import {
   Text,
   Textarea,
   HStack,
+  Tag,
 } from "@chakra-ui/react";
 import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
 
@@ -22,7 +23,7 @@ import AutoResizingTextarea from "./AutoResizingTextarea";
 import RevealablePasswordInput from "./RevealablePasswordInput";
 
 import { useSettings } from "../hooks/use-settings";
-import { isMac, isWindows } from "../utils";
+import { isMac, isWindows, formatNumber } from "../utils";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -67,6 +68,7 @@ type PromptFormProps = {
   onSingleMessageModeChange: (value: boolean) => void;
   isLoading: boolean;
   previousMessage?: string;
+  tokenCount?: number;
 };
 
 function PromptForm({
@@ -78,6 +80,7 @@ function PromptForm({
   onSingleMessageModeChange,
   isLoading,
   previousMessage,
+  tokenCount,
 }: PromptFormProps) {
   const [prompt, setPrompt] = useState("");
   // Has the user started typing?
@@ -157,15 +160,19 @@ function PromptForm({
       <Flex justify="space-between" alignItems="baseline">
         <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
 
-        <ButtonGroup isAttached>
-          <IconButton
-            aria-label={isExpanded ? "Minimize prompt area" : "Maximize prompt area"}
-            title={isExpanded ? "Minimize prompt area" : "Maximize prompt area"}
-            icon={isExpanded ? <CgChevronDownO /> : <CgChevronUpO />}
-            variant="ghost"
-            onClick={toggleExpanded}
-          />
-        </ButtonGroup>
+        <HStack>
+          {tokenCount && <Tag size="sm">{formatNumber(tokenCount)} Tokens</Tag>}
+
+          <ButtonGroup isAttached>
+            <IconButton
+              aria-label={isExpanded ? "Minimize prompt area" : "Maximize prompt area"}
+              title={isExpanded ? "Minimize prompt area" : "Maximize prompt area"}
+              icon={isExpanded ? <CgChevronDownO /> : <CgChevronUpO />}
+              variant="ghost"
+              onClick={toggleExpanded}
+            />
+          </ButtonGroup>
+        </HStack>
       </Flex>
 
       {/* If we have an API Key in storage, show the chat form;

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -5,7 +5,7 @@ import { BaseChatMessage, AIChatMessage, SystemChatMessage } from "langchain/sch
 
 import { useSettings } from "./use-settings";
 
-const systemMessage = `You are ChatCraft.org, a web-based, expert programming AI.
+export const systemMessage = `You are ChatCraft.org, a web-based, expert programming AI.
  You help programmers learn, experiment, and be more creative with code.
  Respond in GitHub flavored Markdown and format ALL lines of code to 80
  characters or fewer.`;
@@ -35,6 +35,7 @@ function useChatOpenAI() {
           },
         }),
       });
+
       // Send the chat history + user's prompt, and prefix it all with a system message
       const systemChatMessage = new SystemChatMessage(systemMessage);
       return chatOpenAI
@@ -44,7 +45,19 @@ function useChatOpenAI() {
     [settings, setStreamingMessage]
   );
 
-  return { streamingMessage, callChatApi };
+  const getTokenCount = useCallback(
+    async (messages: BaseChatMessage[]) => {
+      const api = new ChatOpenAI({
+        openAIApiKey: settings.apiKey,
+        modelName: settings.model,
+      });
+      const { totalCount } = await api.getNumTokensFromMessages(messages);
+      return totalCount;
+    },
+    [settings]
+  );
+
+  return { streamingMessage, callChatApi, getTokenCount };
 }
 
 export default useChatOpenAI;

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -35,8 +35,8 @@ const initialMessages = (hasApiKey: boolean): BaseChatMessage[] =>
 
 function useMessages() {
   const { settings } = useSettings();
-  const { getTokenCount } = useChatOpenAI();
-  const [tokenCount, setTokenCount] = useState<number | undefined>();
+  const { getTokenInfo } = useChatOpenAI();
+  const [tokenInfo, setTokenInfo] = useState<TokenInfo | undefined>();
   const hasApiKey = !!settings.apiKey;
   const [storage, setStorage] = useLocalStorage<BaseChatMessage[]>("messages", [greetingMessage], {
     raw: false,
@@ -74,17 +74,17 @@ function useMessages() {
   useEffect(() => {
     if (settings.countTokens) {
       // Include the system message too, since we send that as well
-      getTokenCount([new SystemChatMessage(systemMessage), ...messages])
-        .then(setTokenCount)
+      getTokenInfo([new SystemChatMessage(systemMessage), ...messages])
+        .then(setTokenInfo)
         .catch((err: any) => console.warn("Unable to count tokens in messages", err.message));
     } else {
-      setTokenCount(undefined);
+      setTokenInfo(undefined);
     }
-  }, [messages, settings, getTokenCount, setTokenCount]);
+  }, [messages, settings, getTokenInfo, setTokenInfo]);
 
   return {
     messages: messages,
-    tokenCount,
+    tokenInfo,
     setMessages(messages?: BaseChatMessage[]) {
       // Allow clearing existing messages back to the initial message list
       const newMessages = messages || initialMessages(hasApiKey);

--- a/src/hooks/use-settings.tsx
+++ b/src/hooks/use-settings.tsx
@@ -12,6 +12,8 @@ import { useLocalStorage } from "react-use";
 const defaultSettings: Settings = {
   model: "gpt-3.5-turbo",
   enterBehaviour: "send",
+  // Disabled by default, since token parsing requires downloading larger deps
+  countTokens: false,
 };
 
 type SettingsContextType = {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,11 @@
-// Models we expect to use
-type GptModel = "gpt-3.5-turbo" | "gpt-4";
+// Models we expect to use. See
+// https://platform.openai.com/docs/models/overview
+// https://github.com/hwchase17/langchainjs/blob/9330102c98c30eb4796263f2dfba9d8cbb4d179c/langchain/src/base_language/count_tokens.ts#L34-L49
+type GptModel =
+  // GPT-4
+  | "gpt-4"
+  // GPT-3.5
+  | "gpt-3.5-turbo";
 
 // Enter key either sends message or adds newline
 type EnterBehaviour = "send" | "newline";
@@ -10,4 +16,10 @@ type Settings = {
   model: GptModel;
   enterBehaviour: EnterBehaviour;
   countTokens: boolean;
+};
+
+// Information about tokens in a chat
+type TokenInfo = {
+  count: number;
+  cost?: number;
 };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -9,4 +9,5 @@ type Settings = {
   apiKey?: string;
   model: GptModel;
   enterBehaviour: EnterBehaviour;
+  countTokens: boolean;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,7 @@
 export const isMac = () => navigator.userAgent.includes("Macintosh");
 export const isWindows = () => !isMac();
+
 export const formatNumber = (n: number) => n.toLocaleString();
+
+export const formatCurrency = (n: number) =>
+  Intl.NumberFormat(undefined, { style: "currency", currency: "USD" }).format(n);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,2 +1,3 @@
 export const isMac = () => navigator.userAgent.includes("Macintosh");
 export const isWindows = () => !isMac();
+export const formatNumber = (n: number) => n.toLocaleString();


### PR DESCRIPTION
Adds the ability to see how many tokens are being sent in a chat (i.e., across all messages).  It's off by default (adds extra download size for token parser), but for people who care about this, it can be enabled via the preferences.

<img width="1039" alt="Screenshot 2023-04-29 at 12 28 07 PM" src="https://user-images.githubusercontent.com/427398/235314035-19813c74-d1de-4889-95d3-ddd51c3058db.png">

Uses the token parse for the model currently being used, which is nice (thank you langchainjs!)