### PR TITLE
Add tag in header with saved chat count, use tag in search count

### DIFF
--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -9,6 +9,7 @@ import {
   GridItem,
   Heading,
   Center,
+  Tag,
 } from "@chakra-ui/react";
 import {
   Link as ReactRouterLink,
@@ -97,11 +98,9 @@ export default function Search() {
         <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
           {hasResults ? (
             <>
-              <Heading as="h2" size="sm" mt={4}>
-                {`${messages.length} ${messages.length > 1 ? "Messages" : "Message"} Found in ${
-                  chatIds.length
-                } ${chatIds.length > 1 ? "Chats" : "Chat"}`}
-              </Heading>
+              <Tag maxW="fit-content" mt={4}>{`${messages.length} ${
+                messages.length > 1 ? "Messages" : "Message"
+              } Found in ${chatIds.length} ${chatIds.length > 1 ? "Chats" : "Chat"}`}</Tag>
               <Box flex={1}>
                 {messages.map((message) => (
                   <Message

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,6 +14,7 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
+  Tag,
   Text,
   useColorMode,
   useColorModeValue,
@@ -23,9 +24,12 @@ import { BiSun, BiMoon } from "react-icons/bi";
 import { BsGithub } from "react-icons/bs";
 import { TbSearch, TbLayoutSidebarLeftExpand, TbLayoutSidebarRightExpand } from "react-icons/tb";
 import { Form } from "react-router-dom";
+import { useLiveQuery } from "dexie-react-hooks";
 
 import PreferencesModal from "./PreferencesModal";
 import { useUser } from "../hooks/use-user";
+import db from "../lib/db";
+import { formatNumber } from "../lib/utils";
 
 type HeaderProps = {
   inputPromptRef: RefObject<HTMLTextAreaElement>;
@@ -43,6 +47,7 @@ function Header({
   const { toggleColorMode } = useColorMode();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { user, login, logout } = useUser();
+  const chatsCount = useLiveQuery<number, 0>(() => db.chats.count(), [], 0);
 
   return (
     <Flex
@@ -80,6 +85,10 @@ function Header({
       </Box>
 
       <ButtonGroup isAttached pr={2} alignItems="center">
+        <Tag size="sm" variant="outline" mr={1}>
+          {formatNumber(chatsCount)} Saved Chats
+        </Tag>
+
         <IconButton
           aria-label={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           title={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}


### PR DESCRIPTION
Added live chat count in db.  I moved it to the right, so it doesn't like like it's connected to the search.

<img width="1061" alt="Screenshot 2023-06-01 at 4 01 49 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/232bbd18-6965-4c58-be89-bb14ea4f257a">

While doing this I realized the search result count would look better as a tag too.