### PR TITLE
Double scroll threshold to account for UI jitter when streaming

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -81,7 +81,7 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
     // We need a "fudge factor" here, or it constantly loses auto scroll
     // as content streams in and the container is auto scroll in the
     // previous useEffect.
-    const scrollThreshold = 25;
+    const scrollThreshold = 50;
     const atBottom =
       messageList.scrollTop + messageList.clientHeight >=
       messageList.scrollHeight - scrollThreshold;


### PR DESCRIPTION
The way that the UI jumps when streaming responses include syntax highlighting is causing the autoscroll logic to break when it shouldn't.  I have a `scrollThreshold` that is used to allow the user to scroll up and break autoscroll, but these UI jitters are also causing it to break.

I've doubled it from `25` to `50`.  Locally it seems to fix it, but it's easy to increase it more.