### PR TITLE
Always collapse system prompt, make edit textarea scrollable

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -279,7 +279,7 @@ function MessageBase({
                       as={ResizeTextarea}
                       name="text"
                       minH="unset"
-                      overflow="hidden"
+                      overflowY="scroll"
                       w="100%"
                       maxH="30vh"
                       resize="vertical"

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -1,8 +1,8 @@
-import { memo, useMemo } from "react";
+import { memo } from "react";
 import { Avatar, Button, Flex, Text, useDisclosure } from "@chakra-ui/react";
 
 import MessageBase, { type MessageBaseProps } from "./MessageBase";
-import { isDefaultSystemPrompt, createSystemPromptSummary } from "../../lib/system-prompt";
+import { createSystemPromptSummary } from "../../lib/system-prompt";
 
 type SystemMessageProps = Omit<MessageBaseProps, "avatar">;
 
@@ -19,23 +19,27 @@ function SystemMessage(props: SystemMessageProps) {
     />
   );
 
-  // If the user customizes the system prompt, we always show it.
-  // However, if it's just the normal prompt, we truncate it to save space
-  // but allow the user to click a "More..." button to reveal the whole thing.
   const { isOpen, onToggle } = useDisclosure();
-  const isCustomSystemPrompt = useMemo(() => !isDefaultSystemPrompt(message), [message]);
-  const summaryText = isCustomSystemPrompt ? undefined : createSystemPromptSummary();
+  const summaryText = createSystemPromptSummary(message);
 
-  const footer = !isCustomSystemPrompt && (
-    <Flex w="100%" justify="space-between" align="center">
-      <Button size="sm" variant="ghost" onClick={() => onToggle()}>
-        {isOpen ? "Less" : "More..."}
-      </Button>
-      <Text fontSize="2xs" as="em">
-        Edit to customize
-      </Text>
-    </Flex>
-  );
+  // If we're showing the whole prompt, don't bother with the "More..." button
+  const footer =
+    message.text.length > summaryText.length ? (
+      <Flex w="100%" justify="space-between" align="center">
+        <Button size="sm" variant="ghost" onClick={() => onToggle()}>
+          {isOpen ? "Less" : "More..."}
+        </Button>
+        <Text fontSize="2xs" as="em">
+          Edit to customize
+        </Text>
+      </Flex>
+    ) : (
+      <Flex w="100%" justify="flex-end" align="center">
+        <Text fontSize="2xs" as="em">
+          Edit to customize
+        </Text>
+      </Flex>
+    );
 
   return (
     <MessageBase

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -24,17 +24,21 @@ const buildSystemPrompt = () => {
   return systemPrompt;
 };
 
+// Compare the given system prompt to the default system prompts we use
+const isDefaultSystemPrompt = (message: ChatCraftSystemMessage) =>
+  message.text === buildSystemPrompt();
+
 export function createSystemMessage() {
   return new ChatCraftSystemMessage({ text: buildSystemPrompt() });
 }
 
 // A shorter version of the system prompt to show if we don't want to reveal the whole thing
-export function createSystemPromptSummary() {
-  return "I am ChatCraft, a web-based, expert programming AI assistant. I help programmers learn, experiment, and be more creative with code...";
-}
+export function createSystemPromptSummary(message: ChatCraftSystemMessage) {
+  if (isDefaultSystemPrompt(message)) {
+    return "I am ChatCraft, a web-based, expert programming AI assistant. I help programmers learn, experiment, and be more creative with code...";
+  }
 
-// Compare the given system prompt to the default system prompts we use
-export const isDefaultSystemPrompt = (prompt: string | ChatCraftSystemMessage) => {
-  const text = prompt instanceof ChatCraftSystemMessage ? prompt.text : prompt;
-  return text === buildSystemPrompt();
-};
+  // Grab first few lines of text, and add ellipses if necessary to indicate more
+  const { text } = message;
+  return text.length > 250 ? `${message.text.slice(0, 250).trim()}...` : message.text;
+}


### PR DESCRIPTION
Today I was working on custom system prompts, and one was very long.  I've made to improvements to the UI based on what I learned using it:

1. When a system prompt is long, it gets in the way of what you're doing.  I want to be able to see it all, but only if I choose to, or want to edit.  Most of the time it should be "background" to what I'm actually trying to accomplish in the chat.  This modifies our System Prompt UI behaviour to always shrink down to the first few lines unless you click "More..."

<img width="1122" alt="Screenshot 2023-06-27 at 8 15 20 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/1ce6a79d-28a1-4078-a40e-992aa4329c85">

<img width="1120" alt="Screenshot 2023-06-27 at 8 15 38 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/2f2d0095-6e8f-4d67-8b08-429b2849ce36">

2. When you edit a message, if the text is long, we don't show you a scrollbar.  This sets `overflow-y` to `scroll` so it works like you expect.