### PR TITLE
Handle readonly (from JSON) vs. regular (from DB) chats/messages differently

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -19,10 +19,9 @@ import ChatHeader from "./ChatHeader";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
-  readonly: boolean;
 };
 
-function ChatBase({ chat, readonly }: ChatBaseProps) {
+function ChatBase({ chat }: ChatBaseProps) {
   const { error: apiError } = useModels();
   // TODO: this token stuff is no longer right and useMessages() needs to be removed
   const { tokenInfo } = useMessages();
@@ -199,7 +198,7 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
             )
           }
 
-          <ChatHeader chat={chat} canDelete={!readonly} />
+          <ChatHeader chat={chat} />
 
           <ScrollRestoration />
 
@@ -220,9 +219,9 @@ function ChatBase({ chat, readonly }: ChatBaseProps) {
 
       <GridItem>
         <Box maxW="900px" mx="auto" h="100%">
-          {readonly ? (
+          {chat.readonly ? (
             <Flex w="100%" h="45px" justify="end" align="center" p={2}>
-              <NewButton forkUrl={`./fork`} variant="solid" disableClear={readonly} />
+              <NewButton forkUrl={`./fork`} variant="solid" disableClear={chat.readonly} />
             </Flex>
           ) : (
             <PromptForm

--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -25,10 +25,9 @@ import ShareModal from "../components/ShareModal";
 
 type ChatHeaderProps = {
   chat: ChatCraftChat;
-  canDelete: boolean;
 };
 
-function ChatHeader({ chat, canDelete }: ChatHeaderProps) {
+function ChatHeader({ chat }: ChatHeaderProps) {
   const { user } = useUser();
   const [, copyToClipboard] = useCopyToClipboard();
   const toast = useToast();
@@ -125,7 +124,7 @@ function ChatHeader({ chat, canDelete }: ChatHeaderProps) {
                   <MenuItem onClick={onOpen}>Create Public URL...</MenuItem>
                 )}
 
-                {canDelete && (
+                {!chat.readonly && (
                   <>
                     <MenuDivider />
                     <MenuItem color="red.400" onClick={() => handleDeleteClick()}>

--- a/src/Chat/LocalChat.tsx
+++ b/src/Chat/LocalChat.tsx
@@ -4,12 +4,8 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import ChatBase from "./ChatBase";
 
-type LocalChatProps = {
-  readonly: boolean;
-};
-
 // Load a chat from the database locally
-export default function LocalChat({ readonly }: LocalChatProps) {
+export default function LocalChat() {
   const chatId = useLoaderData() as string;
   const chat = useLiveQuery<ChatCraftChat | undefined>(() => {
     if (chatId) {
@@ -18,5 +14,5 @@ export default function LocalChat({ readonly }: LocalChatProps) {
   }, [chatId]);
 
   // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+  return chat ? <ChatBase chat={chat} /> : null;
 }

--- a/src/Chat/RemoteChat.tsx
+++ b/src/Chat/RemoteChat.tsx
@@ -3,14 +3,10 @@ import { useLoaderData } from "react-router-dom";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import ChatBase from "./ChatBase";
 
-type LocalChatProps = {
-  readonly: boolean;
-};
-
 // Load a chat from over the network as a JSON blob (already available via loader)
-export default function LocalChat({ readonly }: LocalChatProps) {
+export default function RemoteChat() {
   const chat = useLoaderData() as ChatCraftChat;
 
   // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} readonly={readonly} /> : null;
+  return chat ? <ChatBase chat={chat} /> : null;
 }

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -172,7 +172,9 @@ function OpenAiMessage(props: OpenAiMessageProps) {
       avatar={getAvatar(message.model, "sm")}
       heading={`${message.model.prettyModel} ${retrying ? ` (retrying...)` : ""}`}
       headingMenu={
-        <MessageVersionsMenu message={message} chatId={props.chatId} isDisabled={retrying} />
+        !message.readonly && (
+          <MessageVersionsMenu message={message} chatId={props.chatId} isDisabled={retrying} />
+        )
       }
       onRetryClick={retrying ? undefined : handleRetryClick}
       onDeleteClick={retrying ? undefined : props.onDeleteClick}

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -42,7 +42,7 @@ function Message({
         onPrompt={onPrompt}
         onDeleteClick={onDeleteClick}
         disableFork={disableFork}
-        disableEdit={disableEdit}
+        disableEdit={message.readonly && disableEdit}
       />
     );
   }
@@ -60,7 +60,7 @@ function Message({
         onPrompt={onPrompt}
         onDeleteClick={onDeleteClick}
         disableFork={disableFork}
-        disableEdit={disableEdit}
+        disableEdit={message.readonly && disableEdit}
       />
     );
   }
@@ -75,7 +75,7 @@ function Message({
         onPrompt={onPrompt}
         onDeleteClick={onDeleteClick}
         disableFork={true}
-        disableEdit={true}
+        disableEdit={message.readonly && disableEdit}
       />
     );
   }

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -47,6 +47,9 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     setIsSharing(true);
     try {
       const url = await chat.share(user, summary);
+      if (!url) {
+        throw new Error("Unable to create Share URL");
+      }
       setUrl(url);
     } catch (err: any) {
       console.error(err);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -51,7 +51,7 @@ export default createBrowserRouter([
       }
       return id;
     },
-    element: <LocalChat readonly={false} />,
+    element: <LocalChat />,
   },
   // Delete a chat from the local db
   {
@@ -142,7 +142,7 @@ export default createBrowserRouter([
         redirect(`/`);
       }
     },
-    element: <RemoteChat readonly={true} />,
+    element: <RemoteChat />,
   },
 
   // Fork a remote chat into the local db


### PR DESCRIPTION
Fixes #121

This modifies both `ChatCraftChat` and all `ChatCraftMessage` types to include a `.readonly` property.  When we load a chat or message from JSON, we now mark it as `readonly=true` so that the app knows it can't be updated, changed, etc.

The only non-obvious change that this PR will make is that now, when you fork a chat, I'm going to clone the messages.  This will mean we can have duplicates in search results, since multiple messages can have the same text.  That's probably OK, and won't surprise people, but it's different than before.