### PR TITLE
Turn Send button into Ask + model chooser

### DIFF
--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -25,7 +25,7 @@ import {
   useToast,
 } from "@chakra-ui/react";
 import { CgChevronUpO, CgChevronDownO, CgInfo } from "react-icons/cg";
-import { TbShare2 } from "react-icons/tb";
+import { TbShare2, TbChevronUp } from "react-icons/tb";
 import { useCopyToClipboard } from "react-use";
 
 import AutoResizingTextarea from "./AutoResizingTextarea";
@@ -113,6 +113,7 @@ function PromptForm({
   const [, copyToClipboard] = useCopyToClipboard();
   const toast = useToast();
   const { messages } = chat;
+  const modelName = settings.model === "gpt-3.5-turbo" ? "GPT-3.5" : "GPT-4";
 
   // If the user clears the prompt, allow up-arrow again
   useEffect(() => {
@@ -315,14 +316,35 @@ function PromptForm({
                   checked={singleMessageMode}
                   onChange={(e) => onSingleMessageModeChange(e.target.checked)}
                 >
-                  Single Message Mode
+                  Single Message
                 </Checkbox>
 
                 <Flex gap={2} align="center">
                   <NewButton forkUrl={forkUrl} variant="outline" />
-                  <Button type="submit" size="sm" isLoading={isLoading} loadingText="Send">
-                    Send
-                  </Button>
+                  <ButtonGroup isAttached>
+                    <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
+                      Ask {modelName}
+                    </Button>
+                    <Menu>
+                      <MenuButton
+                        as={IconButton}
+                        size="sm"
+                        aria-label="Choose Model"
+                        title="Choose Model"
+                        icon={<TbChevronUp />}
+                      />
+                      <MenuList>
+                        <MenuItem
+                          onClick={() => setSettings({ ...settings, model: "gpt-3.5-turbo" })}
+                        >
+                          GPT-3.5
+                        </MenuItem>
+                        <MenuItem onClick={() => setSettings({ ...settings, model: "gpt-4" })}>
+                          GPT-4
+                        </MenuItem>
+                      </MenuList>
+                    </Menu>
+                  </ButtonGroup>
                 </Flex>
               </Flex>
             </Flex>


### PR DESCRIPTION
Make it easier to switch models.  The "Send" button is now "Ask" with a menu that lets you change models.  I shortened "Single Message Mode" to drop the "Mode" so it fits on mobile.

<img width="786" alt="Screenshot 2023-06-07 at 12 02 57 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/609f2f39-a0b3-48e6-a719-38901b130e49">
<img width="790" alt="Screenshot 2023-06-07 at 12 02 49 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/5f30dbb4-aec8-4146-bb0d-824f39ce2711">
<img width="1069" alt="Screenshot 2023-06-07 at 12 02 39 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/a3f1808f-2fef-4728-badd-16179c930822">
