### PR TITLE
duplicate chat until message

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -79,7 +79,6 @@ function MessageBase({
   const [editing, setEditing] = useState(false);
   const { onCopy } = useClipboard(text);
   const toast = useToast();
-  const navigate = useNavigate();
   const [isHovering, setIsHovering] = useState(false);
 
   const handleCopy = useCallback(() => {

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -237,8 +237,8 @@ function MessageBase({
                   <MenuItem onClick={() => handleCopy()}>Copy</MenuItem>
                   <MenuItem onClick={() => handleDownload()}>Download</MenuItem>
                   {!disableFork && (
-                    <MenuItem onClick={() => navigate(`./fork/${id}`)}>
-                      Duplicate Chat from Message...
+                    <MenuItem as={ReactRouterLink} to={`./fork/${id}`} target="_blank">
+                      Duplicate Chat until Message...
                     </MenuItem>
                   )}
 

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -174,7 +174,7 @@ export class ChatCraftChat {
     if (messageId) {
       const idx = messages.findIndex((message) => message.id === messageId);
       if (idx) {
-        messages = messages.slice(idx);
+        messages = messages.slice(0, idx + 1);
       }
     }
 


### PR DESCRIPTION
I keep wanting to fork my chats to take them in different directions(kind of like threads in other chat apps).

We had a `Duplicate Chat from Message`, which nuked the system message and included all chats after message. It also did that inplace and looked like it lost my very custom system message.

This changes that to 'Duplicate Chat until Message' which now opens a new window and includes all messages up to and including message-being-duplicated