### PR TITLE
Parse OpenAI errors from langchain error messages

### DIFF
--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -122,7 +122,20 @@ function useChatOpenAI() {
               text: buffer.join(""),
             });
           }
-          throw err;
+
+          // Try to extract the actual OpenAI API error from what langchain gives us
+          // which is JSON embedded in the error text.
+          // eslint-disable-next-line no-useless-catch
+          try {
+            const matches = err.message.match(/{"error".+$/);
+            if (matches) {
+              const openAiError = JSON.parse(matches[0]);
+              throw new Error(`OpenAI API Error: ${openAiError.error.message}`);
+            }
+            throw err;
+          } catch (err2) {
+            throw err2;
+          }
         })
         .finally(() => {
           setStreamingMessage(undefined);


### PR DESCRIPTION
I'm debugging something, and I got sick of the way langchain embeds the OpenAI error as JSON in their error message.  This parses it out so we can display it properly.

<img width="1046" alt="Screenshot 2023-06-16 at 12 33 30 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/af2a7708-d2e4-4552-b6f2-642cab5f095f">
