### PR TITLE
Let users know why we ask them to login to GitHub when sharing

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -134,7 +134,8 @@ function UnauthenticatedForm({ onLoginClick }: { onLoginClick: () => void }) {
           <BsGithub /> <Text ml={2}>Sign in with GitHub</Text>
         </Button>
         <FormHelperText>
-          Users must authenticate with GitHub in order to create a public URL.
+          To avoid abuse and spam, we ask that users authenticate with an existing GitHub account
+          before creating public URLs.
         </FormHelperText>
       </FormControl>
     </VStack>


### PR DESCRIPTION
Fix to address https://github.com/tarasglek/chatcraft.org/issues/101#issuecomment-1584412764

<img width="533" alt="Screenshot 2023-06-16 at 4 24 03 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/335c193b-90df-400b-9743-483e2af03afa">

See if you think this solves it.