### PR TITLE
dynamic model list

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -29,6 +29,7 @@ import { useUser } from "../hooks/use-user";
 import NewButton from "../components/NewButton";
 import { formatDate } from "../lib/utils";
 import { useSettings } from "../hooks/use-settings";
+import { useModels } from "../hooks/use-models";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -37,6 +38,7 @@ type ChatBaseProps = {
 };
 
 function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
+  const { error: apiError } = useModels();
   // TODO: this token stuff is no longer right and useMessages() needs to be removed
   const { tokenInfo } = useMessages();
   // When chatting with OpenAI, a streaming message is returned during loading
@@ -54,6 +56,21 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
   const toast = useToast();
   const { user } = useUser();
+
+  // If we can't load models, it's a bad sign for API connectivity.
+  // Show an error so the user is aware.
+  useEffect(() => {
+    if (apiError) {
+      toast({
+        id: "api-error",
+        title: `Error Updating Message to Version`,
+        description: apiError.message,
+        status: "error",
+        position: "top",
+        isClosable: true,
+      });
+    }
+  }, [apiError, toast]);
 
   const handleToggleSidebarVisible = useCallback(() => {
     const newValue = !isSidebarVisible;

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -144,7 +144,7 @@ function OpenAiMessage(props: OpenAiMessageProps) {
         setRetrying(true);
         const newVersionText = await ai.chat(context, {
           apiKey: settings.apiKey,
-          model: settings.model.id,
+          model: model.id,
           onToken(_token: string, currentText: string) {
             setMessage(new ChatCraftAiMessage({ id, date, model, text: currentText, versions }));
           },

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -19,17 +19,7 @@ import { ChatCraftAiMessage, ChatCraftAiMessageVersion } from "../../lib/ChatCra
 import db from "../../lib/db";
 import useSystemMessage from "../../hooks/use-system-message";
 import { formatDate } from "../../lib/utils";
-
-const getHeading = (model: GptModel) => {
-  switch (model) {
-    case "gpt-4":
-      return "GPT - 4";
-    case "gpt-3.5-turbo":
-    // falls through
-    default:
-      return "ChatGPT";
-  }
-};
+import { ChatCraftModel } from "../../lib/ChatCraftModel";
 
 const getAvatar = (model: GptModel, size: "sm" | "xs") => {
   switch (model) {
@@ -81,7 +71,7 @@ function MessageVersionsMenu({
               >
                 <HStack>
                   <Box>
-                    <strong>{getHeading(model)}</strong>
+                    <strong>{new ChatCraftModel(model).prettyModel}</strong>
                   </Box>
                   <Box>{formatDate(date)}</Box>
                   <Box>{message.currentVersion?.id === id ? <strong>✓</strong> : " "}</Box>
@@ -167,7 +157,7 @@ function OpenAiMessage(props: OpenAiMessageProps) {
       message={message}
       hidePreviews={retrying}
       avatar={getAvatar(message.model, "sm")}
-      heading={retrying ? `${getHeading(message.model)} (retrying...)` : getHeading(message.model)}
+      heading={new ChatCraftModel(message.model).prettyModel + (retrying ? ` (retrying...)` : "")}
       headingMenu={<MessageVersionsMenu message={message} isDisabled={retrying} />}
       onRetryClick={retrying ? undefined : handleRetryClick}
       onDeleteClick={retrying ? undefined : props.onDeleteClick}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -62,26 +62,11 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
   }, []);
 
   useEffect(() => {
-    async function fetchModels() {
-      const response = await fetch("https://api.openai.com/v1/models", {
-        headers: {
-          Authorization: `Bearer ${settings.apiKey}`,
-        },
-      });
-      const data = await response.json();
-      setModels(
-        data.data
-          // Hide all pinned models (visual noise) except gpt-3.5-turbo-0613 as that wont be default till June 27 :(
-          .filter(
-            (model: any) =>
-              model.id.includes("gpt") &&
-              (model.id == "gpt-3.5-turbo-0613" || !/\d{4}$/.test(model.id))
-          )
-          .map((model: any) => new ChatCraftModel(`OpenAI/${model.id}`))
-      );
+    async function fetchModels(apiKey: string) {
+      setModels(await ChatCraftModel.fetchModels(apiKey));
     }
-    if (isOpen) {
-      fetchModels();
+    if (isOpen && settings.apiKey) {
+      fetchModels(settings.apiKey);
     }
   }, [settings.apiKey, isOpen]);
 

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -29,6 +29,7 @@ import RevealablePasswordInput from "./RevealablePasswordInput";
 import { useSettings } from "../hooks/use-settings";
 import { download, isMac } from "../lib/utils";
 import db from "../lib/db";
+import { useModels } from "../hooks/use-models";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 // https://dexie.org/docs/StorageManager
@@ -48,11 +49,11 @@ type PreferencesModalProps = {
 
 function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalProps) {
   const { settings, setSettings } = useSettings();
+  const { models } = useModels();
   // Using this hook vs. useClipboard() in Chakra to work around a bug
   const [, copyToClipboard] = useCopyToClipboard();
   // Whether our db is being persisted
   const [isPersisted, setIsPersisted] = useState(false);
-  const [models, setModels] = useState<ChatCraftModel[]>([]);
   const toast = useToast();
 
   useEffect(() => {
@@ -60,15 +61,6 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
       .then((value) => setIsPersisted(value))
       .catch(console.error);
   }, []);
-
-  useEffect(() => {
-    async function fetchModels(apiKey: string) {
-      setModels(await ChatCraftModel.fetchModels(apiKey));
-    }
-    if (isOpen && settings.apiKey) {
-      fetchModels(settings.apiKey);
-    }
-  }, [settings.apiKey, isOpen]);
 
   async function handlePersistClick() {
     if (navigator.storage?.persist) {
@@ -169,11 +161,13 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
             <FormControl>
               <FormLabel>GPT Model</FormLabel>
               <Select
-                value={settings.model}
-                onChange={(e) => setSettings({ ...settings, model: e.target.value as GptModel })}
+                value={settings.model.id}
+                onChange={(e) =>
+                  setSettings({ ...settings, model: new ChatCraftModel(e.target.value) })
+                }
               >
                 {models.map((model) => (
-                  <option key={model.prettyModel} value={model.id}>
+                  <option key={model.id} value={model.id}>
                     {model.prettyModel}
                   </option>
                 ))}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -71,7 +71,12 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
       const data = await response.json();
       setModels(
         data.data
-          .filter((model: any) => model.id.includes("gpt") && !/\d{4}$/.test(model.id))
+          // Hide all pinned models (visual noise) except gpt-3.5-turbo-0613 as that wont be default till June 27 :(
+          .filter(
+            (model: any) =>
+              model.id.includes("gpt") &&
+              (model.id == "gpt-3.5-turbo-0613" || !/\d{4}$/.test(model.id))
+          )
           .map((model: any) => new ChatCraftModel(`OpenAI/${model.id}`))
       );
     }

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -36,6 +36,7 @@ import { isMac, isWindows, formatNumber, formatCurrency, download } from "../lib
 import ShareModal from "./ShareModal";
 import NewButton from "./NewButton";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -315,7 +316,7 @@ function PromptForm({
                   <NewButton forkUrl={forkUrl} variant="outline" />
                   <ButtonGroup isAttached>
                     <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
-                      Ask {modelName}
+                      Ask {new ChatCraftModel(settings.model).prettyModel}
                     </Button>
                     <Menu>
                       <MenuButton

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -32,11 +32,11 @@ import AutoResizingTextarea from "./AutoResizingTextarea";
 import RevealablePasswordInput from "./RevealablePasswordInput";
 
 import { useSettings } from "../hooks/use-settings";
+import { useModels } from "../hooks/use-models";
 import { isMac, isWindows, formatNumber, formatCurrency, download } from "../lib/utils";
 import ShareModal from "./ShareModal";
 import NewButton from "./NewButton";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -104,9 +104,9 @@ function PromptForm({
   // Has the user started typing?
   const [isDirty, setIsDirty] = useState(false);
   const { settings, setSettings } = useSettings();
+  const { models } = useModels();
   const [, copyToClipboard] = useCopyToClipboard();
   const toast = useToast();
-  const modelName = settings.model === "gpt-3.5-turbo" ? "ChatGPT" : "GPT - 4";
 
   // If the user clears the prompt, allow up-arrow again
   useEffect(() => {
@@ -316,7 +316,7 @@ function PromptForm({
                   <NewButton forkUrl={forkUrl} variant="outline" />
                   <ButtonGroup isAttached>
                     <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
-                      Ask {new ChatCraftModel(settings.model).prettyModel}
+                      Ask {settings.model.prettyModel}
                     </Button>
                     <Menu>
                       <MenuButton
@@ -327,14 +327,14 @@ function PromptForm({
                         icon={<TbChevronUp />}
                       />
                       <MenuList>
-                        <MenuItem
-                          onClick={() => setSettings({ ...settings, model: "gpt-3.5-turbo" })}
-                        >
-                          ChatGPT
-                        </MenuItem>
-                        <MenuItem onClick={() => setSettings({ ...settings, model: "gpt-4" })}>
-                          GPT - 4
-                        </MenuItem>
+                        {models.map((model) => (
+                          <MenuItem
+                            key={model.id}
+                            onClick={() => setSettings({ ...settings, model })}
+                          >
+                            {model.prettyModel}
+                          </MenuItem>
+                        ))}
                       </MenuList>
                     </Menu>
                   </ButtonGroup>

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -10,6 +10,7 @@ import {
   ChatCraftAiMessage,
   ChatCraftSystemMessage,
 } from "../lib/ChatCraftMessage";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 // See https://openai.com/pricing
 const calculateTokenCost = (tokens: number, model: GptModel): number | undefined => {
@@ -68,7 +69,7 @@ function useChatOpenAI() {
         openAIApiKey: settings.apiKey,
         temperature: 0,
         streaming: true,
-        modelName: settings.model,
+        modelName: new ChatCraftModel(settings.model).model,
       });
 
       // Allow the stream to be cancelled
@@ -134,12 +135,13 @@ function useChatOpenAI() {
 
   const getTokenInfo = useCallback(
     async (messages: ChatCraftMessage[]): Promise<TokenInfo> => {
+      const modelName = new ChatCraftModel(settings.model).model;
       const api = new ChatOpenAI({
         openAIApiKey: settings.apiKey,
-        modelName: settings.model,
+        modelName: modelName,
       });
       const { totalCount } = await api.getNumTokensFromMessages(messages);
-      return { count: totalCount, cost: calculateTokenCost(totalCount, settings.model) };
+      return { count: totalCount, cost: calculateTokenCost(totalCount, modelName as GptModel) };
     },
     [settings]
   );

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -10,10 +10,9 @@ import {
   ChatCraftAiMessage,
   ChatCraftSystemMessage,
 } from "../lib/ChatCraftMessage";
-import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 // See https://openai.com/pricing
-const calculateTokenCost = (tokens: number, model: GptModel): number | undefined => {
+const calculateTokenCost = (tokens: number, model: string): number | undefined => {
   // Pricing is per 1,000K tokens
   tokens = tokens / 1000;
 
@@ -69,7 +68,7 @@ function useChatOpenAI() {
         openAIApiKey: settings.apiKey,
         temperature: 0,
         streaming: true,
-        modelName: new ChatCraftModel(settings.model).model,
+        modelName: settings.model.id,
       });
 
       // Allow the stream to be cancelled
@@ -135,13 +134,13 @@ function useChatOpenAI() {
 
   const getTokenInfo = useCallback(
     async (messages: ChatCraftMessage[]): Promise<TokenInfo> => {
-      const modelName = new ChatCraftModel(settings.model).model;
+      const modelName = settings.model.id;
       const api = new ChatOpenAI({
         openAIApiKey: settings.apiKey,
         modelName: modelName,
       });
       const { totalCount } = await api.getNumTokensFromMessages(messages);
-      return { count: totalCount, cost: calculateTokenCost(totalCount, modelName as GptModel) };
+      return { count: totalCount, cost: calculateTokenCost(totalCount, modelName) };
     },
     [settings]
   );

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -1,0 +1,72 @@
+import {
+  useState,
+  useEffect,
+  createContext,
+  useContext,
+  useRef,
+  type ReactNode,
+  type FC,
+} from "react";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
+import { queryOpenAiModels } from "../lib/ai";
+import { useSettings } from "./use-settings";
+
+const defaultModels = [new ChatCraftModel("gpt-3.5-turbo", "OpenAI")];
+
+type ModelsContextType = {
+  models: ChatCraftModel[];
+  error: Error | null;
+};
+
+const ModelsContext = createContext<ModelsContextType>({
+  models: defaultModels,
+  error: null,
+});
+
+export const useModels = () => useContext(ModelsContext);
+
+export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [models, setModels] = useState<ChatCraftModel[] | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [fetched, setFetched] = useState(false);
+  const isFetching = useRef(false);
+  const { settings } = useSettings();
+
+  useEffect(() => {
+    const apiKey = settings.apiKey;
+    if (!apiKey || isFetching.current) {
+      return;
+    }
+
+    const fetchModels = async () => {
+      isFetching.current = true;
+      try {
+        console.log("updating models");
+        const openAiModels = await queryOpenAiModels(apiKey).then((models) => {
+          models.sort();
+          return models.map((model) => new ChatCraftModel(model, "OpenAI"));
+        });
+        setModels(openAiModels);
+        setFetched(true);
+      } catch (err) {
+        console.warn("Unable to update OpenAI models, using defaults.", err);
+        setModels(defaultModels);
+        setError(err as Error);
+        setFetched(true);
+      } finally {
+        isFetching.current = false;
+      }
+    };
+
+    if (!models) {
+      fetchModels();
+    }
+  }, [settings.apiKey, models, setModels, fetched]);
+
+  const value = {
+    models: models || defaultModels,
+    error,
+  };
+
+  return <ModelsContext.Provider value={value}>{children}</ModelsContext.Provider>;
+};

--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -1,57 +1,52 @@
 export class ChatCraftModel {
   private modelId: string;
+  private owner: string;
 
   /**
-   * @param modelId The model ID in format vendor/model, eg OpenAI/gpt-3.5-turbo-16k
+   * @param model The model. If the format is `vendor/model` (eg `OpenAI/gpt-3.5-turbo-16k`)
+   * then the vendor is extracted from the ID
+   * @param vendor Optional vendor name. Used if model name does not have explicit `vendor/*`
    */
-  constructor(modelId: string) {
-    if (!modelId.includes("/")) {
-      // throw new Error(`Invalid model ID: ${modelId}`);
-      modelId = "OpenAI/" + modelId;
+  constructor(model: string, vendor?: "OpenAI") {
+    if (model && vendor) {
+      this.modelId = model;
+      this.owner = vendor;
+    } else if (model.includes("/") && !vendor) {
+      const [v, m] = model.split("/");
+      this.modelId = m;
+      this.owner = v;
+    } else {
+      this.modelId = model;
+      // Assume OpenAI if we don't get any vendor info
+      this.owner = "OpenAI";
     }
-    this.modelId = modelId;
   }
 
-  get id(): string {
+  get id() {
     return this.modelId;
   }
 
-  get model(): string {
-    return this.modelId.split("/")[1];
-  }
-
-  get vendor(): string {
-    return this.modelId.split("/")[0];
+  get vendor() {
+    return this.owner;
   }
 
   get prettyModel(): string {
-    console.log(this.modelId);
-    switch (this.modelId) {
-      case "OpenAI/gpt-3.5-turbo-0613":
-        return "ChatGPT";
-      case "OpenAI/gpt-3.5-turbo":
-        return "ChatGPT-0301";
-      case "OpenAI/gpt-4":
-        return "GPT-4";
-      default:
-        return `${this.vendor} ${this.model}`;
+    if (this.modelId.startsWith("gpt-3.5-turbo")) {
+      return this.modelId.replace("gpt-3.5-turbo", "ChatGPT");
     }
+
+    if (this.modelId.startsWith("gpt-4")) {
+      return this.modelId.replace("gpt-4", "GPT-4");
+    }
+
+    return `${this.owner} ${this.modelId}`;
   }
-  static async fetchModels(apiKey: string): Promise<ChatCraftModel[]> {
-    const response = await fetch("https://api.openai.com/v1/models", {
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-      },
-    });
-    const data = await response.json();
-    // Hide all pinned models (visual noise) except gpt-3.5-turbo-0613 as that wont be default till June 27 :(
-    const ret = data.data
-      .filter(
-        (model: any) =>
-          model.id.includes("gpt") && (model.id == "gpt-3.5-turbo-0613" || !/\d{4}$/.test(model.id))
-      )
-      .map((model: any) => new ChatCraftModel(`OpenAI/${model.id}`));
-    console.log(ret);
-    return ret;
+
+  toString() {
+    return `${this.owner}/${this.modelId}`;
+  }
+
+  toJSON() {
+    return `${this.owner}/${this.modelId}`;
   }
 }

--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -1,0 +1,38 @@
+export class ChatCraftModel {
+  private modelId: string;
+
+  /**
+   * @param modelId The model ID in format vendor/model, eg OpenAI/gpt-3.5-turbo-16k
+   */
+  constructor(modelId: string) {
+    if (!modelId.includes("/")) {
+      // throw new Error(`Invalid model ID: ${modelId}`);
+      modelId = "OpenAI/" + modelId;
+    }
+    this.modelId = modelId;
+  }
+
+  get id(): string {
+    return this.modelId;
+  }
+
+  get model(): string {
+    return this.modelId.split("/")[1];
+  }
+
+  get vendor(): string {
+    return this.modelId.split("/")[0];
+  }
+
+  get prettyModel(): string {
+    console.log(this.modelId);
+    switch (this.modelId) {
+      case "OpenAI/gpt-3.5-turbo":
+        return "ChatGPT";
+      case "OpenAI/gpt-4":
+        return "GPT-4";
+      default:
+        return `${this.vendor} ${this.model}`;
+    }
+  }
+}

--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -27,12 +27,31 @@ export class ChatCraftModel {
   get prettyModel(): string {
     console.log(this.modelId);
     switch (this.modelId) {
-      case "OpenAI/gpt-3.5-turbo":
+      case "OpenAI/gpt-3.5-turbo-0613":
         return "ChatGPT";
+      case "OpenAI/gpt-3.5-turbo":
+        return "ChatGPT-0301";
       case "OpenAI/gpt-4":
         return "GPT-4";
       default:
         return `${this.vendor} ${this.model}`;
     }
+  }
+  static async fetchModels(apiKey: string): Promise<ChatCraftModel[]> {
+    const response = await fetch("https://api.openai.com/v1/models", {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+    const data = await response.json();
+    // Hide all pinned models (visual noise) except gpt-3.5-turbo-0613 as that wont be default till June 27 :(
+    const ret = data.data
+      .filter(
+        (model: any) =>
+          model.id.includes("gpt") && (model.id == "gpt-3.5-turbo-0613" || !/\d{4}$/.test(model.id))
+      )
+      .map((model: any) => new ChatCraftModel(`OpenAI/${model.id}`));
+    console.log(ret);
+    return ret;
   }
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,7 +7,7 @@ import { defaultSystemMessage } from "../hooks/use-system-message";
 
 export type ChatOptions = {
   apiKey: string;
-  model: GptModel;
+  model: string;
   temperature?: number;
   onToken: (token: string, currentText: string) => void;
   controller?: AbortController;
@@ -46,3 +46,26 @@ export const chat = (messages: ChatCraftMessage[], options: ChatOptions) => {
     )
     .then(({ text }) => text);
 };
+
+export async function queryOpenAiModels(apiKey: string) {
+  const res = await fetch("https://api.openai.com/v1/models", {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+
+  if (!res.ok) {
+    const { error } = await res.json();
+    throw new Error(error?.message ?? `error querying API`);
+  }
+
+  const { data } = await res.json();
+
+  // Hide all pinned models (visual noise) except gpt-3.5-turbo-0613 as that wont be default till June 27 :(
+  return data
+    .filter(
+      (model: any) =>
+        model.id.includes("gpt") && (model.id == "gpt-3.5-turbo-0613" || !/\d{4}$/.test(model.id))
+    )
+    .map((model: any) => model.id) as string[];
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,8 +1,6 @@
 import Dexie, { Table } from "dexie";
 import { type MessageType } from "langchain/schema";
 
-import { ChatCraftAiMessageVersion } from "./ChatCraftMessage";
-
 export type ChatCraftChatTable = {
   id: string;
   date: Date;
@@ -16,10 +14,10 @@ export type ChatCraftMessageTable = {
   date: Date;
   chatId: string;
   type: MessageType;
-  model?: GptModel;
+  model?: string;
   user?: User;
   text: string;
-  versions?: ChatCraftAiMessageVersion[];
+  versions?: { id: string; date: Date; model: string; text: string }[];
 };
 
 class ChatCraftDatabase extends Dexie {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -41,7 +41,7 @@ export async function loadShare(user: string, id: string) {
   }
 
   const serialized: SerializedChatCraftChat = await res.json();
-  return ChatCraftChat.parse(serialized);
+  return ChatCraftChat.fromJSON(serialized);
 }
 
 export async function summarizeChat(openaiApiKey: string, chat: ChatCraftChat) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,15 +7,18 @@ import router from "./router";
 import theme from "./theme";
 import { SettingsProvider } from "./hooks/use-settings";
 import { UserProvider } from "./hooks/use-user";
+import { ModelsProvider } from "./hooks/use-models";
 
 ReactDOM.createRoot(document.querySelector("main") as HTMLElement).render(
   <React.StrictMode>
     <ChakraProvider theme={theme}>
       <SettingsProvider>
-        <UserProvider>
-          <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-          <RouterProvider router={router} />
-        </UserProvider>
+        <ModelsProvider>
+          <UserProvider>
+            <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+            <RouterProvider router={router} />
+          </UserProvider>
+        </ModelsProvider>
       </SettingsProvider>
     </ChakraProvider>
   </React.StrictMode>

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,12 +1,3 @@
-// Models we expect to use. See
-// https://platform.openai.com/docs/models/overview
-// https://github.com/hwchase17/langchainjs/blob/9330102c98c30eb4796263f2dfba9d8cbb4d179c/langchain/src/base_language/count_tokens.ts#L34-L49
-type GptModel =
-  // GPT-4
-  | "gpt-4"
-  // GPT-3.5
-  | "gpt-3.5-turbo";
-
 // Enter key either sends message or adds newline
 type EnterBehaviour = "send" | "newline";
 


### PR DESCRIPTION
Addresses #106 by querying openai for available models, also gets us ready for claude support.

new chatgpt model is using date suffix, so mark that as chatgpt and mark old one with date. Will change that after 27th.

Left for followup:
* Need to list models for various places in UI. Need to decide on what we wanna do to reduce calls to models endpoint. (probably persist in cache if not called from options dialog) 
* Retry-with needs to use this list
* Ask GPT-4/ChatGPT 
* Should also use this api endpoint for validating api key
* Costs

<img width="505" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/857083/70677acc-890d-4622-bb69-abb9c0d4f689">
