### PR TITLE
Add Clear Messages option to "New" menu button

### DIFF
--- a/src/components/NewButton.tsx
+++ b/src/components/NewButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Menu, MenuButton, MenuList, MenuItem } from "@chakra-ui/react";
+import { Button, Menu, MenuButton, MenuList, MenuItem, MenuDivider } from "@chakra-ui/react";
 import { Link as ReactRouterLink } from "react-router-dom";
 import { TbPlus } from "react-icons/tb";
 
@@ -15,13 +15,17 @@ function NewButton({ forkUrl, variant = "outline" }: NewButtonProps) {
       </MenuButton>
       <MenuList>
         <MenuItem as={ReactRouterLink} to="/new" target="_blank">
-          Blank Chat...
+          New Blank Chat...
         </MenuItem>
         {forkUrl && (
           <MenuItem as={ReactRouterLink} to={forkUrl} target="_blank">
-            Duplicate Chat...
+            New Duplicate Chat...
           </MenuItem>
         )}
+        <MenuDivider />
+        <MenuItem as={ReactRouterLink} to="./reset-messages">
+          Clear Messages
+        </MenuItem>
       </MenuList>
     </Menu>
   );

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -66,7 +66,22 @@ export class ChatCraftChat {
   }
 
   async removeMessage(id: string, user?: User) {
+    await ChatCraftMessage.delete(id);
     this.messages = this.messages.filter((message) => message.id !== id);
+    return this.update(user);
+  }
+
+  async resetMessages(user?: User) {
+    // Delete existing messages from db
+    await db.messages.bulkDelete(this.messages.map(({ id }) => id));
+    // Make a new set of messages
+    this.messages = [
+      new ChatCraftAiMessage({
+        text: AiGreetingText,
+        model: "gpt-3.5-turbo",
+      }),
+    ];
+    // Update the db
     return this.update(user);
   }
 

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -68,6 +68,27 @@ export default createBrowserRouter([
       return redirect("/");
     },
   },
+  // Reset the current set of messages in a chat
+  {
+    path: "/c/:id/reset-messages",
+    async loader({ params }) {
+      const { id } = params;
+      if (!id) {
+        return redirect(`/`);
+      }
+
+      try {
+        const chat = await ChatCraftChat.find(id);
+        if (chat) {
+          await chat.resetMessages();
+        }
+      } catch (err) {
+        console.warn("Unable to reset chat messages", { id, err });
+      }
+
+      return redirect(`/c/${id}`);
+    },
+  },
   // Fork an existing local chat and redirect to it. If a `messageId` is included,
   // use that as our starting message vs. whole chat (partial fork)
   {


### PR DESCRIPTION
Adds the ability for users to clear the current set of messages in a chat without making a new one.

<img width="324" alt="Screenshot 2023-06-06 at 4 07 48 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/8b7a6915-34ea-4a20-840f-a09b5ae5e1cd">
