### PR TITLE
Fix-up main

### DIFF
--- a/src/components/Message/NewMessage.tsx
+++ b/src/components/Message/NewMessage.tsx
@@ -18,6 +18,8 @@ function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewM
         key={message.id}
         message={message}
         chatId={chatId}
+        editing={false}
+        onEditingChange={/* ignore editing changes while streaming new response */ () => {}}
         isLoading
         heading={message.model.prettyModel}
       />


### PR DESCRIPTION
I've re-applied the change from #155 and fixed the build failure.

This reverts commit 2d25e0b602ad527c6898db84159b9eea0b1bbf95.
Revert "Refactor ai chat code to use single codepath"
This reverts commit 43561ed748c045246f58ae5999907846e92f4aba.
Refactor ai chat code to use single codepath
Use one code path for all AI calls
Deal with editing/onEditingChange in NewMessage.tsx