### PR TITLE
Create ChatCraftAppMessage and AppMessage for ChatCraft messages

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -138,10 +138,10 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
         // Add this prompt message to the chat
         await chat.addMessage(new ChatCraftHumanMessage({ text: prompt, user }), user);
 
-        // In single-message-mode, trim messages to last few. Otherwise send all
-        const messagesToSend = singleMessageMode
-          ? [...chat.messages].slice(-2)
-          : [...chat.messages];
+        // In single-message-mode, trim messages to last few. Otherwise send all.
+        // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
+        const messages = chat.nonAppMessages;
+        const messagesToSend = singleMessageMode ? [...messages].slice(-2) : [...messages];
         const response = await callChatApi(messagesToSend);
 
         // Add this response message to the chat

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -140,7 +140,7 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
 
         // In single-message-mode, trim messages to last few. Otherwise send all.
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
-        const messages = chat.nonAppMessages;
+        const messages = chat.messages({ includeAppMessages: false });
         const messagesToSend = singleMessageMode ? [...messages].slice(-2) : [...messages];
         const response = await callChatApi(messagesToSend);
 
@@ -263,7 +263,7 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
           <ScrollRestoration />
 
           <MessagesView
-            messages={chat.messages}
+            messages={chat.messages()}
             chatId={chat.id}
             newMessage={streamingMessage}
             isLoading={loading}
