### PR TITLE
Login and Logout should redirect back to same chat URL

### DIFF
--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -12,18 +12,24 @@ interface Env {
 // We store the token in a secure, HTTP-only cookie.
 export async function handleLogin({
   code,
+  chatId,
   CLIENT_ID,
   CLIENT_SECRET,
   JWT_SECRET,
 }: {
   code: string | null;
+  chatId: string | null;
   CLIENT_ID: string;
   CLIENT_SECRET: string;
   JWT_SECRET: string;
 }) {
   // If we're missing the code, redirect to the GitHub Auth UI
   if (!code) {
-    const url = buildUrl("https://github.com/login/oauth/authorize", { client_id: CLIENT_ID });
+    const url = buildUrl(
+      "https://github.com/login/oauth/authorize",
+      // If there's a chatId, piggy-back it on the request as state
+      chatId ? { client_id: CLIENT_ID, state: chatId } : { client_id: CLIENT_ID }
+    );
     return Response.redirect(url, 302);
   }
 
@@ -37,10 +43,13 @@ export async function handleLogin({
     // API authorization goes in an HTTP-Only cookie that only functions can read
     const accessToken = await createToken(user.username, { role: "api" }, JWT_SECRET);
 
+    // Return to the root or a specific chat if we have an id
+    const url = new URL(chatId ? `/c/${chatId}` : "/", "https://chatcraft.org").href;
+
     return new Response(null, {
       status: 302,
       headers: new Headers([
-        ["Location", "https://chatcraft.org/"],
+        ["Location", url],
         ["Set-Cookie", serializeToken("access_token", accessToken)],
         ["Set-Cookie", serializeToken("id_token", idToken)],
       ]),
@@ -55,6 +64,9 @@ export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
   const { CLIENT_ID, CLIENT_SECRET, JWT_SECRET } = env;
   const reqUrl = new URL(request.url);
   const code = reqUrl.searchParams.get("code");
+  // Include ?chat_id=... to redirect back to a given chat in the client.  GitHub will
+  // return it back to us via ?state=...
+  const chatId = reqUrl.searchParams.get("chat_id") || reqUrl.searchParams.get("state");
 
-  return handleLogin({ code, CLIENT_ID, CLIENT_SECRET, JWT_SECRET });
+  return handleLogin({ code, chatId, CLIENT_ID, CLIENT_SECRET, JWT_SECRET });
 };

--- a/functions/api/logout.test.ts
+++ b/functions/api/logout.test.ts
@@ -8,7 +8,7 @@ describe("/api/logout", () => {
     const JWT_SECRET = "secret";
     const accessToken = null;
     const idToken = await createToken("subject", {}, JWT_SECRET);
-    const res = await handleLogout({ accessToken, idToken, JWT_SECRET });
+    const res = await handleLogout({ accessToken, chatId: null, idToken, JWT_SECRET });
     expect(res.status).toBe(401);
   });
 
@@ -16,7 +16,7 @@ describe("/api/logout", () => {
     const JWT_SECRET = "secret";
     const accessToken = await createToken("subject", {}, JWT_SECRET);
     const idToken = null;
-    const res = await handleLogout({ accessToken, idToken, JWT_SECRET });
+    const res = await handleLogout({ accessToken, chatId: null, idToken, JWT_SECRET });
     expect(res.status).toBe(401);
   });
 
@@ -24,7 +24,12 @@ describe("/api/logout", () => {
     // Swap the secrets between creating and verifying tokens
     const accessToken = await createToken("subject", {}, "old_secret");
     const idToken = await createToken("subject", {}, "old_secret");
-    const res = await handleLogout({ accessToken, idToken, JWT_SECRET: "new_secret" });
+    const res = await handleLogout({
+      accessToken,
+      idToken,
+      chatId: null,
+      JWT_SECRET: "new_secret",
+    });
     expect(res.status).toBe(401);
   });
 
@@ -32,9 +37,10 @@ describe("/api/logout", () => {
     const JWT_SECRET = "secret";
     const accessToken = await createToken("subject", {}, JWT_SECRET);
     const idToken = await createToken("subject", {}, JWT_SECRET);
-    const res = await handleLogout({ accessToken, idToken, JWT_SECRET: JWT_SECRET });
-    expect(res.status).toBe(204);
+    const res = await handleLogout({ accessToken, idToken, chatId: null, JWT_SECRET: JWT_SECRET });
+    expect(res.status).toBe(302);
 
+    expect(res.headers.get("Location")).toEqual("https://chatcraft.org/");
     res.headers.forEach((value, key) => {
       if (key.toLowerCase() !== "set-cookie") {
         return;
@@ -48,5 +54,16 @@ describe("/api/logout", () => {
         expect(value).toMatch(/__Host-id_token=[^;]+; Max-Age=0; Path=\/; Secure; SameSite=Strict/);
       }
     });
+  });
+
+  test("/api/logout with ?chat_id should redirect back to specified chat", async () => {
+    const JWT_SECRET = "secret";
+    const accessToken = await createToken("subject", {}, JWT_SECRET);
+    const idToken = await createToken("subject", {}, JWT_SECRET);
+    const chatId = "123456";
+    const res = await handleLogout({ accessToken, idToken, chatId, JWT_SECRET: JWT_SECRET });
+    expect(res.status).toBe(302);
+
+    expect(res.headers.get("Location")).toEqual(`https://chatcraft.org/c/${chatId}`);
   });
 });

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -161,6 +161,7 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
     >
       <GridItem colSpan={2}>
         <Header
+          chatId={chat.id}
           inputPromptRef={inputPromptRef}
           isSidebarVisible={isSidebarVisible}
           onSidebarVisibleClick={toggleSidebarVisible}
@@ -218,7 +219,7 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
             </Flex>
           ) : (
             <PromptForm
-              messages={chat.messages}
+              chat={chat}
               forkUrl={`./fork`}
               onSendClick={onPrompt}
               isExpanded={isExpanded}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,4 @@
-import { type RefObject } from "react";
+import { useCallback, type RefObject } from "react";
 import {
   Avatar,
   Box,
@@ -32,6 +32,7 @@ import db from "../lib/db";
 import { formatNumber } from "../lib/utils";
 
 type HeaderProps = {
+  chatId?: string;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
   searchText?: string;
   isSidebarVisible: boolean;
@@ -39,6 +40,7 @@ type HeaderProps = {
 };
 
 function Header({
+  chatId,
   inputPromptRef,
   searchText,
   isSidebarVisible,
@@ -48,6 +50,14 @@ function Header({
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { user, login, logout } = useUser();
   const chatsCount = useLiveQuery<number>(() => db.chats.count());
+
+  const handleLoginLogout = useCallback(() => {
+    if (user) {
+      logout(chatId);
+    } else {
+      login(chatId);
+    }
+  }, [chatId, user, login, logout]);
 
   return (
     <Flex
@@ -120,7 +130,7 @@ function Header({
             />
             <MenuList>
               <MenuItem onClick={onOpen}>Settings...</MenuItem>
-              <MenuItem onClick={user ? logout : login}>
+              <MenuItem onClick={handleLoginLogout}>
                 {user ? (
                   "Logout"
                 ) : (

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -42,7 +42,7 @@ import {
 } from "../lib/utils";
 import ShareModal from "./ShareModal";
 import NewButton from "./NewButton";
-import { ChatCraftMessage } from "../lib/ChatCraftMessage";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -76,7 +76,7 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
 }
 
 type PromptFormProps = {
-  messages: ChatCraftMessage[];
+  chat: ChatCraftChat;
   forkUrl: string;
   onSendClick: (prompt: string) => void;
   // Whether or not to automatically manage the height of the prompt.
@@ -93,7 +93,7 @@ type PromptFormProps = {
 };
 
 function PromptForm({
-  messages,
+  chat,
   forkUrl,
   onSendClick,
   isExpanded,
@@ -112,6 +112,7 @@ function PromptForm({
   const { settings, setSettings } = useSettings();
   const [, copyToClipboard] = useCopyToClipboard();
   const toast = useToast();
+  const { messages } = chat;
 
   // If the user clears the prompt, allow up-arrow again
   useEffect(() => {
@@ -256,7 +257,7 @@ function PromptForm({
               </Menu>
             </Box>
             <ShareModal
-              messages={messages}
+              chat={chat}
               isOpen={isOpen}
               onClose={onClose}
               finalFocusRef={inputPromptRef}

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -26,7 +26,6 @@ import { TbCopy } from "react-icons/tb";
 
 import { useUser } from "../hooks/use-user";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { ChatCraftMessage } from "../lib/ChatCraftMessage";
 import { summarizeChat } from "../lib/share";
 import { useSettings } from "../hooks/use-settings";
 
@@ -145,13 +144,13 @@ function UnauthenticatedForm({ onLoginClick }: { onLoginClick: () => void }) {
 }
 
 type ShareModalProps = {
-  messages: ChatCraftMessage[];
+  chat: ChatCraftChat;
   isOpen: boolean;
   onClose: () => void;
   finalFocusRef: RefObject<HTMLTextAreaElement>;
 };
 
-function ShareModal({ messages, isOpen, onClose, finalFocusRef }: ShareModalProps) {
+function ShareModal({ chat, isOpen, onClose, finalFocusRef }: ShareModalProps) {
   const { user, login } = useUser();
 
   return (
@@ -162,9 +161,9 @@ function ShareModal({ messages, isOpen, onClose, finalFocusRef }: ShareModalProp
         <ModalCloseButton />
         <ModalBody>
           {user ? (
-            <AuthenticatedForm chat={new ChatCraftChat({ messages })} user={user} />
+            <AuthenticatedForm chat={chat} user={user} />
           ) : (
-            <UnauthenticatedForm onLoginClick={login} />
+            <UnauthenticatedForm onLoginClick={() => login(chat.id)} />
           )}
         </ModalBody>
         <ModalFooter></ModalFooter>


### PR DESCRIPTION
Fixes #91 

This updates the `/api/login` and `/api/logout` routes to allow passing a `?chat_id=...`.  Doing so will mean that the user gets redirected back to this chat vs. going to a different one.

Having the tests already in place for this was nice.

It's going to be impossible to fully test this until it lands on prod, so I might do that and then fix afterward.