### PR TITLE
Clean up prompt buttons, add loading/pause hint

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -122,6 +122,12 @@ function App() {
     }
   }
 
+  // Restart auto-scrolling and resume a paused response when Follow Chat is clicked
+  function handleFollowChatClick() {
+    setShouldAutoScroll(true);
+    resume();
+  }
+
   return (
     <Box w="100%" h="100%">
       <Flex flexDir="column" h="100%">
@@ -151,7 +157,7 @@ function App() {
             /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
             !shouldAutoScroll && (
               <Box position="absolute" top="5em" zIndex="500" w="100%" textAlign="center">
-                <Button onClick={() => setShouldAutoScroll(true)}>
+                <Button onClick={() => handleFollowChatClick()}>
                   <CgArrowDownO />
                   <Text ml={2}>Follow Chat</Text>
                 </Button>

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -56,6 +56,26 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
   );
 }
 
+type LoadingHintProps = {
+  isPaused: boolean;
+};
+
+function LoadingHint({ isPaused }: LoadingHintProps) {
+  return (
+    <Text ml={2} fontSize="sm" color="gray.400" _dark={{ color: "gray.500" }}>
+      <span>
+        {isPaused ? (
+          <span>Paused</span>
+        ) : (
+          <span>
+            <em>Loading...</em>
+          </span>
+        )}
+      </span>
+    </Text>
+  );
+}
+
 type PromptFormProps = {
   onPrompt: (prompt: string) => void;
   onClear: () => void;
@@ -166,7 +186,11 @@ function PromptForm({
   return (
     <Box h="100%" px={1}>
       <Flex justify="space-between" alignItems="baseline">
-        <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
+        {isLoading ? (
+          <LoadingHint isPaused={isPaused} />
+        ) : (
+          <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
+        )}
 
         <HStack>
           {
@@ -257,15 +281,12 @@ function PromptForm({
                     Cancel
                   </Button>
                 )}
-                <Button
-                  type="submit"
-                  size="sm"
-                  isDisabled={isLoading || !prompt.length}
-                  isLoading={isLoading}
-                  loadingText="Loading"
-                >
-                  Send
-                </Button>
+
+                {!isLoading && (
+                  <Button type="submit" size="sm">
+                    Send
+                  </Button>
+                )}
               </ButtonGroup>
             </Flex>
           </Flex>

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -17,7 +17,14 @@ import {
   HStack,
   Tag,
 } from "@chakra-ui/react";
-import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
+import {
+  CgChevronUpO,
+  CgChevronDownO,
+  CgInfo,
+  CgPlayPauseO,
+  CgPlayButtonO,
+  CgPlayStopO,
+} from "react-icons/cg";
 
 import AutoResizingTextarea from "./AutoResizingTextarea";
 import RevealablePasswordInput from "./RevealablePasswordInput";
@@ -58,21 +65,28 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
 
 type LoadingHintProps = {
   isPaused: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onCancel: () => void;
 };
 
-function LoadingHint({ isPaused }: LoadingHintProps) {
+function LoadingHint({ isPaused, onPause, onResume }: LoadingHintProps) {
   return (
-    <Text ml={2} fontSize="sm" color="gray.400" _dark={{ color: "gray.500" }}>
-      <span>
-        {isPaused ? (
-          <span>Paused</span>
-        ) : (
-          <span>
-            <em>Loading...</em>
-          </span>
-        )}
-      </span>
-    </Text>
+    <ButtonGroup>
+      <Button variant="outline" size="xs" leftIcon={<CgPlayStopO />} onClick={onResume}>
+        Cancel
+      </Button>
+
+      {isPaused ? (
+        <Button size="xs" leftIcon={<CgPlayButtonO />} onClick={onResume}>
+          Resume
+        </Button>
+      ) : (
+        <Button size="xs" leftIcon={<CgPlayPauseO />} onClick={onPause}>
+          Pause
+        </Button>
+      )}
+    </ButtonGroup>
   );
 }
 
@@ -187,7 +201,12 @@ function PromptForm({
     <Box h="100%" px={1}>
       <Flex justify="space-between" alignItems="baseline">
         {isLoading ? (
-          <LoadingHint isPaused={isPaused} />
+          <LoadingHint
+            isPaused={isPaused}
+            onPause={onPause}
+            onResume={onResume}
+            onCancel={onCancel}
+          />
         ) : (
           <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
         )}
@@ -196,10 +215,16 @@ function PromptForm({
           {
             /* Only bother with cost if it's $0.01 or more */
             tokenInfo?.cost && tokenInfo?.cost >= 0.01 && (
-              <Tag size="sm">{formatCurrency(tokenInfo.cost)}</Tag>
+              <Tag key="token-cost" size="sm">
+                {formatCurrency(tokenInfo.cost)}
+              </Tag>
             )
           }
-          {tokenInfo?.count && <Tag size="sm">{formatNumber(tokenInfo.count)} Tokens</Tag>}
+          {tokenInfo?.count && (
+            <Tag key="token-count" size="sm">
+              {formatNumber(tokenInfo.count)} Tokens
+            </Tag>
+          )}
 
           <ButtonGroup isAttached>
             <IconButton
@@ -259,34 +284,12 @@ function PromptForm({
                 Single Message Mode
               </Checkbox>
               <ButtonGroup>
-                {!isLoading && (
-                  <Button onClick={onClear} variant="outline" size="sm" isDisabled={isLoading}>
-                    Clear Chat
-                  </Button>
-                )}
-
-                {isLoading && isPaused && (
-                  <Button size="sm" variant="outline" onClick={() => onResume()}>
-                    Resume
-                  </Button>
-                )}
-                {isLoading && !isPaused && (
-                  <Button size="sm" variant="outline" onClick={() => onPause()}>
-                    Pause
-                  </Button>
-                )}
-
-                {isLoading && (
-                  <Button size="sm" onClick={() => onCancel()}>
-                    Cancel
-                  </Button>
-                )}
-
-                {!isLoading && (
-                  <Button type="submit" size="sm">
-                    Send
-                  </Button>
-                )}
+                <Button onClick={onClear} variant="outline" size="sm" isDisabled={isLoading}>
+                  Clear Chat
+                </Button>
+                <Button type="submit" size="sm" isLoading={isLoading} loadingText="Send">
+                  Send
+                </Button>
               </ButtonGroup>
             </Flex>
           </Flex>


### PR DESCRIPTION
Fixes for comments in https://github.com/tarasglek/chatcraft.org/pull/43#issuecomment-1537733989.

Reduces the number of buttons we have when loading, and adds some hints about what's going on:

<img width="924" alt="Screenshot 2023-05-08 at 1 36 38 PM" src="https://user-images.githubusercontent.com/427398/236892289-f29bf6d9-b461-4710-8f88-93f1867db8ec.png">
<img width="919" alt="Screenshot 2023-05-08 at 1 36 32 PM" src="https://user-images.githubusercontent.com/427398/236892294-d9a4021c-1056-4aff-b4bf-d05a511efcbe.png">
