### PR TITLE
Rework message UI to add a heading, use full width for body

### DIFF
--- a/src/components/Message/HumanMessage.tsx
+++ b/src/components/Message/HumanMessage.tsx
@@ -10,12 +10,19 @@ function HumanMessage(props: HumanMessageProps) {
 
   // If we have a user's name and GitHub avatar, use that.
   const avatar = avatarUrl ? (
-    <Avatar size="sm" src={avatarUrl} title={name} />
+    <Avatar
+      size="sm"
+      src={avatarUrl}
+      title={name}
+      showBorder
+      borderColor="gray.100"
+      _dark={{ borderColor: "gray.600" }}
+    />
   ) : (
     <Avatar size="sm" bg="gray.600" _dark={{ bg: "gray.500" }} />
   );
 
-  return <MessageBase {...rest} avatar={avatar} />;
+  return <MessageBase {...rest} avatar={avatar} heading={name} />;
 }
 
 export default memo(HumanMessage);

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -1,13 +1,29 @@
 import { memo, useCallback, type ReactNode } from "react";
-import { Box, Card, Flex, IconButton, useClipboard, useToast } from "@chakra-ui/react";
-import { CgCloseO } from "react-icons/cg";
-import { TbCopy } from "react-icons/tb";
+import {
+  Box,
+  Card,
+  CardBody,
+  CardHeader,
+  Divider,
+  Flex,
+  Heading,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuDivider,
+  MenuItem,
+  MenuList,
+  useClipboard,
+  useToast,
+} from "@chakra-ui/react";
+import { TbDots } from "react-icons/tb";
 
 import Markdown from "../Markdown";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 
 export interface MessageBaseProps {
+  heading?: string;
   text: string;
   avatar: ReactNode;
   isLoading: boolean;
@@ -17,6 +33,7 @@ export interface MessageBaseProps {
 }
 
 function MessageBase({
+  heading,
   text,
   avatar,
   isLoading,
@@ -40,47 +57,54 @@ function MessageBase({
   }, [onCopy, toast]);
 
   return (
-    <Card p={6} my={6}>
-      <Flex>
-        <Box pr={6}>{avatar}</Box>
+    <Box my={6} flex={1}>
+      <Card>
+        <CardHeader p={0} py={1} pr={1}>
+          <Flex justify="space-between" align="center" ml={5} mr={2}>
+            <Flex gap={3}>
+              <Box>{avatar}</Box>
+              <Flex direction="column" justify="center">
+                <Heading as="h2" size="xs">
+                  {heading}
+                </Heading>
+              </Flex>
+            </Flex>
 
-        <Box flex="1" maxWidth="100%" overflow="hidden" mt={1}>
-          {/* Messages are being rendered in Markdown format */}
-          <Markdown previewCode={!hidePreviews} isLoading={isLoading} onPrompt={onPrompt}>
-            {text}
-          </Markdown>
-        </Box>
-
-        <Flex
-          flexDir={{ base: "column-reverse", md: "row" }}
-          minW={{ md: "80px " }}
-          justify="start"
-        >
-          <IconButton
-            aria-label="Copy to Clipboard"
-            title="Copy to Clipboard"
-            icon={<TbCopy />}
-            onClick={() => handleCopy()}
-            color="gray.600"
-            _dark={{ color: "gray.300" }}
-            variant="ghost"
-          />
-          {onDeleteClick && (
-            <IconButton
-              aria-label="Delete"
-              title="Delete"
-              icon={<CgCloseO />}
-              variant="ghost"
-              color="gray.600"
-              _dark={{ color: "gray.300" }}
-              onClick={onDeleteClick && (() => onDeleteClick())}
-            />
-          )}
-        </Flex>
-      </Flex>
-    </Card>
+            <Menu>
+              <MenuButton
+                as={IconButton}
+                aria-label="Message Menu"
+                icon={<TbDots />}
+                variant="ghost"
+                isDisabled={isLoading}
+              />
+              <MenuList>
+                <MenuItem onClick={() => handleCopy()}>Copy</MenuItem>
+                <MenuDivider />
+                <MenuItem>Edit (TODO...)</MenuItem>
+                {onDeleteClick && (
+                  <MenuItem onClick={() => onDeleteClick()} color="red.400">
+                    Delete
+                  </MenuItem>
+                )}
+              </MenuList>
+            </Menu>
+          </Flex>
+        </CardHeader>
+        <CardBody p={0}>
+          <Flex direction="column" gap={3}>
+            <Divider />
+            <Box maxWidth="100%" overflow="hidden" px={6} pb={2}>
+              {/* Messages are being rendered in Markdown format */}
+              <Markdown previewCode={!hidePreviews} isLoading={isLoading} onPrompt={onPrompt}>
+                {text}
+              </Markdown>
+            </Box>
+          </Flex>
+        </CardBody>
+      </Card>
+    </Box>
   );
 }
 
-// Memoize to reduce re-renders/flickering when content hasn't changed
 export default memo(MessageBase);

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -10,18 +10,24 @@ interface OpenAiMessageProps extends Omit<MessageBaseProps, "avatar"> {
 const getAvatar = (model: GptModel) => {
   switch (model) {
     case "gpt-4":
-      return <Avatar size="sm" bg="#A96CF9" src={`/openai-logo.png`} title="GPT-4" />;
+      return {
+        avatar: <Avatar size="sm" bg="#A96CF9" src={`/openai-logo.png`} title="GPT-4" />,
+        heading: "GPT-4",
+      };
     case "gpt-3.5-turbo":
     // falls through
     default:
-      return <Avatar size="sm" bg="#75AB9C" src={`/openai-logo.png`} title="ChatGPT" />;
+      return {
+        avatar: <Avatar size="sm" bg="#75AB9C" src={`/openai-logo.png`} title="ChatGPT" />,
+        heading: "ChatGPT",
+      };
   }
 };
 
 function OpenAiMessage(props: OpenAiMessageProps) {
-  const avatar = getAvatar(props.model);
+  const { heading, avatar } = getAvatar(props.model);
 
-  return <MessageBase {...props} avatar={avatar} />;
+  return <MessageBase {...props} avatar={avatar} heading={heading} />;
 }
 
 export default memo(OpenAiMessage);


### PR DESCRIPTION
I reworked the message UI so it has:

1. a header with "dots" menu, inspired by GitHub
2. full-width body, since I don't want to wrap code so often

<img width="1047" alt="Screenshot 2023-05-25 at 11 42 23 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/9027d503-be0b-442d-8f73-baadc3603e0d">

Clicking the "dots" menu gives you the various options for this message:

<img width="920" alt="Screenshot 2023-05-25 at 11 44 19 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/f8dc16d3-fa1b-43e0-a7ee-ca0aead08ac6">

The better use of space is also great on mobile:

<img width="369" alt="Screenshot 2023-05-25 at 11 43 32 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/fe533fcd-8838-4430-8f57-3b34b863c512">
