### PR TITLE
Show recent chats, allow deletes

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -3,14 +3,16 @@ import {
   Box,
   Button,
   Flex,
+  Link,
   Text,
   useDisclosure,
   useBreakpoint,
   useToast,
   Grid,
   GridItem,
+  Heading,
 } from "@chakra-ui/react";
-import { ScrollRestoration } from "react-router-dom";
+import { Form, Link as ReactRouterLink, ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
 
 import PromptForm from "../components/PromptForm";
@@ -23,13 +25,15 @@ import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { useUser } from "../hooks/use-user";
 import NewButton from "../components/NewButton";
+import { formatDate } from "../lib/utils";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
   readonly: boolean;
+  canDelete: boolean;
 };
 
-function ChatBase({ chat, readonly }: ChatBaseProps) {
+function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
   // Messages are all the static, previous messages in the chat
   // TODO: this token stuff is no longer right and useMessages() needs to be removed
   const { tokenInfo } = useMessages();
@@ -168,7 +172,7 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
       </GridItem>
 
       <GridItem rowSpan={2} overflowY="auto">
-        <Sidebar />
+        <Sidebar selectedChat={chat} />
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">
@@ -194,6 +198,21 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
           }
 
           <ScrollRestoration />
+
+          <Flex justify={canDelete ? "space-between" : "end"} align="center">
+            <Heading as="h2" fontSize="lg">
+              <Link as={ReactRouterLink} to={`/c/${chat.id}`}>
+                {formatDate(chat.date)}
+              </Link>
+            </Heading>
+            {canDelete && (
+              <Form action={`/c/${chat.id}/delete`} method="post">
+                <Button type="submit" size="sm" variant="ghost" colorScheme="red">
+                  Delete
+                </Button>
+              </Form>
+            )}
+          </Flex>
 
           <MessagesView
             messages={chat.messages}

--- a/src/Chat/LocalChat.tsx
+++ b/src/Chat/LocalChat.tsx
@@ -18,5 +18,5 @@ export default function LocalChat({ readonly }: LocalChatProps) {
   }, [chatId]);
 
   // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+  return chat ? <ChatBase chat={chat} readonly={readonly} canDelete={true} /> : null;
 }

