### PR TITLE
Fix syntax highlighting using lowlight vs. prism

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "langchain": "^0.0.67",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.4",
     "react-icons": "^4.8.0",
     "react-markdown": "^8.0.7",
     "react-syntax-highlighter": "^15.5.0",

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -1,0 +1,92 @@
+import { type ReactNode } from "react";
+import {
+  Flex,
+  ButtonGroup,
+  IconButton,
+  useToast,
+  useClipboard,
+  useColorModeValue,
+  Text,
+  Box,
+} from "@chakra-ui/react";
+import { TbCopy, TbDownload } from "react-icons/tb";
+
+type PreHeaderProps = { language: string; children: ReactNode; code: string };
+
+function CodeHeader({ language, children, code }: PreHeaderProps) {
+  const { onCopy } = useClipboard(code);
+  const toast = useToast();
+
+  const handleCopy = () => {
+    onCopy();
+    toast({
+      title: "Copied to Clipboard",
+      description: "Code was copied to your clipboard.",
+      status: "info",
+      duration: 3000,
+      position: "top",
+      isClosable: true,
+    });
+  };
+
+  const handleDownload = () => {
+    const blob = new Blob([code], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.setAttribute("download", "code.txt");
+    anchor.setAttribute("href", url);
+    anchor.click();
+
+    toast({
+      title: "Downloaded",
+      description: "Code was downloaded as a file",
+      status: "info",
+      duration: 3000,
+      position: "top",
+      isClosable: true,
+    });
+  };
+
+  return (
+    <>
+      <Flex
+        bg={useColorModeValue("gray.200", "gray.600")}
+        alignItems="center"
+        justify="space-between"
+        align="center"
+        mb={2}
+      >
+        <Box pl={2}>
+          <Text as="code" fontSize="xs">
+            {language}
+          </Text>
+        </Box>
+        <ButtonGroup isAttached pr={2}>
+          <IconButton
+            size="sm"
+            aria-label="Download code"
+            title="Download code"
+            icon={<TbDownload />}
+            color="gray.600"
+            _dark={{ color: "gray.300" }}
+            variant="ghost"
+            onClick={handleDownload}
+          />
+          <IconButton
+            size="sm"
+            aria-label="Copy to Clipboard"
+            title="Copy to Clipboard"
+            icon={<TbCopy />}
+            color="gray.600"
+            _dark={{ color: "gray.300" }}
+            variant="ghost"
+            onClick={handleCopy}
+          />
+        </ButtonGroup>
+      </Flex>
+      {children}
+    </>
+  );
+}
+
+export default CodeHeader;

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -1,0 +1,9 @@
+type HtmlPreviewProps = {
+  children: React.ReactNode & React.ReactNode[];
+};
+
+const HtmlPreview = ({ children }: HtmlPreviewProps) => {
+  return <iframe className="htmlPreview" srcDoc={String(children)}></iframe>;
+};
+
+export default HtmlPreview;

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -28,7 +28,6 @@
   font-style: italic;
 }
 
-.message-text code,
 .message-text kbd {
   padding: 5px;
   border-radius: 6px;
@@ -53,10 +52,21 @@
 }
 
 .message-text pre > code {
-  padding: 10px;
-  display: block;
   overflow-x: auto;
   font-size: 0.9em;
+}
+
+.linenumber {
+  padding-left: 0.5em;
+  font-style: italic;
+}
+
+/* Force the line numbers to be lighter gray in highlight.js styles */
+.chakra-ui-light .linenumber {
+  color: rgb(160, 161, 167);
+}
+.chakra-ui-dark .linenumber {
+  color: rgb(92, 99, 112);
 }
 
 .message-text img {

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -7,13 +7,13 @@ import Markdown from "./Markdown";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 
-type MessagesViewProps = {
+type MessageProps = {
   message: BaseChatMessage;
-  loading: boolean;
+  loading?: boolean;
   onDeleteClick?: () => void;
 };
 
-function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
+function Message({ message, loading, onDeleteClick }: MessageProps) {
   const { onCopy } = useClipboard(message.text);
   const toast = useToast();
   const isAI = message instanceof AIChatMessage;
@@ -73,4 +73,4 @@ function MessagesView({ message, loading, onDeleteClick }: MessagesViewProps) {
   );
 }
 
-export default MessagesView;
+export default Message;

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -31,14 +31,12 @@ function MessagesView({
               <Message
                 key={index}
                 message={message}
-                loading={loading && message === lastMessage}
+                loading={loading}
                 onDeleteClick={() => onRemoveMessage(message)}
               />
             );
           })}