@@ -293,7 +293,7 @@ function ChatBase({ chat, readonly, canDelete }: ChatBaseProps) {
               singleMessageMode={singleMessageMode}
               onSingleMessageModeChange={setSingleMessageMode}
               isLoading={loading}
-              previousMessage={chat.messages.at(-1)?.text}
+              previousMessage={chat.messages().at(-1)?.text}
               tokenInfo={tokenInfo}
               inputPromptRef={inputPromptRef}
             />

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -17,7 +17,7 @@ import Header from "./components/Header";
 import Sidebar from "./components/Sidebar";
 import db, { ChatCraftMessageTable } from "./lib/db";
 import Message from "./components/Message";
-import { AiGreetingText, ChatCraftMessage } from "./lib/ChatCraftMessage";
+import { AiGreetingText, ChatCraftAppMessage, ChatCraftMessage } from "./lib/ChatCraftMessage";
 import NewButton from "./components/NewButton";
 import { useSettings } from "./hooks/use-settings";
 
@@ -34,11 +34,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
   return {
     searchText: q,
     // Return all messages that include the search text,
-    // excluding the "How can I help?" greeting, sorted
+    // excluding the "How can I help?" greeting and other
+    // app messages, and sort
     messages: await db.messages
       .where("text")
       .notEqual(AiGreetingText)
-      .filter((message) => re.test(message.text))
+      .filter((message) => {
+        if (message instanceof ChatCraftAppMessage) {
+          return false;
+        }
+        return re.test(message.text);
+      })
       .reverse()
       .sortBy("date"),
   };

--- a/src/components/Message/AppMessage.tsx
+++ b/src/components/Message/AppMessage.tsx
@@ -1,0 +1,23 @@
+import { memo } from "react";
+import { Avatar } from "@chakra-ui/react";
+
+import MessageBase, { type MessageBaseProps } from "./MessageBase";
+
+type AppMessageProps = Omit<MessageBaseProps, "avatar">;
+
+function AppMessage(props: AppMessageProps) {
+  const avatar = (
+    <Avatar
+      size="sm"
+      src="/apple-touch-icon.png"
+      title="ChatCraft"
+      showBorder
+      borderColor="gray.100"
+      _dark={{ borderColor: "gray.600" }}
+    />
+  );
+
+  return <MessageBase {...props} avatar={avatar} heading="ChatCraft" />;
+}
+
+export default memo(AppMessage);

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -209,7 +209,7 @@ function MessageBase({
                   </>
                 )}
 
-                {!disableEdit && onDeleteClick && <MenuDivider />}
+                {(!disableEdit || onDeleteClick) && <MenuDivider />}
                 {!disableEdit && (
                   <MenuItem onClick={() => setEditing(!editing)}>
                     {editing ? "Cancel Editing" : "Edit"}

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -132,7 +132,7 @@ function OpenAiMessage(props: OpenAiMessageProps) {
         }
 
         // Work with the messages, stripping out the app messages
-        const messages = chat.nonAppMessages;
+        const messages = chat.messages({ includeAppMessages: false });
         const idx = messages.findIndex((m) => m.id === message.id);
         if (!idx) {
           throw new Error(`Unable to find message within chat with id=${message.id}`);

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -131,12 +131,13 @@ function OpenAiMessage(props: OpenAiMessageProps) {
           throw new Error(`Unable to find chat with chatId=${props.chatId}`);
         }
 
-        const idx = chat.messages.findIndex((m) => m.id === message.id);
+        // Work with the messages, stripping out the app messages
+        const messages = chat.nonAppMessages;
+        const idx = messages.findIndex((m) => m.id === message.id);
         if (!idx) {
           throw new Error(`Unable to find message within chat with id=${message.id}`);
         }
-        const context = chat.messages.slice(0, idx);
-
+        const context = messages.slice(0, idx);
         const date = new Date();
         const { id, versions } = message;
         setMessage(new ChatCraftAiMessage({ id, date, model, text: "", versions }));
@@ -163,7 +164,7 @@ function OpenAiMessage(props: OpenAiMessageProps) {
         setRetrying(false);
       }
     },
-    [props.chatId, settings.apiKey, settings.model, message, systemMessage]
+    [props.chatId, settings.apiKey, message, systemMessage]
   );
 
   return (

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -2,10 +2,12 @@ import { memo } from "react";
 import {
   ChatCraftHumanMessage,
   ChatCraftAiMessage,
+  ChatCraftAppMessage,
   ChatCraftMessage,
 } from "../../lib/ChatCraftMessage";
 import HumanMessage from "./HumanMessage";
 import OpenAiMessage from "./OpenAiMessage";
+import AppMessage from "./AppMessage";
 
 type MessageProps = {
   message: ChatCraftMessage;
@@ -57,6 +59,21 @@ function Message({
         onDeleteClick={onDeleteClick}
         disableFork={disableFork}
         disableEdit={disableEdit}
+      />
+    );
+  }
+
+  if (message instanceof ChatCraftAppMessage) {
+    return (
+      <AppMessage
+        message={message}
+        chatId={chatId}
+        isLoading={isLoading}
+        hidePreviews={hidePreviews}
+        onPrompt={onPrompt}
+        onDeleteClick={onDeleteClick}
+        disableFork={true}
+        disableEdit={true}
       />
     );
   }

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -7,6 +7,7 @@ import NewMessage from "./NewMessage";
 import {
   ChatCraftMessage,
   ChatCraftAiMessage,
+  ChatCraftAppMessage,
   ApiKeyInstructionsText,
   AiGreetingText,
 } from "../lib/ChatCraftMessage";
@@ -102,9 +103,10 @@ function MessagesView({
   const instructions = useMemo(() => {
     // If there's no API key in storage, show instructions so we get one
     if (!settings.apiKey) {
+      const message = new ChatCraftAppMessage({ text: ApiKeyInstructionsText });
       return (
         <Message
-          message={new ChatCraftAiMessage({ text: ApiKeyInstructionsText, model: settings.model })}
+          message={message}
           chatId={chatId}
           isLoading={isLoading}
           onPrompt={onPrompt}
@@ -113,7 +115,7 @@ function MessagesView({
         />
       );
     }
-  }, [settings.apiKey, settings.model, chatId, onPrompt, isLoading]);
+  }, [settings.apiKey, chatId, onPrompt, isLoading]);
 
   return (
     <Box minHeight="100%" scrollBehavior="smooth">

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -88,7 +88,7 @@ export class ChatCraftMessage extends BaseChatMessage {
     };
   }
 
-  save(chatId: string) {
+  async save(chatId: string) {
     return db.messages.put(this.toDB(chatId));
   }
 
@@ -101,6 +101,8 @@ export class ChatCraftMessage extends BaseChatMessage {
         return ChatCraftHumanMessage.fromJSON(message);
       case "system":
         return ChatCraftSystemMessage.fromJSON(message);
+      case "generic":
+        return ChatCraftAppMessage.fromJSON(message);
       default:
         throw new Error(`Error parsing unknown message type: ${message.type}`);
     }
@@ -115,6 +117,8 @@ export class ChatCraftMessage extends BaseChatMessage {
         return ChatCraftHumanMessage.fromDB(message);
       case "system":
         return ChatCraftSystemMessage.fromDB(message);
+      case "generic":
+        return ChatCraftAppMessage.fromDB(message);
       default:
         throw new Error(`Error parsing unknown message type: ${message.type}`);
     }
@@ -297,6 +301,29 @@ export class ChatCraftSystemMessage extends ChatCraftMessage {
 
   static fromDB(message: ChatCraftMessageTable) {
     return new ChatCraftSystemMessage({
+      id: message.id,
+      date: message.date,
+      text: message.text,
+    });
+  }
+}
+
+// Messages we display to the user in ChatCraft, but don't store in db or send to AI
+export class ChatCraftAppMessage extends ChatCraftMessage {
+  constructor({ id, date, text }: { id?: string; date?: Date; text: string }) {
+    super({ id, date, type: "generic", text });
+  }
+
+  static fromJSON(message: SerializedChatCraftMessage) {
+    return new ChatCraftAppMessage({
+      id: message.id,
+      date: new Date(message.date),
+      text: message.text,
+    });
+  }
+
+  static fromDB(message: ChatCraftMessageTable) {
+    return new ChatCraftAppMessage({
       id: message.id,
       date: message.date,
       text: message.text,

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -60,7 +60,8 @@ export async function summarizeChat(openaiApiKey: string, chat: ChatCraftChat) {
   });
 
   try {
-    const res = await chatOpenAI.call([systemChatMessage, ...chat.messages, summarizeInstruction]);
+    const messages = chat.messages({ includeAppMessages: false });
+    const res = await chatOpenAI.call([systemChatMessage, ...messages, summarizeInstruction]);
     return res.text.trim();
   } catch (err) {
     console.error("Error summarizing chat", err);


### PR DESCRIPTION
Fixes #103

This adds a new message type, `ChatCraftAppMessage`, and a new component to display them, `AppMessage`.

We now have two ways to work with the messages in a chat:

1. `.messages` includes all messages
2. `.nonAppMessages` all messages with app messages stripped out

The latter is suitable for sending to an LLM or sharing, the former for showing in the UI/db.

<img width="1102" alt="Screenshot 2023-06-16 at 1 47 48 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/3f4b4c8a-cbac-4c5c-8d66-d5580f8ffb9d">

Later, we can build on this to put widgets into the UI for things like entering API key.