### PR TITLE
Move total chats count to sidebar from header

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,7 +14,6 @@ import {
   MenuDivider,
   MenuItem,
   MenuList,
-  Tag,
   Text,
   useColorMode,
   useColorModeValue,
@@ -24,12 +23,9 @@ import { BiSun, BiMoon } from "react-icons/bi";
 import { BsGithub } from "react-icons/bs";
 import { TbSearch, TbLayoutSidebarLeftExpand, TbLayoutSidebarRightExpand } from "react-icons/tb";
 import { Form } from "react-router-dom";
-import { useLiveQuery } from "dexie-react-hooks";
 
 import PreferencesModal from "./PreferencesModal";
 import { useUser } from "../hooks/use-user";
-import db from "../lib/db";
-import { formatNumber } from "../lib/utils";
 
 type HeaderProps = {
   chatId?: string;
@@ -49,7 +45,6 @@ function Header({
   const { toggleColorMode } = useColorMode();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { user, login, logout } = useUser();
-  const chatsCount = useLiveQuery<number>(() => db.chats.count());
 
   const handleLoginLogout = useCallback(() => {
     if (user) {
@@ -95,10 +90,6 @@ function Header({
       </Box>
 
       <ButtonGroup isAttached pr={2} alignItems="center">
-        <Tag size="sm" variant="outline" mr={1}>
-          {formatNumber(chatsCount || 0)} Saved Chats
-        </Tag>
-
         <IconButton
           aria-label={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           title={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import {
   Flex,
   VStack,
   Heading,
+  Tag,
   Text,
   Button,
   Center,
@@ -109,9 +110,15 @@ function Sidebar({ selectedChat }: SidebarProps) {
   return (
     <Flex direction="column" h="100%" p={2} gap={4}>
       <VStack align="left">
-        <Heading as="h3" size="sm">
-          Recent Chats
-        </Heading>
+        <Flex justify="space-between">
+          <Heading as="h3" size="sm">
+            Recent Chats
+          </Heading>
+
+          <Tag size="sm" variant="subtle" mr={1}>
+            {formatNumber(chatsTotal || 0)} Saved Chats
+          </Tag>
+        </Flex>
 
         <Box>
           {recentChats?.length &&


### PR DESCRIPTION
I noticed on mobile that the total chats counter in the header was too crammed:

<img width="349" alt="Screenshot 2023-06-06 at 4 15 10 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/25299e36-b691-4a69-825d-29909cc300a5">

I've moved it over to the sidebar near where the recent chats are shown:

<img width="1017" alt="Screenshot 2023-06-06 at 4 14 27 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/bdeacceb-ed0f-4d86-93ac-4a3ef2c4456e">

<img width="348" alt="Screenshot 2023-06-06 at 4 15 24 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/6a623976-ae52-46a0-9615-b9f9fdf7dc92">

I think this is cleaner.