-          {newMessage && (
-            <Message message={newMessage} loading={loading && newMessage === lastMessage} />
-          )}
+          {newMessage && <Message message={newMessage} loading={loading} />}
         </>
       </Collapse>
 
@@ -51,9 +49,7 @@ function MessagesView({
             onDeleteClick={() => onRemoveMessage(lastMessage)}
           />
 
-          {newMessage && (
-            <Message message={newMessage} loading={loading && newMessage === lastMessage} />
-          )}
+          {newMessage && <Message message={newMessage} loading={loading} />}
         </>
       )}
     </Box>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,8 @@ import { join } from "node:path";
 // For syntax highlighting, we use https://github.com/react-syntax-highlighter/react-syntax-highlighter#async-build
 // It includes 180+ languages defined as .js files.  We only want to pre-cache
 // some of these in our service worker.  See full list in:
-// https://github.com/react-syntax-highlighter/react-syntax-highlighter/tree/master/src/languages/prism
-const prismLanguagesDir = "node_modules/react-syntax-highlighter/dist/esm/languages/prism";
+// https://github.com/react-syntax-highlighter/react-syntax-highlighter/tree/master/src/languages/hljs
+const languagesDir = "node_modules/react-syntax-highlighter/dist/esm/languages/hljs";
 const includedLanguages = ["css.js", "javascript.js", "typescript.js", "python.js"];
 
 // bash.js -> assets/bash-*.js
@@ -26,7 +26,7 @@ function buildLanguageGlobPatterns(prefix: string) {
 
 // Language glob patterns to exclude
 function buildLanguageIgnoreGlobPatterns(prefix: string) {
-  const languageFiles = readdirSync(prismLanguagesDir);
+  const languageFiles = readdirSync(languagesDir);
 
   // Turn ['bash.js', ...] into ['assets/bash-*.js', ...]
   // filtering out the languages we want to bundle.
@@ -60,7 +60,7 @@ export default defineConfig({
         display: "standalone",
       },
       workbox: {
-        // Ignore all Prism languages we don't explicitly include as part of `includedLanguages`
+        // Ignore all languages we don't explicitly include as part of `includedLanguages`
         globIgnores: buildLanguageIgnoreGlobPatterns("**/assets/"),
         globPatterns: [
           "**/*.{js,css,html,ico,png,svg}",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,6 +6376,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.4.tgz#d2e84505b0a67cec7a6bf33b0146faadfe31597d"
+  integrity sha512-AbqMFx8bCsob8rCHZvJYQ42MQijK0/034RUvan9qrqyJCpazr8d9vKHrysbxcr6odoHLZvQEcYomFPoIqH9fow==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-fast-compare@3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.1.tgz#53933d9e14f364281d6cba24bfed7a4afb808b5f"


### PR DESCRIPTION
Fixes #32 

This is a work-around for the bug in `react-syntax-highlighter`, where the `refractor`/`prism` based syntax highlighter shows `[object Object]` in production builds.

The `react-syntax-highlighter` component ships with 2 backends: one based on [lowlight](https://www.npmjs.com/package/lowlight), which uses [highlight.js](https://github.com/highlightjs/highlight.js), and the other based on [refractor](https://github.com/wooorm/refractor), which uses [prism.js](https://github.com/PrismJS/prism).

The both do essentially the same thing, though the CSS and language styles are slightly different.  I've tried to make this work as close to what we had before as possible.

I've also added [react-error-boundary](https://github.com/bvaughn/react-error-boundary) to deal with the markdown crashing when rendering previews (I noticed it happen a few times in testing and got sick of having to refresh).  It will try to render with our plugins, and if it crashes, fallback to rendering without plugins.

I spent quite a while looking for other syntax highlighting options, and there are half-a-dozen, but none do the autoloading we need here, and we'd have to end up building the same code as this component already gives.

If/when they update the prism stuff upstream, we can switch back to that.  Or not.  This works great too.

<img width="1124" alt="Screenshot 2023-05-03 at 2 28 28 PM" src="https://user-images.githubusercontent.com/427398/236010251-2385494a-e7ae-4150-bad9-94aab98f9c12.png">
<img width="1122" alt="Screenshot 2023-05-03 at 2 28 20 PM" src="https://user-images.githubusercontent.com/427398/236010255-f986fd75-ab19-45eb-97cd-325e2ac6e873.png">
