### PR TITLE
Support cancel, pause, resume on responses

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "react/no-children-prop": "off",
     "jsx-a11y/no-autofocus": "off",
     "jsx-a11y/iframe-has-title": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-empty-function": "off"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState, type MouseEvent } from "react";
 import {
   Box,
   Button,
@@ -19,7 +19,7 @@ import useChatOpenAI from "./hooks/use-chat-openai";
 
 function App() {
   // When chatting with OpenAI, a streaming message is returned during loading
-  const { streamingMessage, callChatApi } = useChatOpenAI();
+  const { streamingMessage, callChatApi, cancel, isPaused, pause, resume } = useChatOpenAI();
   // Messages are all the static, previous messages in the chat
   const { messages, tokenInfo, setMessages, removeMessage } = useMessages();
   // Whether to include the whole message chat history or just the last response
@@ -109,6 +109,19 @@ function App() {
     [messages, setMessages, singleMessageMode, setLoading, setShouldAutoScroll, callChatApi, toast]
   );
 
+  // If the user presses/releases the mouse while loading a message, pause/resume
+  // to make it easier to copy/paste text as it streams in.
+  function handleMouseDown() {
+    if (loading && !isPaused) {
+      pause();
+    }
+  }
+  function handleMouseUp() {
+    if (loading && isPaused) {
+      resume();
+    }
+  }
+
   return (
     <Box w="100%" h="100%">
       <Flex flexDir="column" h="100%">
@@ -123,6 +136,8 @@ function App() {
             "linear(to-b, white, gray.100)",
             "linear(to-b, gray.600, gray.700)"
           )}
+          onMouseDown={handleMouseDown}
+          onMouseUp={handleMouseUp}
         >
           <MessagesView
             messages={messages}
@@ -154,6 +169,10 @@ function App() {
             <PromptForm
               onPrompt={onPrompt}
               onClear={() => setMessages()}
+              isPaused={isPaused}
+              onPause={() => pause()}
+              onResume={() => resume()}
+              onCancel={() => cancel()}
               isExpanded={isExpanded}
               toggleExpanded={toggleExpanded}
               singleMessageMode={singleMessageMode}

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -59,6 +59,10 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
 type PromptFormProps = {
   onPrompt: (prompt: string) => void;
   onClear: () => void;
+  isPaused: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onCancel: () => void;
   // Whether or not to automatically manage the height of the prompt.
   // When `isExpanded` is `false`, Shit+Enter adds rows. Otherwise,
   // the height is determined automatically by the parent.
@@ -74,6 +78,10 @@ type PromptFormProps = {
 function PromptForm({
   onPrompt,
   onClear,
+  isPaused,
+  onPause,
+  onResume,
+  onCancel,
   isExpanded,
   toggleExpanded,
   singleMessageMode,
@@ -227,9 +235,28 @@ function PromptForm({
                 Single Message Mode
               </Checkbox>
               <ButtonGroup>
-                <Button onClick={onClear} variant="outline" size="sm" isDisabled={isLoading}>
-                  Clear Chat
-                </Button>
+                {!isLoading && (
+                  <Button onClick={onClear} variant="outline" size="sm" isDisabled={isLoading}>
+                    Clear Chat
+                  </Button>
+                )}
+
+                {isLoading && isPaused && (
+                  <Button size="sm" variant="outline" onClick={() => onResume()}>
+                    Resume
+                  </Button>
+                )}
+                {isLoading && !isPaused && (
+                  <Button size="sm" variant="outline" onClick={() => onPause()}>
+                    Pause
+                  </Button>
+                )}
+
+                {isLoading && (
+                  <Button size="sm" onClick={() => onCancel()}>
+                    Cancel
+                  </Button>
+                )}
                 <Button
                   type="submit"
                   size="sm"


### PR DESCRIPTION
Fixes #41
Fixes #35 

This adds support for cancelling, pausing, and resuming streaming responses.  I've included the following:

- escape key cancels + UI button to click and discover
- mouse down while loading pauses, mouse up resumes
- pause/resume toggle button in UI to click and discover

<img width="1265" alt="Screenshot 2023-05-07 at 9 22 59 PM" src="https://user-images.githubusercontent.com/427398/236714188-0d177ac8-cf88-48ea-a3fc-aed98013de89.png">