### PR TITLE
Make shared chats immutable, db migration v5

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -119,7 +119,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
       try {
         // Add this prompt message to the chat
-        await chat.addMessage(new ChatCraftHumanMessage({ text: prompt, user }), user);
+        await chat.addMessage(new ChatCraftHumanMessage({ text: prompt, user }));
 
         // In single-message-mode, trim messages to last few. Otherwise send all.
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
@@ -128,7 +128,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         const response = await callChatApi(messagesToSend);
 
         // Add this response message to the chat
-        await chat.addMessage(response, user);
+        await chat.addMessage(response);
       } catch (err: any) {
         toast({
           title: `OpenAI Response Error`,
@@ -207,7 +207,7 @@ function ChatBase({ chat }: ChatBaseProps) {
             chatId={chat.id}
             newMessage={streamingMessage}
             isLoading={loading}
-            onRemoveMessage={(message) => chat.removeMessage(message.id, user)}
+            onRemoveMessage={(message) => chat.removeMessage(message.id)}
             singleMessageMode={singleMessageMode}
             isPaused={paused}
             onTogglePause={togglePause}

--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -27,7 +27,6 @@ import { useCopyToClipboard, useKey } from "react-use";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { download, formatDate } from "../lib/utils";
-import { useUser } from "../hooks/use-user";
 import ShareModal from "../components/ShareModal";
 import { useSettings } from "../hooks/use-settings";
 import useTitle from "../hooks/use-title";
@@ -37,7 +36,6 @@ type ChatHeaderProps = {
 };
 
 function ChatHeader({ chat }: ChatHeaderProps) {
-  const { user } = useUser();
   const [, copyToClipboard] = useCopyToClipboard();
   const toast = useToast();
   const fetcher = useFetcher();
@@ -55,22 +53,6 @@ function ChatHeader({ chat }: ChatHeaderProps) {
   const handleCopyChatClick = () => {
     const text = chat.toMarkdown();
     copyToClipboard(text);
-    toast({
-      colorScheme: "blue",
-      title: "Chat copied to clipboard",
-      status: "success",
-      position: "top",
-      isClosable: true,
-    });
-  };
-
-  const handleCopyPublicUrlClick = () => {
-    if (!chat.shareUrl) {
-      console.warn("Unexpected copy of missing shareUrl", chat);
-      return;
-    }
-
-    copyToClipboard(chat.shareUrl);
     toast({
       colorScheme: "blue",
       title: "Chat copied to clipboard",
@@ -107,7 +89,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
 
     chat.summary = summary;
     chat
-      .update()
+      .save()
       .catch((err) => {
         console.warn("Unable to update summary for chat", err);
         toast({
@@ -198,22 +180,11 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                 <MenuItem onClick={() => handleCopyChatClick()}>Copy</MenuItem>
                 <MenuItem onClick={() => handleDownloadClick()}>Download</MenuItem>
 
-                {chat.shareUrl && user ? (
-                  <>
-                    <MenuDivider />
-
-                    <MenuItem onClick={() => handleCopyPublicUrlClick()}>Copy Public URL</MenuItem>
-                    <MenuItem onClick={() => chat.unshare(user)}>Unshare</MenuItem>
-                  </>
-                ) : settings.apiKey ? (
-                  <>
-                    <MenuDivider />
-                    <MenuItem onClick={onOpen}>Create Public URL...</MenuItem>
-                  </>
-                ) : null}
-
                 {!chat.readonly && settings.apiKey && (
                   <>
+                    <MenuDivider />
+                    <MenuItem onClick={onOpen}>Share Chat...</MenuItem>
+
                     <MenuDivider />
                     <MenuItem color="red.400" onClick={() => handleDeleteClick()}>
                       Delete

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -36,7 +36,7 @@ type AuthenticatedForm = {
 
 function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
   const { settings } = useSettings();
-  const [url, setUrl] = useState<string>(chat.shareUrl || "");
+  const [url, setUrl] = useState("");
   const [error, setError] = useState<string | undefined>();
   const [summary, setSummary] = useState<string>(chat.summary);
   const [isSummarizing, setIsSummarizing] = useState(false);
@@ -46,7 +46,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
   const handleShareClick = async () => {
     setIsSharing(true);
     try {
-      const url = await chat.share(user, summary);
+      const { url } = await chat.share(user, summary);
       if (!url) {
         throw new Error("Unable to create Share URL");
       }

--- a/src/lib/SharedChatCraftChat.ts
+++ b/src/lib/SharedChatCraftChat.ts
@@ -1,0 +1,53 @@
+import db, { SharedChatCraftChatTable } from "./db";
+import { ChatCraftChat } from "./ChatCraftChat";
+import { deleteShare } from "./share";
+
+export class SharedChatCraftChat {
+  id: string;
+  url: string;
+  date: Date;
+  summary: string;
+  chat: ChatCraftChat;
+
+  constructor({
+    id,
+    url,
+    date,
+    summary,
+    chat,
+  }: {
+    id: string;
+    url: string;
+    date: Date;
+    summary: string;
+    chat: ChatCraftChat;
+  }) {
+    this.id = id;
+    this.url = url;
+    this.date = date;
+    this.summary = summary;
+    this.chat = chat;
+  }
+
+  toDB(): SharedChatCraftChatTable {
+    return {
+      id: this.id,
+      url: this.url,
+      date: this.date,
+      summary: this.summary,
+      chat: this.chat.serialize(),
+    };
+  }
+
+  static fromDB(shared: SharedChatCraftChatTable) {
+    return new SharedChatCraftChat({ ...shared, chat: ChatCraftChat.fromJSON(shared.chat) });
+  }
+
+  static async delete(user: User, id: string) {
+    if (!(await await db.shared.get(id))) {
+      return;
+    }
+
+    return Promise.all([deleteShare(user, id), db.shared.delete(id)]);
+  }
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -11,7 +11,7 @@ export function createShareUrl(chat: ChatCraftChat, user: User) {
   return shareUrl.href;
 }
 
-export async function createOrUpdateShare(chat: ChatCraftChat, user: User) {
+export async function createShare(chat: ChatCraftChat, user: User) {
   const res = await fetch(`/api/share/${user.username}/${chat.id}`, {
     method: "PUT",
     credentials: "same-origin",
@@ -29,8 +29,6 @@ export async function createOrUpdateShare(chat: ChatCraftChat, user: User) {
     } = await res.json();
     throw new Error(`Unable to share chat: ${message || "unknown error"}`);
   }
-
-  return createShareUrl(chat, user);
 }
 
 export async function loadShare(user: string, id: string) {
@@ -69,8 +67,8 @@ export async function summarizeChat(openaiApiKey: string, chat: ChatCraftChat) {
   }
 }
 
-export async function deleteShare(chat: ChatCraftChat, user: User) {
-  const res = await fetch(`/api/share/${user.username}/${chat.id}`, {
+export async function deleteShare(user: User, chatId: string) {
+  const res = await fetch(`/api/share/${user.username}/${chatId}`, {
     method: "DELETE",
     credentials: "same-origin",
   });

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -118,7 +118,8 @@ export default createBrowserRouter([
       return redirect(`/c/${forked.id}`);
     },
   },
-  // Loading a shared chat, which may or may not be owned by this user
+
+  // Loading a shared chat remotely as JSON, which will be readonly
   {
     path: "/c/:user/:chatId",
     async loader({ params }) {
@@ -127,14 +128,6 @@ export default createBrowserRouter([
         return redirect("/");
       }
 
-      // Check if we actually own this chat
-      const chat = await ChatCraftChat.find(chatId);
-      if (chat) {
-        // Go to our local version instead
-        return redirect(`/c/${chatId}`);
-      }
-
-      // Otherwise, try to load it remotely
       try {
         return loadShare(user, chatId);
       } catch (err) {


### PR DESCRIPTION
Fixes #143

This changes our strategy and data schema for shared chats.  Previously, we included an optional `sharedUrl` property on a chat, indicating that it was shared.  This URL was stable even if the chat changed (e.g. you added/deleted messages), since we silently kept the data in R2 in sync with changes in the local database.

However, we're moving to having shared chats be immutable.  Once you share a chat, you can delete it but not change it.  To help with reactivity in the app, I've created a new table to store the shared chat info locally (I played with various approaches where I queried the API functions, but it got overly complicated).  Our IndexedDB database is our source of truth, so shared chats also get managed there.  This makes it easy to show them in the UI.

To accomplish this, I've removed all uses of `shareUrl`, which meant doing another db migration.  This is the first time that I had to write an `upgrade()` function to convert the data to use the new `shared` table (i.e., I take the chats with `shareUrl` values and copy their data over into the new table before deleting the property).  It's really slick how Dixie allows these upgrades in place.

I've also created a new type, `SharedChatCraftChat`, which you get from calling `.share()` on a `ChatCraftChat` object.  It represents the data as we have it in R2 and the `shared` table.

To make testing easier, I've also added an `Import` feature for the database.  Now you can open `chatcraft.org` and go to Settings, click `Export`, get the `.json` file, then go back to a preview URL or localhost and click `Import` to bring that database into the current app.  Then you can test what the migration will do.  I was able to migrate all my data over to localhost without issue.

I will need to rebase this and test some more, but I think all the necessary pieces are working well.  Hopefully this is the last time I have to rewrite sharing!