### PR TITLE
Open links in new tabs in Markdown

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -58,6 +58,7 @@ function Markdown({ previewCode, isLoading, onPrompt, children }: MarkdownProps)
       className="message-text"
       children={children}
       remarkPlugins={[remarkGfm]}
+      linkTarget={"_blank"}
       components={{
         code({ inline, className, children, ...props }) {
           if (inline) {


### PR DESCRIPTION
Fixes https://github.com/tarasglek/chatcraft.org/issues/140

react-markdown has a separate `linkTarget` prop for this.
Same can be achieved by modifying a component like this:
```js
a({ href, children }) {
  return (
    <a href={href} target="_blank">
      {children}
    </a>
  );
},
``` 
but above is cleaner, plus eslint is warning about breaking the [jsx-no-target-blank](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-no-target-blank.md) rule in that case. Did not dive deep into this though.