### PR TITLE
Improve HTML previews, encourage Mermaid diagrams

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -1,9 +1,38 @@
+import { useMemo } from "react";
+import { chakra, Card, CardBody, IconButton } from "@chakra-ui/react";
+import { TbExternalLink } from "react-icons/tb";
+
 type HtmlPreviewProps = {
   children: React.ReactNode & React.ReactNode[];
 };
 
+const toUrl = (html: string) => URL.createObjectURL(new Blob([html], { type: "text/html" }));
+
 const HtmlPreview = ({ children }: HtmlPreviewProps) => {
-  return <iframe className="htmlPreview" srcDoc={String(children)}></iframe>;
+  const url = useMemo(() => toUrl(String(children)), [children]);
+
+  return (
+    <Card variant="outline" position="relative" mt={2} minHeight="12em" resize="vertical">
+      <IconButton
+        position="absolute"
+        right={1}
+        top={1}
+        zIndex={50}
+        as="a"
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Open HTML Preview in New Window"
+        title="Open HTML Preview in New Window"
+        icon={<TbExternalLink />}
+        color="gray.600"
+        variant="ghost"
+      />
+      <CardBody p={2}>
+        <chakra.iframe w="100%" minHeight="200px" frameBorder="0" src={url}></chakra.iframe>
+      </CardBody>
+    </Card>
+  );
 };
 
 export default HtmlPreview;

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -82,7 +82,6 @@ function Markdown({ includePlugins, previewCode, children }: MarkdownProps) {
 
           return (
             <>
-              {preview}
               <Box
                 fontSize="0.9em"
                 border="1px"
@@ -104,6 +103,7 @@ function Markdown({ includePlugins, previewCode, children }: MarkdownProps) {
                   showLineNumbers={true}
                 />
               </Box>
+              {preview}
             </>
           );
         },

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -7,8 +7,8 @@ import { useSettings } from "./use-settings";
 
 export const systemMessage = `You are ChatCraft.org, a web-based, expert programming AI.
  You help programmers learn, experiment, and be more creative with code.
- Respond in GitHub flavored Markdown and format ALL lines of code to 80
- characters or fewer.`;
+ Respond in GitHub flavored Markdown. Format ALL lines of code to 80
+ characters or fewer. Use Mermaid diagrams when discussing visual topics.`;
 
 // See https://openai.com/pricing
 const calculateTokenCost = (tokens: number, model: GptModel): number | undefined => {


### PR DESCRIPTION
This improves a few things about previews:

1. Adds a note to the system prompt to indicate that we'd like to get Mermaid diagrams when discussing anything visual.  My testing has shown that this causes it to use them more often.
2. Make it possible to open an HTML preview in its own tab, and dress up the UI around it a bit. I've also moved the preview below the code, which makes more sense to me as a reference:

<img width="1164" alt="Screenshot 2023-05-06 at 1 17 35 PM" src="https://user-images.githubusercontent.com/427398/236638165-64bc1bd2-5484-43f3-9caa-56a352d211d8.png">
