### PR TITLE
Have all AI chat calls use same code path and UX

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -27,7 +27,7 @@ import ResizeTextarea from "react-textarea-autosize";
 import { TbDots, TbTrash } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
-import { Link as ReactRouterLink, useNavigate } from "react-router-dom";
+import { Link as ReactRouterLink } from "react-router-dom";
 
 import { formatDate, download, formatNumber } from "../../lib/utils";
 import Markdown from "../Markdown";

--- a/src/components/Message/NewMessage.tsx
+++ b/src/components/Message/NewMessage.tsx
@@ -1,7 +1,7 @@
-import { Box, Button, ButtonGroup, Flex } from "@chakra-ui/react";
+import { Box, Button, ButtonGroup } from "@chakra-ui/react";
 
-import Message from "./Message";
-import { ChatCraftAiMessage } from "../lib/ChatCraftMessage";
+import { ChatCraftAiMessage } from "../../lib/ChatCraftMessage";
+import OpenAiMessage from "./OpenAiMessage";
 
 type NewMessageProps = {
   message: ChatCraftAiMessage;
@@ -12,19 +12,15 @@ type NewMessageProps = {
 };
 
 function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewMessageProps) {
-  // If the user presses the mouse button over the streaming message while
-  // loading, pause to make it easier to copy/paste text as it streams in.
-  function handleMouseDown() {
-    if (!isPaused) {
-      onTogglePause();
-    }
-  }
-
   return (
-    <Flex flexDir="column" w="100%">
-      <Box flex={1} onMouseDown={handleMouseDown}>
-        <Message key={chatId} message={message} chatId={chatId} isLoading />
-      </Box>
+    <>
+      <OpenAiMessage
+        key={message.id}
+        message={message}
+        chatId={chatId}
+        isLoading
+        heading={message.model.prettyModel}
+      />
       <Box textAlign="center">
         <ButtonGroup>
           <Button variant="outline" size="xs" onClick={() => onCancel()}>
@@ -42,7 +38,7 @@ function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewM
           )}
         </ButtonGroup>
       </Box>
-    </Flex>
+    </>
   );
 }
 

--- a/src/components/Message/OpenAiMessage.tsx
+++ b/src/components/Message/OpenAiMessage.tsx
@@ -14,11 +14,12 @@ import { TbChevronDown } from "react-icons/tb";
 
 import MessageBase, { type MessageBaseProps } from "./MessageBase";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
-import * as ai from "../../lib/ai";
 import { useSettings } from "../../hooks/use-settings";
 import { ChatCraftAiMessage, ChatCraftAiMessageVersion } from "../../lib/ChatCraftMessage";
 import { formatDate } from "../../lib/utils";
 import { ChatCraftModel } from "../../lib/ChatCraftModel";
