### PR TITLE
Streaming buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ import useChatOpenAI from "./hooks/use-chat-openai";
 
 function App() {
   // When chatting with OpenAI, a streaming message is returned during loading
-  const { streamingMessage, callChatApi, cancel, isPaused, pause, resume } = useChatOpenAI();
+  const { streamingMessage, callChatApi, cancel, paused, resume, togglePause } = useChatOpenAI();
   // Messages are all the static, previous messages in the chat
   const { messages, tokenInfo, setMessages, removeMessage } = useMessages();
   // Whether to include the whole message chat history or just the last response
@@ -110,19 +110,6 @@ function App() {
     [messages, setMessages, singleMessageMode, setLoading, setShouldAutoScroll, callChatApi, toast]
   );
 
-  // If the user presses/releases the mouse while loading a message, pause/resume
-  // to make it easier to copy/paste text as it streams in.
-  function handleMouseDown() {
-    if (loading && !isPaused) {
-      pause();
-    }
-  }
-  function handleMouseUp() {
-    if (loading && isPaused) {
-      resume();
-    }
-  }
-
   // Restart auto-scrolling and resume a paused response when Follow Chat is clicked
   function handleFollowChatClick() {
     setShouldAutoScroll(true);
@@ -137,14 +124,11 @@ function App() {
         <Box
           flex="1"
           overflow="scroll"
-          pb={4}
           ref={messageListRef}
           bgGradient={useColorModeValue(
             "linear(to-b, white, gray.100)",
             "linear(to-b, gray.600, gray.700)"
           )}
-          onMouseDown={handleMouseDown}
-          onMouseUp={handleMouseUp}
         >
           <MessagesView
             messages={messages}
@@ -152,6 +136,9 @@ function App() {
             onRemoveMessage={removeMessage}
             singleMessageMode={singleMessageMode}
             loading={loading}
+            isPaused={paused}
+            onTogglePause={togglePause}
+            onCancel={cancel}
           />
 
           {
@@ -167,19 +154,11 @@ function App() {
           }
         </Box>
 
-        <Box
-          flex={isExpanded ? "1" : undefined}
-          pb={2}
-          bg={useColorModeValue("gray.100", "gray.700")}
-        >
+        <Box flex={isExpanded ? "1" : undefined} bg={useColorModeValue("gray.100", "gray.700")}>
           <Box maxW="900px" mx="auto" h="100%">
             <PromptForm
               onPrompt={onPrompt}
               onClear={() => setMessages()}
-              isPaused={isPaused}
-              onPause={() => pause()}
-              onResume={() => resume()}
-              onCancel={() => cancel()}
               isExpanded={isExpanded}
               toggleExpanded={toggleExpanded}
               singleMessageMode={singleMessageMode}

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { memo, useMemo } from "react";
 import { chakra, Card, CardBody, IconButton } from "@chakra-ui/react";
 import { TbExternalLink } from "react-icons/tb";
 
@@ -35,4 +35,5 @@ const HtmlPreview = ({ children }: HtmlPreviewProps) => {
   );
 };
 
-export default HtmlPreview;
+// Memoize to reduce re-renders/flickering when content hasn't changed
+export default memo(HtmlPreview);

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Box, useColorModeValue } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
@@ -116,4 +117,5 @@ function Markdown({ previewCode, children }: MarkdownProps) {
   );
 }
 
-export default Markdown;
+// Memoize to reduce re-renders/flickering when content hasn't changed
+export default memo(Markdown);

--- a/src/components/MermaidPreview.tsx
+++ b/src/components/MermaidPreview.tsx
@@ -42,7 +42,11 @@ const MermaidPreview = ({ children }: MermaidPreviewProps) => {
         diagramDiv.innerHTML = svg;
         bindFunctions?.(diagramDiv);
       })
-      .catch((err) => console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err));
+      .catch((err) => {
+        // When the diagram fails, use the error vs. diagram for copying (to debug)
+        setValue(err);
+        console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err);
+      });
   }, [diagramRef, code, setValue]);
 
   return (

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from "react";
 import { AIChatMessage, BaseChatMessage } from "langchain/schema";
 import { Avatar, Box, Card, Flex, IconButton, useClipboard, useToast } from "@chakra-ui/react";
 import { CgCloseO } from "react-icons/cg";
@@ -18,7 +19,7 @@ function Message({ message, loading, onDeleteClick }: MessageProps) {
   const toast = useToast();
   const isAI = message instanceof AIChatMessage;
 
-  const handleCopy = () => {
+  const handleCopy = useCallback(() => {
     onCopy();
     toast({
       title: "Copied to Clipboard",
@@ -28,7 +29,7 @@ function Message({ message, loading, onDeleteClick }: MessageProps) {
       position: "top",
       isClosable: true,
     });
-  };
+  }, [onCopy, toast]);
 
   return (
     <Card p={6} my={6}>
@@ -73,4 +74,5 @@ function Message({ message, loading, onDeleteClick }: MessageProps) {
   );
 }
 
-export default Message;
+// Memoize to reduce re-renders/flickering when content hasn't changed
+export default memo(Message);

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -4,6 +4,7 @@ import { Box, Collapse, useColorMode } from "@chakra-ui/react";
 import mermaid from "mermaid";
 
 import Message from "./Message";
+import NewMessage from "./NewMessage";
 
 type MessagesViewProps = {
   messages: BaseChatMessage[];
@@ -11,6 +12,9 @@ type MessagesViewProps = {
   onRemoveMessage: (message: BaseChatMessage) => void;
   singleMessageMode: boolean;
   loading: boolean;
+  isPaused: boolean;
+  onTogglePause: () => void;
+  onCancel: () => void;
 };
 
 function MessagesView({
@@ -19,6 +23,9 @@ function MessagesView({
   onRemoveMessage,
   singleMessageMode,
   loading,
+  isPaused,
+  onTogglePause,
+  onCancel,
 }: MessagesViewProps) {
   const { colorMode } = useColorMode();
   // When we're in singleMessageMode, we collapse all but the final message
@@ -34,22 +41,26 @@ function MessagesView({
     });
   }, [colorMode]);
 
+  // Memoize the previous messages so we don't have to update when newMessage changes
+  const prevMessages = messages.map((message: BaseChatMessage, index: number) => {
+    return <Message key={index} message={message} onDeleteClick={() => onRemoveMessage(message)} />;
+  });
+
   return (
     <Box maxW="900px" mx="auto" scrollBehavior="smooth">
       {/* Show entire message history + current streaming response if available */}
       <Collapse in={!singleMessageMode} animateOpacity>
         <>
-          {messages.map((message: BaseChatMessage, index: number) => {
-            return (
-              <Message
-                key={index}
-                message={message}
-                loading={loading}
-                onDeleteClick={() => onRemoveMessage(message)}
-              />
-            );
-          })}
-          {newMessage && <Message message={newMessage} loading={loading} />}
+          {prevMessages}
+
+          {newMessage && (
+            <NewMessage
+              message={newMessage}
+              isPaused={isPaused}
+              onTogglePause={onTogglePause}
+              onCancel={onCancel}
+            />
+          )}
         </>
       </Collapse>
 
@@ -62,7 +73,14 @@ function MessagesView({
             onDeleteClick={() => onRemoveMessage(lastMessage)}
           />
 
-          {newMessage && <Message message={newMessage} loading={loading} />}
+          {newMessage && (
+            <NewMessage
+              message={newMessage}
+              isPaused={isPaused}
+              onTogglePause={onTogglePause}
+              onCancel={onCancel}
+            />
+          )}
         </>
       )}
     </Box>

--- a/src/components/NewMessage.tsx
+++ b/src/components/NewMessage.tsx
@@ -1,0 +1,48 @@
+import { AIChatMessage } from "langchain/schema";
+import { Box, Button, ButtonGroup, Flex } from "@chakra-ui/react";
+
+import Message from "./Message";
+
+type NewMessageProps = {
+  message: AIChatMessage;
+  isPaused: boolean;
+  onTogglePause: () => void;
+  onCancel: () => void;
+};
+
+function NewMessage({ message, isPaused, onTogglePause, onCancel }: NewMessageProps) {
+  // If the user presses the mouse button over the streaming message while
+  // loading, pause to make it easier to copy/paste text as it streams in.
+  function handleMouseDown() {
+    if (!isPaused) {
+      onTogglePause();
+    }
+  }
+
+  return (
+    <Flex flexDir="column" w="100%">
+      <Box flex={1} onMouseDown={handleMouseDown}>
+        <Message message={message} loading={true} />
+      </Box>
+      <Box textAlign="center">
+        <ButtonGroup>
+          <Button variant="outline" size="xs" onClick={() => onCancel()}>
+            Cancel
+          </Button>
+
+          {isPaused ? (
+            <Button key="resume" size="xs" onClick={() => onTogglePause()}>
+              Resume
+            </Button>
+          ) : (
+            <Button key="pause" size="xs" onClick={() => onTogglePause()}>
+              Pause
+            </Button>
+          )}
+        </ButtonGroup>
+      </Box>
+    </Flex>
+  );
+}
+
+export default NewMessage;

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -17,14 +17,7 @@ import {
   HStack,
   Tag,
 } from "@chakra-ui/react";
-import {
-  CgChevronUpO,
-  CgChevronDownO,
-  CgInfo,
-  CgPlayPauseO,
-  CgPlayButtonO,
-  CgPlayStopO,
-} from "react-icons/cg";
+import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
 
 import AutoResizingTextarea from "./AutoResizingTextarea";
 import RevealablePasswordInput from "./RevealablePasswordInput";
@@ -63,40 +56,9 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
   );
 }
 
-type LoadingHintProps = {
-  isPaused: boolean;
-  onPause: () => void;
-  onResume: () => void;
-  onCancel: () => void;
-};
-
-function LoadingHint({ isPaused, onPause, onResume }: LoadingHintProps) {
-  return (
-    <ButtonGroup>
-      <Button variant="outline" size="xs" leftIcon={<CgPlayStopO />} onClick={onResume}>
-        Cancel
-      </Button>
-
-      {isPaused ? (
-        <Button size="xs" leftIcon={<CgPlayButtonO />} onClick={onResume}>
-          Resume
-        </Button>
-      ) : (
-        <Button size="xs" leftIcon={<CgPlayPauseO />} onClick={onPause}>
-          Pause
-        </Button>
-      )}
-    </ButtonGroup>
-  );
-}
-
 type PromptFormProps = {
   onPrompt: (prompt: string) => void;
   onClear: () => void;
-  isPaused: boolean;
-  onPause: () => void;
-  onResume: () => void;
-  onCancel: () => void;
   // Whether or not to automatically manage the height of the prompt.
   // When `isExpanded` is `false`, Shit+Enter adds rows. Otherwise,
   // the height is determined automatically by the parent.
@@ -113,10 +75,6 @@ type PromptFormProps = {
 function PromptForm({
   onPrompt,
   onClear,
-  isPaused,
-  onPause,
-  onResume,
-  onCancel,
   isExpanded,
   toggleExpanded,
   singleMessageMode,
@@ -201,16 +159,7 @@ function PromptForm({
   return (
     <Box h="100%" px={1}>
       <Flex justify="space-between" alignItems="baseline">
-        {isLoading ? (
-          <LoadingHint
-            isPaused={isPaused}
-            onPause={onPause}
-            onResume={onResume}
-            onCancel={onCancel}
-          />
-        ) : (
-          <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
-        )}
+        <KeyboardHint isVisible={!!prompt.length && !isLoading} isExpanded={isExpanded} />
 
         <HStack>
           {
@@ -233,6 +182,7 @@ function PromptForm({
               title={isExpanded ? "Minimize prompt area" : "Maximize prompt area"}
               icon={isExpanded ? <CgChevronDownO /> : <CgChevronUpO />}
               variant="ghost"
+              isDisabled={isLoading}
               onClick={toggleExpanded}
             />
           </ButtonGroup>

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -39,6 +39,18 @@ function useChatOpenAI() {
     pausedRef.current = paused;
   }, [paused]);
 
+  const pause = () => {
+    setPaused(true);
+  };
+
+  const resume = () => {
+    setPaused(false);
+  };
+
+  const togglePause = () => {
+    setPaused(!paused);
+  };
+
   const callChatApi = useCallback(
     (messages: BaseChatMessage[]) => {
       const buffer: string[] = [];
@@ -112,9 +124,10 @@ function useChatOpenAI() {
     callChatApi,
     getTokenInfo,
     cancel,
-    isPaused: paused,
-    pause: () => setPaused(true),
-    resume: () => setPaused(false),
+    paused,
+    pause,
+    resume,
+    togglePause,
   };
 }
 

--- a/src/hooks/use-system-message.ts
+++ b/src/hooks/use-system-message.ts
@@ -5,7 +5,8 @@ import { useSettings } from "./use-settings";
 const defaultSystemMessage = `You are ChatCraft.org, a web-based, expert programming AI.
  You help programmers learn, experiment, and be more creative with code.
  Respond in GitHub flavored Markdown. Format ALL lines of code to 80
- characters or fewer. Use Mermaid diagrams when discussing visual topics.`;
+ characters or fewer. Use Mermaid diagrams when discussing visual topics and always
+ label Mermaid diagrams with \`\`\`mermaid\n...\`\`\`.`;
 
 const justShowMeTheCodeMessage =
   "However, when responding with code, ONLY return the code and NOTHING else (i.e., don't explain ANYTHING).";


### PR DESCRIPTION
Fixes #52 
Fixes #51 

This fixes and improves a bunch of things.

To start, I've moved the Cancel and Pause/Resume buttons out of the prompt form and below the streaming message.  In order to make this work, I had to fix a bunch of other things:

- fix the way that the pause, resume, etc. hook functions and state work
- move the "mouse down pauses" functionality, and remove "mouse up resumes."  I think this makes way more sense, and "feels right" to me when I use it.  See if you agree.
- reduce re-renders in a bunch of places by memoizing things, which fixed the HTML/Mermaid previews
- refactored the streaming message and streaming buttons into a new component, `NewMessage.tsx`

I've also made it so that when a Mermaid diagram crashes, if you click "copy" it will copy the error vs. the diagram SVG, so you can prompt the AI to debug it.

I've also fixed a bug I hit during testing where the AI would return `text` vs. `mermaid` for mermaid diagrams, making it so they didn't render.  I've included more instructions in the system prompt.

I think these changes make things way smoother.  Test and let me know if you think we need to change anything.