### PR TITLE
Show date/time and some text for all sidebar items

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -19,7 +19,7 @@ import db, { type ChatCraftChatTable } from "../lib/db";
 import { Form, Link } from "react-router-dom";
 import { useState } from "react";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { formatNumber } from "../lib/utils";
+import { formatDate, formatNumber } from "../lib/utils";
 
 type SidebarItemProps = {
   text: string;
@@ -125,7 +125,7 @@ function Sidebar({ selectedChat }: SidebarProps) {
             recentChats.map((chat) => (
               <SidebarItem
                 key={chat.id}
-                text={chat.summarize()}
+                text={`${formatDate(chat.date, true)} - ${chat.summarize() || "(no messages)"}`}
                 url={`/c/${chat.id}`}
                 canDelete={true}
                 isSelected={selectedChat?.id === chat.id}
@@ -149,10 +149,10 @@ function Sidebar({ selectedChat }: SidebarProps) {
 
         <>
           {sharedChats?.length ? (
-            sharedChats.map(({ id, summary, shareUrl }) => (
+            sharedChats.map(({ id, date, summary, shareUrl }) => (
               <SidebarItem
                 key={id}
-                text={summary}
+                text={`${formatDate(date, true)} - ${summary}`}
                 // We've already filtered for all objects with shareUrl, so this is fine
                 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                 url={shareUrl!}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,14 +6,19 @@ export const formatNumber = (n: number) => (n ? n.toLocaleString() : "0");
 export const formatCurrency = (n: number) =>
   Intl.NumberFormat(undefined, { style: "currency", currency: "USD" }).format(n);
 
-export const formatDate = (d: Date) =>
-  d.toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    hour: "numeric",
-    minute: "numeric",
-  });
+export const formatDate = (d: Date, short = false) =>
+  short
+    ? new Intl.DateTimeFormat(undefined, {
+        dateStyle: "short",
+        timeStyle: "short",
+      }).format(d)
+    : new Intl.DateTimeFormat(undefined, {
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+      }).format(d);
 
 export function download(data: string | Blob, filename: string, type = "text/plain") {
   let blob;


### PR DESCRIPTION
Fixes #126 

This does a better job at always showing something for sidebar items.  This includes a shortened date/time, as well as the summary (if available) or "(no messages)" if the chat is empty.

<img width="1074" alt="Screenshot 2023-06-22 at 2 08 26 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/9b114f88-e511-4b64-a4db-0637c1161388">