+import useChatOpenAI from "../../hooks/use-chat-openai";
+import NewMessage from "./NewMessage";
 
 const getAvatar = (model: ChatCraftModel, size: "sm" | "xs") => {
   if (model.id.startsWith("gpt-4")) {
@@ -108,6 +109,7 @@ type OpenAiMessageProps = Omit<MessageBaseProps, "avatar" | "message"> & {
 };
 
 function OpenAiMessage(props: OpenAiMessageProps) {
+  const { streamingMessage, callChatApi, cancel, paused, togglePause } = useChatOpenAI();
   // We may or many not need to adjust the message (e.g., when retrying)
   const [message, setMessage] = useState(props.message);
   const [retrying, setRetrying] = useState(false);
@@ -137,20 +139,12 @@ function OpenAiMessage(props: OpenAiMessageProps) {
         }
         const context = messages.slice(0, idx);
         const date = new Date();
-        const { id, versions } = message;
-        setMessage(new ChatCraftAiMessage({ id, date, model, text: "", versions }));
 
         setRetrying(true);
-        const newVersionText = await ai.chat(context, {
-          apiKey: settings.apiKey,
-          model: model.id,
-          onToken(_token: string, currentText: string) {
-            setMessage(new ChatCraftAiMessage({ id, date, model, text: currentText, versions }));
-          },
-        });
+        const aiMessage = await callChatApi(context, model);
 
-        // Update db with new message info, and also add this as a new version
-        const version = new ChatCraftAiMessageVersion({ date, model, text: newVersionText });
+        // Update db with new message info, and also add this text as a new version
+        const version = new ChatCraftAiMessageVersion({ date, model, text: aiMessage.text });
         message.addVersion(version);
         message.switchVersion(version.id);
         await message.save(chat.id);
@@ -161,12 +155,22 @@ function OpenAiMessage(props: OpenAiMessageProps) {
         setRetrying(false);
       }
     },
-    [props.chatId, settings.apiKey, message]
+    [props.chatId, settings.apiKey, message, callChatApi]
   );
 
-  return (
+  // While we're streaming in a new version, use a different display
+  return streamingMessage ? (
+    <NewMessage
+      message={streamingMessage}
+      chatId={props.chatId}
+      isPaused={paused}
+      onTogglePause={togglePause}
+      onCancel={cancel}
+    />
+  ) : (
     <MessageBase
       {...props}
+      key={message.id}
       message={message}
       hidePreviews={retrying}
       isLoading={props.isLoading || retrying}

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -3,7 +3,7 @@ import { Box, useColorMode } from "@chakra-ui/react";
 import mermaid from "mermaid";
 
 import Message from "./Message";
-import NewMessage from "./NewMessage";
+import NewMessage from "./Message/NewMessage";
 import {
   ChatCraftMessage,
   ChatCraftAiMessage,

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -65,7 +65,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     }
     try {
       setIsSummarizing(true);
-      const summary = await summarizeChat(settings.apiKey, chat);
+      const summary = await summarizeChat(chat);
       setSummary(summary);
     } catch (err: any) {
       console.error(err);

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -26,8 +26,10 @@ import { TbCopy } from "react-icons/tb";
 
 import { useUser } from "../hooks/use-user";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { summarizeChat } from "../lib/share";
 import { useSettings } from "../hooks/use-settings";
+import { ChatCraftHumanMessage, ChatCraftSystemMessage } from "../lib/ChatCraftMessage";
+import useChatOpenAI from "../hooks/use-chat-openai";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 type AuthenticatedForm = {
   chat: ChatCraftChat;
@@ -42,6 +44,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
   const [isSummarizing, setIsSummarizing] = useState(false);
   const [isSharing, setIsSharing] = useState(false);
   const [, copyToClipboard] = useCopyToClipboard();
+  const { callChatApi } = useChatOpenAI();
 
   const handleShareClick = async () => {
     setIsSharing(true);
@@ -59,6 +62,32 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     }
   };
 
+  const summarizeChat = useCallback(
+    async (chat: ChatCraftChat) => {
+      const systemChatMessage = new ChatCraftSystemMessage({
+        text: "You are an expert at writing short summaries.",
+      });
+      const summarizeInstruction = new ChatCraftHumanMessage({
+        text: `Summarize this chat in 25 words or fewer. Respond only with the summary text and focus on the main content, not mentioning the process or participants. For example: "Using a React context and hook to keep track of user state after login."`,
+      });
+      const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: false });
+
+      try {
+        // TODO: this can fail if the chat is too long for gpt-3.5-turbo.
+        // callChatApi() should use a sliding context window
+        const { text } = await callChatApi(
+          [systemChatMessage, ...messages, summarizeInstruction],
+          new ChatCraftModel("gpt-3.5-turbo", "OpenAI")
+        );
+        return text.trim();
+      } catch (err) {
+        console.error("Error summarizing chat", err);
+        throw err;
+      }
+    },
+    [callChatApi]
+  );
+
   const handleSummarizeClick = useCallback(async () => {
     if (!settings.apiKey) {
       return;
@@ -73,7 +102,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     } finally {
       setIsSummarizing(false);
     }
-  }, [settings.apiKey, chat, setIsSummarizing]);
+  }, [settings.apiKey, chat, setIsSummarizing, summarizeChat]);
 
   const handleCopyClick = useCallback(() => {
     copyToClipboard(url);

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -1,113 +1,79 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { ChatOpenAI } from "langchain/chat_models/openai";
-import { CallbackManager } from "langchain/callbacks";
-import { useKey } from "react-use";
 
 import { useSettings } from "./use-settings";
-import {
-  ChatCraftMessage,
-  ChatCraftAiMessage,
-  ChatCraftSystemMessage,
-} from "../lib/ChatCraftMessage";
-import { createSystemMessage } from "../lib/system-prompt";
+import { ChatCraftMessage, ChatCraftAiMessage } from "../lib/ChatCraftMessage";
 import { useCost } from "./use-cost";
-import { calculateTokenCost, countTokensInMessages } from "../lib/ai";
+import { calculateTokenCost, chatWithOpenAI, countTokensInMessages } from "../lib/ai";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
+
+const noop = () => {};
 
 function useChatOpenAI() {
-  const [streamingMessage, setStreamingMessage] = useState<ChatCraftAiMessage>();
   const { settings } = useSettings();
-  const [cancel, setCancel] = useState<() => void>(() => {});
-  const [paused, setPaused] = useState(false);
-  const pausedRef = useRef(paused);
   const { incrementCost } = useCost();
 
-  // Listen for escape being pressed on window, and cancel any in flight
-  useKey("Escape", cancel, { event: "keydown" }, [cancel]);
+  const [streamingMessage, setStreamingMessage] = useState<ChatCraftAiMessage>();
+
+  const pauseRef = useRef<() => void>();
+  const resumeRef = useRef<() => void>();
+  const toggleRef = useRef<() => void>();
+  const cancelRef = useRef<() => void>();
+
+  const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(paused);
 
   // Make sure we always use the correct `paused` value in our streaming callback below
   useEffect(() => {
     pausedRef.current = paused;
   }, [paused]);
 
-  const pause = () => {
-    setPaused(true);
-  };
-
-  const resume = () => {
-    setPaused(false);
-  };
-
-  const togglePause = () => {
-    setPaused(!paused);
-  };
-
-  // TODO: figure out how to combine the code in src/lib/ai.ts
   const callChatApi = useCallback(
-    (messages: ChatCraftMessage[]) => {
-      const buffer: string[] = [];
-      const { model } = settings;
-      const message = new ChatCraftAiMessage({ model, text: "" });
-      // Cache the id so we can re-use it below
-      const id = message.id;
-      setStreamingMessage(message);
+    (messages: ChatCraftMessage[], model?: ChatCraftModel) => {
+      const aiMessage = new ChatCraftAiMessage({ model: model ?? settings.model, text: "" });
+      setStreamingMessage(aiMessage);
 
-      const chatOpenAI = new ChatOpenAI({
-        openAIApiKey: settings.apiKey,
-        temperature: 0,
-        streaming: true,
-        modelName: settings.model.id,
+      const chat = chatWithOpenAI(messages, {
+        model,
+        onPause() {
+          setPaused(true);
+        },
+        onResume() {
+          setPaused(false);
+        },
+        onData({ currentText }) {
+          if (!pausedRef.current) {
+            setStreamingMessage(
+              new ChatCraftAiMessage({
+                id: aiMessage.id,
+                date: aiMessage.date,
+                model: aiMessage.model,
+                text: currentText,
+              })
+            );
+          }
+        },
       });
 
-      // Allow the stream to be cancelled
-      const controller = new AbortController();
+      pauseRef.current = chat.pause;
+      resumeRef.current = chat.resume;
+      toggleRef.current = chat.togglePause;
+      cancelRef.current = chat.cancel;
 
-      // Set the cancel and pause functions
-      setCancel(() => () => {
-        controller.abort();
-      });
-
-      // Send the chat's messages and prefix with a system message unless
-      // the user has already included their own custom system message.
-      const messagesToSend =
-        messages[0] instanceof ChatCraftSystemMessage
-          ? messages
-          : [createSystemMessage(), ...messages];
-
-      return chatOpenAI
-        .call(
-          messagesToSend,
-          {
-            options: { signal: controller.signal },
-          },
-          CallbackManager.fromHandlers({
-            async handleLLMNewToken(token: string) {
-              buffer.push(token);
-
-              if (!pausedRef.current) {
-                setStreamingMessage(
-                  new ChatCraftAiMessage({
-                    id,
-                    model,
-                    text: buffer.join(""),
-                  })
-                );
-              }
-            },
-          })
-        )
-        .then(({ text }): Promise<[ChatCraftAiMessage, number]> => {
-          const aiMessage = new ChatCraftAiMessage({
-            id,
-            model,
+      return chat.promise
+        .then((text): Promise<[ChatCraftAiMessage, number]> => {
+          const response = new ChatCraftAiMessage({
+            id: aiMessage.id,
+            date: aiMessage.date,
+            model: aiMessage.model,
             text,
           });
 
           // If we're tracking token cost, update it
           if (settings.countTokens) {
-            return Promise.all([aiMessage, countTokensInMessages([...messagesToSend, aiMessage])]);
+            return Promise.all([response, countTokensInMessages([...messages, aiMessage])]);
           }
 
-          return Promise.resolve([aiMessage, 0]);
+          return Promise.resolve([response, 0]);
         })
         .then(([aiMessage, tokens]) => {
           if (tokens) {
@@ -116,31 +82,6 @@ function useChatOpenAI() {
           }
 
           return aiMessage;
-        })
-        .catch((err) => {
-          // Deal with cancelled messages by returning a partial message
-          if (err.message.startsWith("Cancel:")) {
-            buffer.push("...");
-            return new ChatCraftAiMessage({
-              id,
-              model,
-              text: buffer.join(""),
-            });
-          }
-
-          // Try to extract the actual OpenAI API error from what langchain gives us
-          // which is JSON embedded in the error text.
-          // eslint-disable-next-line no-useless-catch
-          try {
-            const matches = err.message.match(/{"error".+$/);
-            if (matches) {
-              const openAiError = JSON.parse(matches[0]);
-              throw new Error(`OpenAI API Error: ${openAiError.error.message}`);
-            }
-            throw err;
-          } catch (err2) {
-            throw err2;
-          }
         })
         .finally(() => {
           setStreamingMessage(undefined);
@@ -153,11 +94,14 @@ function useChatOpenAI() {
   return {
     streamingMessage,
     callChatApi,
-    cancel,
     paused,
-    pause,
-    resume,
-    togglePause,
+    // HACK: Because there's a chance these function refs might not exist yet, always
+    // pass an actual function so we don't have to deal with `undefined` in callers.
+    // In practice, this won't be in issue, but the TypeScript-tax must be paid.
+    pause: pauseRef.current ?? noop,
+    resume: resumeRef.current ?? noop,
+    togglePause: toggleRef.current ?? noop,
+    cancel: cancelRef.current ?? noop,
   };
 }
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,54 +1,130 @@
 import { ChatOpenAI } from "langchain/chat_models/openai";
 import { CallbackManager } from "langchain/callbacks";
 
-import { ChatCraftMessage, ChatCraftSystemMessage } from "./ChatCraftMessage";
-import { createSystemMessage } from "./system-prompt";
+import { ChatCraftMessage } from "./ChatCraftMessage";
+import { ChatCraftModel } from "./ChatCraftModel";
 import { getSettings } from "./settings";
 
 import type { Tiktoken } from "tiktoken/lite";
-import { ChatCraftModel } from "./ChatCraftModel";
 
 export type ChatOptions = {
-  apiKey: string;
-  model: string;
+  model?: ChatCraftModel;
   temperature?: number;
-  onToken: (token: string, currentText: string) => void;
-  controller?: AbortController;
+  onFinish?: (text: string) => void;
+  onError?: (err: Error) => void;
+  onData?: ({ token, currentText }: { token: string; currentText: string }) => void;
 };
 
-// TODO: figure out how to consolidate this with the code in hooks/use-chat-openai.ts
-// or replace that with this.
-export const chat = (messages: ChatCraftMessage[], options: ChatOptions) => {
+export const chatWithOpenAI = (messages: ChatCraftMessage[], options: ChatOptions = {}) => {
+  // We can't do anything without an API key
+  const apiKey = getSettings().apiKey;
+  if (!apiKey) {
+    throw new Error("Missing OpenAI API Key");
+  }
+
   const buffer: string[] = [];
-  const chatOpenAI = new ChatOpenAI({
-    openAIApiKey: options.apiKey,
-    temperature: options.temperature ?? 0,
-    streaming: true,
-    modelName: options.model,
-  });
+  const { onData, onFinish, onError, temperature, model } = options;
 
   // Allow the stream to be cancelled
-  const controller = options.controller ?? new AbortController();
+  const controller = new AbortController();
 
-  // Send the chat's messages and prefix with a system message unless
-  // the user has already included their own custom system message.
-  const messagesToSend =
-    messages[0] instanceof ChatCraftSystemMessage ? messages : [createSystemMessage(), ...messages];
+  // Wire-up ESC key to cancel
+  const cancel = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      controller.abort();
+    }
+  };
+  addEventListener("keydown", cancel);
 
-  return chatOpenAI
+  // Allow pause and resume
+  let isPaused = false;
+  const pause = () => {
+    isPaused = true;
+  };
+  const resume = () => {
+    isPaused = false;
+  };
+  const togglePause = () => {
+    isPaused = !isPaused;
+  };
+
+  const chatOpenAI = new ChatOpenAI({
+    openAIApiKey: apiKey,
+    temperature: temperature ?? 0,
+    // Only stream if the caller wants to handle onData events
+    streaming: !!onData,
+    // Use the provided model, or fallback to whichever one is default right now
+    modelName: model ? model.id : getSettings().model.id,
+  });
+
+  // Grab the promise so we can return, but callers can also do everything via events
+  const promise = chatOpenAI
     .call(
-      messagesToSend,
+      messages,
       {
         options: { signal: controller.signal },
       },
       CallbackManager.fromHandlers({
         handleLLMNewToken(token: string) {
           buffer.push(token);
-          options.onToken(token, buffer.join(""));
+          if (onData && !isPaused) {
+            onData({ token, currentText: buffer.join("") });
+          }
         },
       })
     )
-    .then(({ text }) => text);
+    .then(({ text }) => {
+      if (onFinish) {
+        onFinish(text);
+      }
+      return text;
+    })
+    .catch((err) => {
+      // Deal with cancelled messages by returning a partial message
+      if (err.message.startsWith("Cancel:")) {
+        buffer.push("...");
+        const text = buffer.join("");
+        if (onFinish) {
+          onFinish(text);
+        }
+        return text;
+      }
+
+      const handleError = (error: Error) => {
+        if (onError) {
+          onError(error);
+        } else {
+          throw error;
+        }
+      };
+
+      // Try to extract the actual OpenAI API error from what langchain gives us
+      // which is JSON embedded in the error text.
+      // eslint-disable-next-line no-useless-catch
+      try {
+        const matches = err.message.match(/{"error".+$/);
+        if (matches) {
+          const openAiError = JSON.parse(matches[0]);
+          handleError(new Error(`OpenAI API Error: ${openAiError.error.message}`));
+        } else {
+          handleError(err);
+        }
+      } catch (err2) {
+        handleError(err2 as Error);
+      }
+    })
+    .finally(() => {
+      removeEventListener("keydown", cancel);
+    });
+
+  return {
+    // Force the promise to always return a string (langchain's returns undefined in some cases)
+    promise: promise.then((result) => (typeof result === "string" ? result : "")),
+    cancel,
+    pause,
+    resume,
+    togglePause,
+  };
 };
 
 export async function queryOpenAiModels(apiKey: string) {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,9 +1,4 @@
-import { ChatOpenAI } from "langchain/chat_models/openai";
-
-import { chatWithOpenAI } from "../lib/ai";
 import { ChatCraftChat, SerializedChatCraftChat } from "./ChatCraftChat";
-import { ChatCraftHumanMessage, ChatCraftSystemMessage } from "./ChatCraftMessage";
-import { ChatCraftModel } from "./ChatCraftModel";
 
 export function createShareUrl(chat: ChatCraftChat, user: User) {
   // Create a share URL we can give to other people
@@ -42,27 +37,6 @@ export async function loadShare(user: string, id: string) {
 
   const serialized: SerializedChatCraftChat = await res.json();
   return ChatCraftChat.fromJSON(serialized);
-}
-
-export async function summarizeChat(chat: ChatCraftChat) {
-  const systemChatMessage = new ChatCraftSystemMessage({
-    text: "You are an expert at writing short summaries.",
-  });
-
-  const summarizeInstruction = new ChatCraftHumanMessage({
-    text: `Summarize this chat in 25 words or fewer. Respond only with the summary text and focus on the main content, not mentioning the process or participants. For example: "Using a React context and hook to keep track of user state after login."`,
-  });
-
-  try {
-    const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: false });
-    const text = await chatWithOpenAI([systemChatMessage, ...messages, summarizeInstruction], {
-      model: new ChatCraftModel("gpt-3.5-turbo", "OpenAI"),
-    }).promise;
-    return text.trim();
-  } catch (err) {
-    console.error("Error summarizing chat", err);
-    throw err;
-  }
 }
 
 export async function deleteShare(user: User, chatId: string) {


### PR DESCRIPTION
Fixes #152.

We currently have 3 different places where we interact with OpenAI:

1. When you ask a question in the prompt form
2. When we retry an AI message with a different model inline
3. When a user requests that we summarize a chat in the share modal

These all worked a bit differently, so we had 3 different code paths. However, the one we use for the prompt form was the most mature, and included nice UX features like pause/resume and cancel.

I've amalgamated all three of this into a single one.  The low-level stuff now lives in `src/lib/ai.ts` and the UI components use it via `src/hooks/use-chat-openai.ts`.

Some callers need to be able to stream responses, some don't, so I've made something that you can pass event handlers to, but you can also use it via a promise if all you care about is the result.

I've also reworked the code to have both the prompt form and inline retires use the same UI components.  As part of this I fixed some visual bugs, and one downside was that I had to remove the click-to-pause feature.  I think now that we have an actual pause button, this is less important, but let me know if you disagree and I can find a way to re-enable it.

One thing I haven't done yet is fix the auto-scrolling for retry messages, which is #105, and I'll tackle that separately.

I've also fixed a stray import in `src/components/Message/MessageBase.tsx` we missed earlier today.

This needs a bunch of testing.  Try to look past UI bugs that aren't related to what I've done here (I know that's hard), but I just need to get this new OpenAI logic landed and then I can work on fixing things in common code.