### PR TITLE
run js code and send response back to model

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -139,6 +139,7 @@ function App() {
             isPaused={paused}
             onTogglePause={togglePause}
             onCancel={cancel}
+            onPrompt={onPrompt}
           />
 
           {

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -45,10 +45,11 @@ const fixLanguageName = (language: string | null) => {
 
 type MarkdownProps = {
   previewCode?: boolean;
+  onPrompt?: (prompt: string) => void;
   children: string;
 };
 
-function Markdown({ previewCode, children }: MarkdownProps) {
+function Markdown({ previewCode, onPrompt, children }: MarkdownProps) {
   const style = useColorModeValue(oneLight, oneDark);
 
   return (
@@ -98,7 +99,9 @@ function Markdown({ previewCode, children }: MarkdownProps) {
                 <SyntaxHighlighter
                   children={code}
                   language={fixLanguageName(language)}
-                  PreTag={(props) => <CodeHeader {...props} code={code} language={language} />}
+                  PreTag={(props) => (
+                    <CodeHeader {...props} code={code} language={language} onPrompt={onPrompt} />
+                  )}
                   style={style}
                   showLineNumbers={true}
                   showInlineLineNumbers={true}

--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -11,10 +11,11 @@ import "./Message.css";
 type MessageProps = {
   message: BaseChatMessage;
   loading?: boolean;
+  onPrompt?: (prompt: string) => void;
   onDeleteClick?: () => void;
 };
 
-function Message({ message, loading, onDeleteClick }: MessageProps) {
+function Message({ message, loading, onDeleteClick, onPrompt }: MessageProps) {
   const { onCopy } = useClipboard(message.text);
   const toast = useToast();
   const isAI = message instanceof AIChatMessage;
@@ -44,7 +45,9 @@ function Message({ message, loading, onDeleteClick }: MessageProps) {
 
         <Box flex="1" maxWidth="100%" overflow="hidden" mt={1}>
           {/* Messages are being rendered in Markdown format */}
-          <Markdown previewCode={!loading}>{message.text}</Markdown>
+          <Markdown previewCode={!loading} onPrompt={onPrompt}>
+            {message.text}
+          </Markdown>
         </Box>
 
         <Flex flexDir={{ base: "column-reverse", md: "row" }} justify="start">

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -15,6 +15,7 @@ type MessagesViewProps = {
   isPaused: boolean;
   onTogglePause: () => void;
   onCancel: () => void;
+  onPrompt: (prompt: string) => void;
 };
 
 function MessagesView({
@@ -26,6 +27,7 @@ function MessagesView({
   isPaused,
   onTogglePause,
   onCancel,
+  onPrompt,
 }: MessagesViewProps) {
   const { colorMode } = useColorMode();
   // When we're in singleMessageMode, we collapse all but the final message
@@ -53,10 +55,11 @@ function MessagesView({
             key={index}
             message={message}
             onDeleteClick={() => memoizedOnRemoveMessage(message)}
+            onPrompt={onPrompt}
           />
         );
       }),
-    [messages, memoizedOnRemoveMessage]
+    [messages, onPrompt, memoizedOnRemoveMessage]
   );
 
   return (
@@ -82,6 +85,7 @@ function MessagesView({
             message={lastMessage}
             loading={loading}
             onDeleteClick={() => onRemoveMessage(lastMessage)}
+            onPrompt={onPrompt}
           />
 
           {newMessage && (


### PR DESCRIPTION
This change adds a run button which executes javascript and pastes return value into a reply to bot.
<img width="802" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/857083/1fae0e49-1066-4211-b926-0762b9c807cf">
Here is a sample tool made this way:
<img width="686" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/857083/f071d511-45da-407b-81b9-03f0c851c3a1">

This is a pretty sick feature when combined with websockets. Attached sample convo. 
[websocket-chatcraft.html.zip](https://github.com/tarasglek/chatcraft.org/files/11487819/websocket-chatcraft.html.zip)

Used websocat exposed via cloudflare to connect to my computer
`websocat  -E ws-listen:0.0.0.0:8810 sh-c:'TERM=v100 bash -i 2>&1' --binary`

`cloudflared tunnel --url localhost:8810`

Currently i force-feed js output back into model. 
Thoughts:
* I think output should probably go into input box instead, not sure. 
* Model could potentially write JS to go into infinite feedback loop and take over the world :)