### PR TITLE
Revert "Have all AI chat calls use same code path and UX"

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -27,7 +27,7 @@ import ResizeTextarea from "react-textarea-autosize";
 import { TbDots, TbTrash } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
-import { Link as ReactRouterLink } from "react-router-dom";
+import { Link as ReactRouterLink, useNavigate } from "react-router-dom";
 
 import { formatDate, download, formatNumber } from "../../lib/utils";
 import Markdown from "../Markdown";

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -3,7 +3,7 @@ import { Box, useColorMode } from "@chakra-ui/react";
 import mermaid from "mermaid";
 
 import Message from "./Message";
-import NewMessage from "./Message/NewMessage";
+import NewMessage from "./NewMessage";
 import {
   ChatCraftMessage,
   ChatCraftAiMessage,

--- a/src/components/NewMessage.tsx
+++ b/src/components/NewMessage.tsx
@@ -1,7 +1,7 @@
-import { Box, Button, ButtonGroup } from "@chakra-ui/react";
+import { Box, Button, ButtonGroup, Flex } from "@chakra-ui/react";
 
-import { ChatCraftAiMessage } from "../../lib/ChatCraftMessage";
-import OpenAiMessage from "./OpenAiMessage";
+import Message from "./Message";
+import { ChatCraftAiMessage } from "../lib/ChatCraftMessage";
 
 type NewMessageProps = {
   message: ChatCraftAiMessage;
@@ -12,15 +12,19 @@ type NewMessageProps = {
 };
 
 function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewMessageProps) {
+  // If the user presses the mouse button over the streaming message while
+  // loading, pause to make it easier to copy/paste text as it streams in.
+  function handleMouseDown() {
+    if (!isPaused) {
+      onTogglePause();
+    }
+  }
+
   return (
-    <>
-      <OpenAiMessage
-        key={message.id}
-        message={message}
-        chatId={chatId}
-        isLoading
-        heading={message.model.prettyModel}
-      />
+    <Flex flexDir="column" w="100%">
+      <Box flex={1} onMouseDown={handleMouseDown}>
+        <Message key={chatId} message={message} chatId={chatId} isLoading />
+      </Box>
       <Box textAlign="center">
         <ButtonGroup>
           <Button variant="outline" size="xs" onClick={() => onCancel()}>
@@ -38,7 +42,7 @@ function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewM
           )}
         </ButtonGroup>
       </Box>
-    </>
+    </Flex>
   );
 }
 

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -65,7 +65,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     }
     try {
       setIsSummarizing(true);
-      const summary = await summarizeChat(chat);
+      const summary = await summarizeChat(settings.apiKey, chat);
       setSummary(summary);
     } catch (err: any) {
       console.error(err);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -1,130 +1,54 @@
 import { ChatOpenAI } from "langchain/chat_models/openai";
 import { CallbackManager } from "langchain/callbacks";
 
-import { ChatCraftMessage } from "./ChatCraftMessage";
-import { ChatCraftModel } from "./ChatCraftModel";
+import { ChatCraftMessage, ChatCraftSystemMessage } from "./ChatCraftMessage";
+import { createSystemMessage } from "./system-prompt";
 import { getSettings } from "./settings";
 
 import type { Tiktoken } from "tiktoken/lite";
+import { ChatCraftModel } from "./ChatCraftModel";
 
 export type ChatOptions = {
-  model?: ChatCraftModel;
+  apiKey: string;
+  model: string;
   temperature?: number;
-  onFinish?: (text: string) => void;
-  onError?: (err: Error) => void;
-  onData?: ({ token, currentText }: { token: string; currentText: string }) => void;
+  onToken: (token: string, currentText: string) => void;
+  controller?: AbortController;
 };
 
-export const chatWithOpenAI = (messages: ChatCraftMessage[], options: ChatOptions = {}) => {
-  // We can't do anything without an API key
-  const apiKey = getSettings().apiKey;
-  if (!apiKey) {
-    throw new Error("Missing OpenAI API Key");
-  }
-
+// TODO: figure out how to consolidate this with the code in hooks/use-chat-openai.ts
+// or replace that with this.
+export const chat = (messages: ChatCraftMessage[], options: ChatOptions) => {
   const buffer: string[] = [];
-  const { onData, onFinish, onError, temperature, model } = options;
-
-  // Allow the stream to be cancelled
-  const controller = new AbortController();
-
-  // Wire-up ESC key to cancel
-  const cancel = (e: KeyboardEvent) => {
-    if (e.key === "Escape") {
-      controller.abort();
-    }
-  };
-  addEventListener("keydown", cancel);
-
-  // Allow pause and resume
-  let isPaused = false;
-  const pause = () => {
-    isPaused = true;
-  };
-  const resume = () => {
-    isPaused = false;
-  };
-  const togglePause = () => {
-    isPaused = !isPaused;
-  };
-
   const chatOpenAI = new ChatOpenAI({
-    openAIApiKey: apiKey,
-    temperature: temperature ?? 0,
-    // Only stream if the caller wants to handle onData events
-    streaming: !!onData,
-    // Use the provided model, or fallback to whichever one is default right now
-    modelName: model ? model.id : getSettings().model.id,
+    openAIApiKey: options.apiKey,
+    temperature: options.temperature ?? 0,
+    streaming: true,
+    modelName: options.model,
   });
 
-  // Grab the promise so we can return, but callers can also do everything via events
-  const promise = chatOpenAI
+  // Allow the stream to be cancelled
+  const controller = options.controller ?? new AbortController();
+
+  // Send the chat's messages and prefix with a system message unless
+  // the user has already included their own custom system message.
+  const messagesToSend =
+    messages[0] instanceof ChatCraftSystemMessage ? messages : [createSystemMessage(), ...messages];
+
+  return chatOpenAI
     .call(
-      messages,
+      messagesToSend,
       {
         options: { signal: controller.signal },
       },
       CallbackManager.fromHandlers({
         handleLLMNewToken(token: string) {
           buffer.push(token);
-          if (onData && !isPaused) {
-            onData({ token, currentText: buffer.join("") });
-          }
+          options.onToken(token, buffer.join(""));
         },
       })
     )
-    .then(({ text }) => {
-      if (onFinish) {
-        onFinish(text);
-      }
-      return text;
-    })
-    .catch((err) => {
-      // Deal with cancelled messages by returning a partial message
-      if (err.message.startsWith("Cancel:")) {
-        buffer.push("...");
-        const text = buffer.join("");
-        if (onFinish) {
-          onFinish(text);
-        }
-        return text;
-      }
-
-      const handleError = (error: Error) => {
-        if (onError) {
-          onError(error);
-        } else {
-          throw error;
-        }
-      };
-
-      // Try to extract the actual OpenAI API error from what langchain gives us
-      // which is JSON embedded in the error text.
-      // eslint-disable-next-line no-useless-catch
-      try {
-        const matches = err.message.match(/{"error".+$/);
-        if (matches) {
-          const openAiError = JSON.parse(matches[0]);
-          handleError(new Error(`OpenAI API Error: ${openAiError.error.message}`));
-        } else {
-          handleError(err);
-        }
-      } catch (err2) {
-        handleError(err2 as Error);
-      }
-    })
-    .finally(() => {
-      removeEventListener("keydown", cancel);
-    });
-
-  return {
-    // Force the promise to always return a string (langchain's returns undefined in some cases)
-    promise: promise.then((result) => (typeof result === "string" ? result : "")),
-    cancel,
-    pause,
-    resume,
-    togglePause,
-  };
+    .then(({ text }) => text);
 };
 
 export async function queryOpenAiModels(apiKey: string) {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -12,8 +12,6 @@ export type ChatOptions = {
   temperature?: number;
   onFinish?: (text: string) => void;
   onError?: (err: Error) => void;
-  onPause?: () => void;
-  onResume?: () => void;
   onData?: ({ token, currentText }: { token: string; currentText: string }) => void;
 };
 
@@ -25,42 +23,29 @@ export const chatWithOpenAI = (messages: ChatCraftMessage[], options: ChatOption
   }
 
   const buffer: string[] = [];
-  const { onData, onFinish, onPause, onResume, onError, temperature, model } = options;
+  const { onData, onFinish, onError, temperature, model } = options;
 
   // Allow the stream to be cancelled
   const controller = new AbortController();
 
   // Wire-up ESC key to cancel
-  const cancel = () => {
-    controller.abort();
-  };
-  const handleCancel = (e: KeyboardEvent) => {
+  const cancel = (e: KeyboardEvent) => {
     if (e.key === "Escape") {
-      cancel();
+      controller.abort();
     }
   };
-  addEventListener("keydown", handleCancel);
+  addEventListener("keydown", cancel);
 
   // Allow pause and resume
   let isPaused = false;
   const pause = () => {
     isPaused = true;
-    if (onPause) {
-      onPause();
-    }
   };
   const resume = () => {
     isPaused = false;
-    if (onResume) {
-      onResume();
-    }
   };
   const togglePause = () => {
-    if (isPaused) {
-      resume();
-    } else {
-      pause();
-    }
+    isPaused = !isPaused;
   };
 
   const chatOpenAI = new ChatOpenAI({
@@ -129,7 +114,7 @@ export const chatWithOpenAI = (messages: ChatCraftMessage[], options: ChatOption
       }
     })
     .finally(() => {
-      removeEventListener("keydown", handleCancel);
+      removeEventListener("keydown", cancel);
     });
 
   return {

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,4 +1,9 @@
+import { ChatOpenAI } from "langchain/chat_models/openai";
+
+import { chatWithOpenAI } from "../lib/ai";
 import { ChatCraftChat, SerializedChatCraftChat } from "./ChatCraftChat";
+import { ChatCraftHumanMessage, ChatCraftSystemMessage } from "./ChatCraftMessage";
+import { ChatCraftModel } from "./ChatCraftModel";
 
 export function createShareUrl(chat: ChatCraftChat, user: User) {
   // Create a share URL we can give to other people
@@ -37,6 +42,27 @@ export async function loadShare(user: string, id: string) {
 
   const serialized: SerializedChatCraftChat = await res.json();
   return ChatCraftChat.fromJSON(serialized);
+}
+
+export async function summarizeChat(chat: ChatCraftChat) {
+  const systemChatMessage = new ChatCraftSystemMessage({
+    text: "You are an expert at writing short summaries.",
+  });
+
+  const summarizeInstruction = new ChatCraftHumanMessage({
+    text: `Summarize this chat in 25 words or fewer. Respond only with the summary text and focus on the main content, not mentioning the process or participants. For example: "Using a React context and hook to keep track of user state after login."`,
+  });
+
+  try {
+    const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: false });
+    const text = await chatWithOpenAI([systemChatMessage, ...messages, summarizeInstruction], {
+      model: new ChatCraftModel("gpt-3.5-turbo", "OpenAI"),
+    }).promise;
+    return text.trim();
+  } catch (err) {
+    console.error("Error summarizing chat", err);
+    throw err;
+  }
 }
 
 export async function deleteShare(user: User, chatId: string) {


### PR DESCRIPTION
Reverts tarasglek/chatcraft.org#155

This caused
```
> chatcraft.org@0.0.0 build /Users/taras/Documents/chatcraft.org
> tsc && vite build

src/components/Message/MessageBase.tsx:157:17 - error TS2540: Cannot assign to 'text' because it is a read-only property.

157         message.text = text;
                    ~~~~

src/components/Message/NewMessage.tsx:17:8 - error TS2739: Type '{ key: string; message: ChatCraftAiMessage; chatId: string; isLoading: true; heading: string; }' is missing the following properties from type 'Omit<MessageBaseProps, "message" | "avatar">': editing, onEditingChange

17       <OpenAiMessage
          ~~~~~~~~~~~~~

src/lib/ChatCraftMessage.ts:194:10 - error TS2540: Cannot assign to 'text' because it is a read-only property.

194     this.text = text;
             ~~~~


Found 3 errors in 3 files.

Errors  Files
     1  src/components/Message/MessageBase.tsx:157
     1  src/components/Message/NewMessage.tsx:17
     1  src/lib/ChatCraftMessage.ts:194
 ELIFECYCLE  Command failed with exit code 2.
 ```