### PR TITLE
Add word wrap to code blocks

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -94,7 +94,6 @@ function Markdown({ includePlugins, previewCode, children }: MarkdownProps) {
                   borderColor: "gray.600",
                 }}
                 pb={1}
-                overflowX="auto"
               >
                 <SyntaxHighlighter
                   children={code}
@@ -102,6 +101,11 @@ function Markdown({ includePlugins, previewCode, children }: MarkdownProps) {
                   PreTag={(props) => <CodeHeader {...props} code={code} language={language} />}
                   style={style}
                   showLineNumbers={true}
+                  showInlineLineNumbers={true}
+                  wrapLines={true}
+                  lineProps={{
+                    style: { display: "block" },
+                  }}
                 />
               </Box>
             </>

--- a/src/components/Message.css
+++ b/src/components/Message.css
@@ -51,12 +51,15 @@
   margin: 0.5em auto;
 }
 
-.message-text pre > code {
-  overflow-x: auto;
-  font-size: 0.9em;
+.message-text pre code {
+  font-size: 0.95em;
+  max-width: 100%;
+  white-space: pre-wrap !important;
+  overflow-wrap: break-word;
 }
 
 .linenumber {
+  display: inline-block;
   padding-left: 0.5em;
   font-style: italic;
 }


### PR DESCRIPTION
Fixes #37 

There are a bunch of bugs in the way `react-syntax-highlighter` does their word wrapping.  I've used what I could, and overridden the rest with manual styles.  I think this is "good enough."  See if you agree:

<img width="818" alt="Screenshot 2023-05-05 at 1 11 07 PM" src="https://user-images.githubusercontent.com/427398/236522982-e754a830-c94a-4f8b-bee3-f5490761f2fe.png">

<img width="1164" alt="Screenshot 2023-05-05 at 1 13 00 PM" src="https://user-images.githubusercontent.com/427398/236523118-392e9245-4ccc-49d5-8f88-2cd62954cb95.png">
 
I've tried half-a-dozen different approaches to this, but without controlling more of how the HTML gets generated for each line, it's hard to make it perfect.