### PR TITLE
Going to / should redirect to most recent chat if possible

### DIFF
--- a/src/router.tsx
+++ b/src/router.tsx
@@ -8,10 +8,21 @@ import db from "./lib/db";
 import { getUser } from "./lib/storage";
 
 export default createBrowserRouter([
-  // Redirect users from / -> /new so they can create a chat
+  // Load the user's most recent chat, or start a new one the first time
   {
     path: "/",
-    element: <Navigate to="/new" />,
+    async loader() {
+      try {
+        const recentChat = await db.chats.orderBy("date").last();
+        if (recentChat) {
+          return redirect(`/c/${recentChat.id}`);
+        }
+      } catch (err) {
+        console.warn("Error getting most recent chat", err);
+      }
+
+      return redirect("/new");
+    },
   },
   // Create a new chat
   {
@@ -23,7 +34,7 @@ export default createBrowserRouter([
     },
   },
 
-  // People shouldn't end-up here, so create new chat if they do
+  // People shouldn't end-up here, so create a new chat if they do
   {
     path: "/c",
     element: <Navigate to="/new" />,


### PR DESCRIPTION
I'm not happy with the way that the `/` route works.  Currently, it always redirects to `/new`, so you end up with lots of chats you might not want in the db.

I think this change is better: when you go to `/` it will get the most recent chat and open that.  If you want to make a new one, you opt into that manually.

See if you agree.