### PR TITLE
Improve chat header and app message UI when missing api key

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -16,7 +16,6 @@ import NewButton from "../components/NewButton";
 import { useSettings } from "../hooks/use-settings";
 import { useModels } from "../hooks/use-models";
 import ChatHeader from "./ChatHeader";
-import useTitle from "../hooks/use-title";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -41,7 +40,6 @@ function ChatBase({ chat }: ChatBaseProps) {
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
   const toast = useToast();
   const { user } = useUser();
-  useTitle(chat);
 
   // If we can't load models, it's a bad sign for API connectivity.
   // Show an error so the user is aware.

--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -29,6 +29,8 @@ import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { download, formatDate } from "../lib/utils";
 import { useUser } from "../hooks/use-user";
 import ShareModal from "../components/ShareModal";
+import { useSettings } from "../hooks/use-settings";
+import useTitle from "../hooks/use-title";
 
 type ChatHeaderProps = {
   chat: ChatCraftChat;
@@ -41,7 +43,8 @@ function ChatHeader({ chat }: ChatHeaderProps) {
   const fetcher = useFetcher();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [isEditing, setIsEditing] = useState(false);
-  const text = chat.summary || "New Chat";
+  const { settings } = useSettings();
+  const title = useTitle(chat);
 
   useKey("Escape", () => setIsEditing(false), { event: "keydown" }, [setIsEditing]);
 
@@ -165,19 +168,21 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                   <Box>
                     <MdOutlineChatBubbleOutline />
                   </Box>
-                  <Text fontSize="md" fontWeight="bold" noOfLines={1} title={text}>
+                  <Text fontSize="md" fontWeight="bold" noOfLines={1} title={title}>
                     <Link as={ReactRouterLink} to={`/c/${chat.id}`}>
-                      {text}
+                      {title}
                     </Link>
                   </Text>
-                  <IconButton
-                    variant="ghost"
-                    size="sm"
-                    icon={<AiOutlineEdit />}
-                    aria-label="Edit summary"
-                    title="Edit summary"
-                    onClick={() => setIsEditing(true)}
-                  />
+                  {settings.apiKey && (
+                    <IconButton
+                      variant="ghost"
+                      size="sm"
+                      icon={<AiOutlineEdit />}
+                      aria-label="Edit summary"
+                      title="Edit summary"
+                      onClick={() => setIsEditing(true)}
+                    />
+                  )}
                 </Flex>
               )}
             </Box>
@@ -192,18 +197,22 @@ function ChatHeader({ chat }: ChatHeaderProps) {
               <MenuList>
                 <MenuItem onClick={() => handleCopyChatClick()}>Copy</MenuItem>
                 <MenuItem onClick={() => handleDownloadClick()}>Download</MenuItem>
-                <MenuDivider />
 
                 {chat.shareUrl && user ? (
                   <>
+                    <MenuDivider />
+
                     <MenuItem onClick={() => handleCopyPublicUrlClick()}>Copy Public URL</MenuItem>
                     <MenuItem onClick={() => chat.unshare(user)}>Unshare</MenuItem>
                   </>
-                ) : (
-                  <MenuItem onClick={onOpen}>Create Public URL...</MenuItem>
-                )}
+                ) : settings.apiKey ? (
+                  <>
+                    <MenuDivider />
+                    <MenuItem onClick={onOpen}>Create Public URL...</MenuItem>
+                  </>
+                ) : null}
 
-                {!chat.readonly && (
+                {!chat.readonly && settings.apiKey && (
                   <>
                     <MenuDivider />
                     <MenuItem color="red.400" onClick={() => handleDeleteClick()}>

--- a/src/components/Message/AppMessage/index.tsx
+++ b/src/components/Message/AppMessage/index.tsx
@@ -23,11 +23,27 @@ function AppMessage(props: AppMessageProps) {
 
   // See if this is one of the special app message types that needs its own UI
   if (ChatCraftAppMessage.isInstructions(message)) {
-    return <Instructions {...props} avatar={avatar} heading={heading} />;
+    return (
+      <Instructions
+        {...props}
+        avatar={avatar}
+        heading={heading}
+        disableFork={true}
+        disableEdit={true}
+      />
+    );
   }
 
   // Otherwise, use a basic message type and show the text
-  return <MessageBase {...props} avatar={avatar} heading={heading} />;
+  return (
+    <MessageBase
+      {...props}
+      avatar={avatar}
+      heading={heading}
+      disableFork={true}
+      disableEdit={true}
+    />
+  );
 }
 
 export default memo(AppMessage);

--- a/src/hooks/use-title.ts
+++ b/src/hooks/use-title.ts
@@ -1,10 +1,24 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { useSettings } from "./use-settings";
 
 export default function useTitle(chat: ChatCraftChat) {
+  const [title, setTitle] = useState("");
+  const { settings } = useSettings();
+
   useEffect(() => {
-    // Browsers won't show more than 55 chars, so truncate
-    const title = chat.summary?.slice(0, 40) || "New Chat";
+    if (!settings.apiKey) {
+      setTitle("Please Enter API Key");
+    } else {
+      setTitle(chat.summary || "New Chat");
+    }
+  }, [chat.summary, settings.apiKey]);
+
+  // Update the window's title as well
+  useEffect(() => {
+    // Browsers won't show more than ~55 chars, so truncate.
     document.title = `${title} - ChatCraft`;
-  }, [chat.summary]);
+  }, [title]);
+
+  return title;
 }


### PR DESCRIPTION
Fixes #145 

- Uses "Please Enter API Key" in chat header and window title when API Key is missing
- Removes chat header icons/menu items that don't make sense if you don't have an API Key
- Does a similar fix to app messages to remove unnecessary shortcut icons/menu items (e.g., edit)