### PR TITLE
Lift editing state to shared props for all Message types

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -46,6 +46,8 @@ import { useSettings } from "../../hooks/use-settings";
 export interface MessageBaseProps {
   message: ChatCraftMessage;
   chatId: string;
+  editing: boolean;
+  onEditingChange: (newValue: boolean) => void;
   summaryText?: string;
   heading?: string;
   headingMenu?: ReactNode;
@@ -63,6 +65,8 @@ export interface MessageBaseProps {
 function MessageBase({
   message,
   chatId,
+  editing,
+  onEditingChange,
   summaryText,
   heading,
   headingMenu,
@@ -78,7 +82,6 @@ function MessageBase({
 }: MessageBaseProps) {
   const { id, date, text } = message;
   const { models } = useModels();
-  const [editing, setEditing] = useState(false);
   const { onCopy } = useClipboard(text);
   const toast = useToast();
   const [isHovering, setIsHovering] = useState(false);
@@ -149,7 +152,7 @@ function MessageBase({
               isClosable: true,
             });
           })
-          .finally(() => setEditing(false));
+          .finally(() => onEditingChange(false));
       } else {
         message.text = text;
         message.date = editedAt;
@@ -165,10 +168,10 @@ function MessageBase({
               isClosable: true,
             });
           })
-          .finally(() => setEditing(false));
+          .finally(() => onEditingChange(false));
       }
     },
-    [message, toast, chatId]
+    [message, toast, chatId, onEditingChange]
   );
 
   return (
@@ -226,7 +229,7 @@ function MessageBase({
                       icon={<AiOutlineEdit />}
                       aria-label="Edit message"
                       title="Edit message"
-                      onClick={() => setEditing(!editing)}
+                      onClick={() => onEditingChange(!editing)}
                     />
                   )}
                   {onDeleteClick && (
@@ -270,7 +273,7 @@ function MessageBase({
 
                   {(!disableEdit || onDeleteClick) && <MenuDivider />}
                   {!disableEdit && (
-                    <MenuItem onClick={() => setEditing(!editing)}>
+                    <MenuItem onClick={() => onEditingChange(!editing)}>
                       {editing ? "Cancel Editing" : "Edit"}
                     </MenuItem>
                   )}
@@ -303,7 +306,7 @@ function MessageBase({
                       autoFocus={true}
                     />
                     <ButtonGroup>
-                      <Button size="sm" variant="outline" onClick={() => setEditing(false)}>
+                      <Button size="sm" variant="outline" onClick={() => onEditingChange(false)}>
                         Cancel
                       </Button>
                       <Button size="sm" type="submit">

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -7,7 +7,7 @@ import { createSystemPromptSummary } from "../../lib/system-prompt";
 type SystemMessageProps = Omit<MessageBaseProps, "avatar">;
 
 function SystemMessage(props: SystemMessageProps) {
-  const { message } = props;
+  const { message, editing, onEditingChange } = props;
   const avatar = (
     <Avatar
       size="sm"
@@ -29,15 +29,23 @@ function SystemMessage(props: SystemMessageProps) {
         <Button size="sm" variant="ghost" onClick={() => onToggle()}>
           {isOpen ? "Less" : "More..."}
         </Button>
-        <Text fontSize="2xs" as="em">
-          Edit to customize
-        </Text>
+        {!editing && (
+          <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
+            <Text fontSize="2xs" as="em">
+              Edit to customize
+            </Text>
+          </Button>
+        )}
       </Flex>
     ) : (
       <Flex w="100%" justify="flex-end" align="center">
-        <Text fontSize="2xs" as="em">
-          Edit to customize
-        </Text>
+        {!editing && (
+          <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
+            <Text fontSize="2xs" as="em">
+              Edit to customize
+            </Text>
+          </Button>
+        )}
       </Flex>
     );
 

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, useCallback, useState } from "react";
 import {
   ChatCraftHumanMessage,
   ChatCraftAiMessage,
@@ -32,11 +32,22 @@ function Message({
   disableFork,
   disableEdit,
 }: MessageProps) {
+  const [editing, setEditing] = useState(false);
+
+  const handleEditingChange = useCallback(
+    (newValue: boolean) => {
+      setEditing(newValue);
+    },
+    [setEditing]
+  );
+
   if (message instanceof ChatCraftAiMessage) {
     return (
       <OpenAiMessage
         message={message}
         chatId={chatId}
+        editing={editing}
+        onEditingChange={handleEditingChange}
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
@@ -53,6 +64,8 @@ function Message({
       <HumanMessage
         message={message}
         chatId={chatId}
+        editing={editing}
+        onEditingChange={handleEditingChange}
         name={user?.name || "User"}
         avatarUrl={user?.avatarUrl}
         isLoading={isLoading}
@@ -70,6 +83,8 @@ function Message({
       <AppMessage
         message={message as ChatCraftAppMessage}
         chatId={chatId}
+        editing={editing}
+        onEditingChange={handleEditingChange}
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
@@ -85,6 +100,8 @@ function Message({
       <SystemMessage
         message={message}
         chatId={chatId}
+        editing={editing}
+        onEditingChange={handleEditingChange}
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}


### PR DESCRIPTION
Fixes #151.

I've moved the `editing` state out of `MessageBase`, and lifted it up to the `Message/index.tsx` component, where I then pass it down as props.  This allows the `SystemMessage` to update `editing` in the footer.