### PR TITLE
Fixes to sharing UI

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -11,32 +11,25 @@ import {
   GridItem,
   ButtonGroup,
 } from "@chakra-ui/react";
-import { Link as ReactRouterLink, ScrollRestoration, useParams } from "react-router-dom";
+import { Link as ReactRouterLink, ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
-import { useLiveQuery } from "dexie-react-hooks";
 
-import PromptForm from "./components/PromptForm";
-import MessagesView from "./components/MessagesView";
-import Header from "./components/Header";
-import Sidebar from "./components/Sidebar";
-import useMessages from "./hooks/use-messages";
-import useChatOpenAI from "./hooks/use-chat-openai";
-import { ChatCraftHumanMessage } from "./lib/ChatCraftMessage";
-import { ChatCraftChat } from "./lib/ChatCraftChat";
-import { useUser } from "./hooks/use-user";
+import PromptForm from "../components/PromptForm";
+import MessagesView from "../components/MessagesView";
+import Header from "../components/Header";
+import Sidebar from "../components/Sidebar";
+import useMessages from "../hooks/use-messages";
+import useChatOpenAI from "../hooks/use-chat-openai";
+import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { useUser } from "../hooks/use-user";
 
-type ChatProps = {
+type ChatBaseProps = {
+  chat: ChatCraftChat;
   readonly: boolean;
 };
 
-function Chat({ readonly }: ChatProps) {
-  const { id: chatId } = useParams();
-  const chat = useLiveQuery<ChatCraftChat | undefined>(() => {
-    if (chatId) {
-      return Promise.resolve(ChatCraftChat.find(chatId));
-    }
-  }, [chatId]);
-
+function ChatBase({ chat, readonly }: ChatBaseProps) {
   // Messages are all the static, previous messages in the chat
   // TODO: this token stuff is no longer right and useMessages() needs to be removed
   const { tokenInfo } = useMessages();
@@ -120,10 +113,6 @@ function Chat({ readonly }: ChatProps) {
   // Handle prompt form submission
   const onPrompt = useCallback(
     async (prompt: string) => {
-      if (!chat) {
-        return;
-      }
-
       setShouldAutoScroll(true);
       setLoading(true);
 
@@ -159,11 +148,6 @@ function Chat({ readonly }: ChatProps) {
   function handleFollowChatClick() {
     setShouldAutoScroll(true);
     resume();
-  }
-
-  // Wait until we have a chat object to render
-  if (!chat) {
-    return null;
   }
 
   return (
@@ -236,7 +220,7 @@ function Chat({ readonly }: ChatProps) {
                     New
                   </Button>
                 </ReactRouterLink>
-                <ReactRouterLink to={`/c/${chat.id}/fork`}>
+                <ReactRouterLink to="./fork">
                   <Button variant="link" size="sm">
                     Fork
                   </Button>
@@ -264,4 +248,4 @@ function Chat({ readonly }: ChatProps) {
   );
 }
 
-export default Chat;
+export default ChatBase;

--- a/src/Chat/LocalChat.tsx
+++ b/src/Chat/LocalChat.tsx
@@ -1,0 +1,22 @@
+import { useLoaderData } from "react-router-dom";
+import { useLiveQuery } from "dexie-react-hooks";
+
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import ChatBase from "./ChatBase";
+
+type LocalChatProps = {
+  readonly: boolean;
+};
+
+// Load a chat from the database locally
+export default function LocalChat({ readonly }: LocalChatProps) {
+  const chatId = useLoaderData() as string;
+  const chat = useLiveQuery<ChatCraftChat | undefined>(() => {
+    if (chatId) {
+      return Promise.resolve(ChatCraftChat.find(chatId));
+    }
+  }, [chatId]);
+
+  // TODO: need some kind of error handling here if `chat` doesn't exist
+  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+}

--- a/src/Chat/RemoteChat.tsx
+++ b/src/Chat/RemoteChat.tsx
@@ -1,0 +1,16 @@
+import { useLoaderData } from "react-router-dom";
+
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import ChatBase from "./ChatBase";
+
+type LocalChatProps = {
+  readonly: boolean;
+};
+
+// Load a chat from over the network as a JSON blob (already available via loader)
+export default function LocalChat({ readonly }: LocalChatProps) {
+  const chat = useLoaderData() as ChatCraftChat;
+
+  // TODO: need some kind of error handling here if `chat` doesn't exist
+  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+}

--- a/src/Chat/index.tsx
+++ b/src/Chat/index.tsx
@@ -1,0 +1,2 @@
+export { default as LocalChat } from "./LocalChat";
+export { default as RemoteChat } from "./RemoteChat";

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -109,7 +109,7 @@ export default function Search() {
                 {messages.map((message) => (
                   <Message
                     key={message.id}
-                    message={ChatCraftMessage.parse(message)}
+                    message={ChatCraftMessage.fromDB(message)}
                     chatId={message.chatId}
                     isLoading={false}
                   />

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -120,9 +120,7 @@ function MessageBase({
                 <MenuItem onClick={() => handleCopy()}>Copy</MenuItem>
                 <MenuItem onClick={() => handleDownload()}>Download</MenuItem>
                 {!disableFork && (
-                  <MenuItem onClick={() => navigate(`/c/${chatId}/fork/${id}`)}>
-                    Fork from Message
-                  </MenuItem>
+                  <MenuItem onClick={() => navigate(`./fork/${id}`)}>Fork from Message</MenuItem>
                 )}
                 {!disableEdit && onDeleteClick && <MenuDivider />}
                 {!disableEdit && <MenuItem>Edit (TODO...)</MenuItem>}

--- a/src/hooks/use-messages.ts
+++ b/src/hooks/use-messages.ts
@@ -43,9 +43,15 @@ const msg2obj = (msg: BaseChatMessage | ChatCraftMessage): SerializedChatCraftMe
 
   // It's one of the older message formats, upgrade them
   if (msg instanceof HumanChatMessage) {
-    return { id: nanoid(), type: "human", text: msg.text, date: new Date() };
+    return { id: nanoid(), type: "human", text: msg.text, date: new Date().toISOString() };
   }
-  return { id: nanoid(), type: "ai", model: "gpt-3.5-turbo", text: msg.text, date: new Date() };
+  return {
+    id: nanoid(),
+    type: "ai",
+    model: "gpt-3.5-turbo",
+    text: msg.text,
+    date: new Date().toISOString(),
+  };
 };
 
 const greetingMessage = "I am a helpful assistant! How can I help?";

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -1,9 +1,10 @@
 import { nanoid } from "nanoid";
 import { BaseChatMessage, type MessageType } from "langchain/schema";
+import { ChatCraftMessageTable } from "./db";
 
 export type SerializedChatCraftMessage = {
   id: string;
-  date: Date;
+  date: string;
   type: MessageType;
   model?: GptModel;
   user?: User;
@@ -64,7 +65,7 @@ export class ChatCraftMessage extends BaseChatMessage {
   serialize(): SerializedChatCraftMessage {
     return {
       id: this.id,
-      date: this.date,
+      date: this.date.toISOString(),
       type: this.type,
       model: this.model,
       user: this.user,
@@ -72,6 +73,7 @@ export class ChatCraftMessage extends BaseChatMessage {
     };
   }
 
+  // Parse from serialized JSON
   static parse({
     id,
     date,
@@ -81,12 +83,24 @@ export class ChatCraftMessage extends BaseChatMessage {
     text,
   }: SerializedChatCraftMessage): ChatCraftMessage {
     if (type === "ai") {
-      return new ChatCraftAiMessage({ id, date, model: model || "gpt-3.5-turbo", text });
+      return new ChatCraftAiMessage({
+        id,
+        date: new Date(date),
+        model: model || "gpt-3.5-turbo",
+        text,
+      });
     } else if (type === "human") {
-      return new ChatCraftHumanMessage({ id, date, user, text });
+      return new ChatCraftHumanMessage({ id, date: new Date(date), user, text });
     } else {
-      return new ChatCraftSystemMessage({ id, date, text });
+      return new ChatCraftSystemMessage({ id, date: new Date(date), text });
     }
+  }
+
+  // Parse from db representation
+  static fromDB(message: ChatCraftMessageTable) {
+    return new ChatCraftMessage({
+      ...message,
+    });
   }
 }
 


### PR DESCRIPTION
This adds some larger fixes I needed to un-break sharing on prod.

Major changes included in this:

- Separate `Chat.tsx` into `LocalChat.tsx` and `RemoteChat.tsx`, since they need to load their data differently (local from db via Dexie, remote from R2 using `fetch()`).  The commonalities are now moved to `ChatBase.tsx`
- I've had to properly implement parsing from the DB types (i.e., added `.fromDB()` methods to the `ChatCraftChat` and `ChatCraftMessage` classes), which simplified a bunch of things.
- Dealt with `Date` being a `string` when serialized to JSON vs. a `Date` in DB/Memory
- Implemented proper `Chat` loading from R2/functions.  Now you can load/clone shared chats.

Again, I'll merge this once it passes CI, since I need it to get back to zero on prod.  I'll have to update some of the other PRs to work with this, though, which I'll do tonight or over the weekend.