--- a/src/Chat/RemoteChat.tsx
+++ b/src/Chat/RemoteChat.tsx
@@ -12,5 +12,5 @@ export default function LocalChat({ readonly }: LocalChatProps) {
   const chat = useLoaderData() as ChatCraftChat;
 
   // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+  return chat ? <ChatBase chat={chat} readonly={readonly} canDelete={false} /> : null;
 }

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -94,7 +94,7 @@ function MessageBase({
                   <Heading as="h2" size="xs">
                     {heading}
                   </Heading>
-                  <Text as="span" fontSize="sm" textDecoration="underline">
+                  <Text as="span" fontSize="sm">
                     <Link
                       as={ReactRouterLink}
                       to={`/c/${chatId}#${id}`}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,29 +1,96 @@
-import { Box, Flex, VStack, Heading, Text } from "@chakra-ui/react";
+import {
+  Box,
+  Flex,
+  VStack,
+  Heading,
+  Text,
+  Button,
+  Center,
+  useColorModeValue,
+  IconButton,
+} from "@chakra-ui/react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { MdOutlineChatBubbleOutline } from "react-icons/md";
 import { TbShare2 } from "react-icons/tb";
+import { CgClose } from "react-icons/cg";
 
 import db, { type ChatCraftChatTable } from "../lib/db";
-import { Link } from "react-router-dom";
+import { Form, Link } from "react-router-dom";
+import { useState } from "react";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { formatNumber } from "../lib/utils";
 
-function SidebarItem({ text, url }: { text: string; url: string }) {
+type SidebarItemProps = {
+  text: string;
+  url: string;
+  isSelected: boolean;
+  canDelete?: boolean;
+};
+
+function SidebarItem({ text, url, isSelected, canDelete }: SidebarItemProps) {
+  const bg = useColorModeValue(
+    isSelected ? "gray.200" : undefined,
+    isSelected ? "gray.700" : undefined
+  );
+  const border = isSelected ? "1px solid" : "1px solid transparent";
+  const borderColor = useColorModeValue(
+    isSelected ? "gray.300" : undefined,
+    isSelected ? "gray.800" : undefined
+  );
+
   return (
-    <Link to={url}>
-      <Flex gap={2} pr={6}>
-        <Box mt={1}>
+    <Flex gap={2} p={1} bg={bg} border={border} borderColor={borderColor} borderRadius={4}>
+      <VStack mt={1} gap={1} minH={14}>
+        <Flex w={6} h={6} justify="center" align="center">
           <MdOutlineChatBubbleOutline />
-        </Box>
-        <Box flex={1} maxW="100%">
+        </Flex>
+        {isSelected && canDelete && (
+          <Form action={`${url}/delete`} method="post">
+            <IconButton
+              size="xs"
+              variant="ghost"
+              type="submit"
+              icon={<CgClose />}
+              aria-label="Delete chat"
+              title="Delete chat"
+              colorScheme="red"
+            />
+          </Form>
+        )}
+      </VStack>
+      <Box flex={1} maxW="100%">
+        <Link to={url}>
           <Text noOfLines={4} fontSize="sm" title={text}>
             {text}
           </Text>
-        </Box>
-      </Flex>
-    </Link>
+        </Link>
+      </Box>
+    </Flex>
   );
 }
 
-function Sidebar() {
+type SidebarProps = {
+  selectedChat?: ChatCraftChat;
+};
+
+function Sidebar({ selectedChat }: SidebarProps) {
+  const [recentCount, setRecentCount] = useState(5);
+
+  const chatsTotal = useLiveQuery<number, number>(() => db.chats.count(), [], 0);
+
+  const recentChats = useLiveQuery<ChatCraftChat[], ChatCraftChat[]>(
+    async () => {
+      const records = await db.chats.orderBy("date").reverse().limit(recentCount).toArray();
+      if (!records) {
+        return [];
+      }
+      const chats = await Promise.all(records.map(({ id }) => ChatCraftChat.find(id)));
+      return chats.filter((chat): chat is ChatCraftChat => !!chat);
+    },
+    [recentCount],
+    []
+  );
+
   const sharedChats = useLiveQuery<ChatCraftChatTable[], ChatCraftChatTable[]>(
     async () =>
       db.chats
@@ -34,44 +101,79 @@ function Sidebar() {
     []
   );
 
-  return (
-    <Flex direction="column" h="100%" p={4} gap={2}>
-      <Box>
-        <Flex align="center" gap={1}>
-          <Heading as="h3" size="sm">
-            Shared Chats
-          </Heading>
-        </Flex>
-      </Box>
+  function handleShowMoreClick() {
+    const newCount = Math.min(recentCount + 10, chatsTotal);
+    setRecentCount(newCount);
+  }
 
-      <>
-        {sharedChats?.length ? (
-          sharedChats.map(({ id, summary, shareUrl }) => (
-            // We've already filtered for all objects with shareUrl, so this is fine
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            <SidebarItem key={id} text={summary} url={shareUrl!} />
-          ))
-        ) : (
-          <VStack align="left">
-            <Text>You don&apos;t have any shared chats.</Text>
-            <Text>
-              Share your first chat by clicking the <strong>Share</strong> button ({" "}
-              <Box
-                display="inline-block"
-                as="span"
-                w="1.3em"
-                verticalAlign="middle"
-                color="blue.600"
-                _dark={{ color: "blue.200" }}
-              >
-                <TbShare2 />
-              </Box>
-              ) to create a <strong>public URL</strong>. Anyone with this URL will be able to read
-              or fork the chat.
-            </Text>
-          </VStack>
+  return (
+    <Flex direction="column" h="100%" p={2} gap={4}>
+      <VStack align="left">
+        <Heading as="h3" size="sm">
+          Recent Chats
+        </Heading>
+
+        <Box>
+          {recentChats?.length &&
+            recentChats.map((chat) => (
+              <SidebarItem
+                key={chat.id}
+                text={chat.summarize()}
+                url={`/c/${chat.id}`}
+                canDelete={true}
+                isSelected={selectedChat?.id === chat.id}
+              />
+            ))}
+        </Box>
+
+        {recentCount < chatsTotal && (
+          <Center>
+            <Button size="xs" variant="ghost" onClick={() => handleShowMoreClick()}>
+              ({formatNumber(recentCount)} of {formatNumber(chatsTotal)}) Show More...
+            </Button>
+          </Center>
         )}
-      </>
+      </VStack>
+
+      <Box flex={1}>
+        <Heading as="h3" size="sm">
+          Shared Chats
+        </Heading>
+
+        <>
+          {sharedChats?.length ? (
+            sharedChats.map(({ id, summary, shareUrl }) => (
+              <SidebarItem
+                key={id}
+                text={summary}
+                // We've already filtered for all objects with shareUrl, so this is fine
+                // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                url={shareUrl!}
+                isSelected={selectedChat?.id === id}
+              />
+            ))
+          ) : (
+            <VStack align="left">
+              <Text>You don&apos;t have any shared chats.</Text>
+              <Text>
+                Share your first chat by clicking the <strong>Share</strong> button ({" "}
+                <Box
+                  display="inline-block"
+                  as="span"
+                  w="1.3em"
+                  verticalAlign="middle"
+                  color="blue.600"
+                  _dark={{ color: "blue.200" }}
+                >
+                  <TbShare2 />
+                </Box>
+                ) to create a <strong>public URL</strong>. Anyone with this URL will be able to read
+                or fork the chat.
+              </Text>
+            </VStack>
+          )}
+        </>
+      </Box>
     </Flex>
   );
 }

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -169,6 +169,22 @@ export class ChatCraftChat {
     };
   }
 
+  static async delete(id: string) {
+    const chat = await ChatCraftChat.find(id);
+    if (chat) {
+      await Promise.all(
+        chat.messages.map((message) => {
+          try {
+            ChatCraftMessage.delete(message.id);
+          } catch (_) {
+            /* empty */
+          }
+        })
+      );
+      return db.chats.delete(id);
+    }
+  }
+
   // Parse from serialized JSON
   static parse({ id, date, shareUrl, summary, messages }: SerializedChatCraftChat): ChatCraftChat {
     return new ChatCraftChat({

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 import { BaseChatMessage, type MessageType } from "langchain/schema";
-import { ChatCraftMessageTable } from "./db";
+import db, { type ChatCraftMessageTable } from "./db";
 
 export type SerializedChatCraftMessage = {
   id: string;
@@ -71,6 +71,10 @@ export class ChatCraftMessage extends BaseChatMessage {
       user: this.user,
       text: this.text,
     };
+  }
+
+  static async delete(id: string) {
+    return db.messages.delete(id);
   }
 
   // Parse from serialized JSON

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,7 +3,7 @@ import { ChatCraftMessage } from "./ChatCraftMessage";
 export const isMac = () => navigator.userAgent.includes("Macintosh");
 export const isWindows = () => !isMac();
 
-export const formatNumber = (n: number) => n.toLocaleString();
+export const formatNumber = (n: number) => (n ? n.toLocaleString() : "0");
 
 export const shorten = (s: string, max = 50) => s.slice(0, max).concat("...");
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -53,6 +53,21 @@ export default createBrowserRouter([
     },
     element: <LocalChat readonly={false} />,
   },
+  // Delete a chat from the local db
+  {
+    path: "/c/:id/delete",
+    async action({ params }) {
+      const { id } = params;
+      if (id) {
+        try {
+          await ChatCraftChat.delete(id);
+        } catch (err) {
+          console.warn("Unable to delete chat", { id, err });
+        }
+      }
+      return redirect("/");
+    },
+  },
   // Fork an existing local chat and redirect to it. If a `messageId` is included,
   // use that as our starting message vs. whole chat (partial fork)
   {


### PR DESCRIPTION
Part of #91

This adds **Recent Chats** to the sidebar (defaults to show previous 5, but you can click **Show More...** to load another 10, etc).

I've also added UI to let you **Delete** old chats.

The only risk I see with delete is that it means you could delete a chat you forked off, and currently I don't do a deep copy of a fork'd chat (i.e., I share the messages) so that we don't have a done of duplication in search results.

<img width="1018" alt="Screenshot 2023-06-06 at 12 21 17 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/fe554aaf-8db0-4573-8108-9e9e56bde8b5">
 