### PR TITLE
Model validation in prefs modal, better model/provider handling

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -29,7 +29,6 @@ import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { useSettings } from "../hooks/use-settings";
 import { ChatCraftHumanMessage, ChatCraftSystemMessage } from "../lib/ChatCraftMessage";
 import useChatOpenAI from "../hooks/use-chat-openai";
-import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 type AuthenticatedForm = {
   chat: ChatCraftChat;
@@ -75,10 +74,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
       try {
         // TODO: this can fail if the chat is too long for gpt-3.5-turbo.
         // callChatApi() should use a sliding context window
-        const { text } = await callChatApi(
-          [systemChatMessage, ...messages, summarizeInstruction],
-          new ChatCraftModel("gpt-3.5-turbo", "OpenAI")
-        );
+        const { text } = await callChatApi([systemChatMessage, ...messages, summarizeInstruction]);
         return text.trim();
       } catch (err) {
         console.error("Error summarizing chat", err);

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -28,8 +28,8 @@ function useChatOpenAI() {
   }, [paused]);
 
   const callChatApi = useCallback(
-    (messages: ChatCraftMessage[], model?: ChatCraftModel) => {
-      const aiMessage = new ChatCraftAiMessage({ model: model ?? settings.model, text: "" });
+    (messages: ChatCraftMessage[], model: ChatCraftModel = settings.model) => {
+      const aiMessage = new ChatCraftAiMessage({ model, text: "" });
       setStreamingMessage(aiMessage);
 
       const chat = chatWithLLM(messages, {

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -2,7 +2,7 @@ import { nanoid } from "nanoid";
 import { AIMessage, HumanMessage, SystemMessage, type MessageType } from "langchain/schema";
 import db, { type ChatCraftMessageTable } from "./db";
 import { ChatCraftModel } from "./ChatCraftModel";
-import { countTokens } from "./ai";
+import { countTokens, defaultModelForProvider } from "./ai";
 
 export class ChatCraftAiMessageVersion {
   id: string;
@@ -264,7 +264,7 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
     return new ChatCraftAiMessage({
       id: message.id,
       date: new Date(message.date),
-      model: new ChatCraftModel(message.model || "gpt-3.5-turbo"),
+      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
       text: message.text,
       versions: message.versions?.map(
         (version) =>
@@ -282,7 +282,7 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
     return new ChatCraftAiMessage({
       id: message.id,
       date: message.date,
-      model: new ChatCraftModel(message.model || "gpt-3.5-turbo"),
+      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
       text: message.text,
       versions: message.versions?.map(
         (version) =>

--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -1,41 +1,40 @@
 export class ChatCraftModel {
-  private modelId: string;
-  private owner: string;
+  id: string;
+  vendor: string;
+  name: string;
 
   /**
-   * @param model The model. If the format is `vendor/model` (eg `OpenAI/gpt-3.5-turbo-16k`)
-   * then the vendor is extracted from the ID
-   * @param vendor Optional vendor name. Used if model name does not have explicit `vendor/*`
+   * @param model The model's name. Different providers give this in different
+   * formats. OpenAI uses `gpt-3.5-turbo` with no vendor info, while OpenRouter.ai
+   * uses `openai/gpt-3.5-turbo` (i.e., with vendor/* prefix).
    */
-  constructor(model: string, vendor?: string) {
-    this.modelId = model;
-    if (vendor) {
-      this.owner = vendor;
-    } else {
-      this.owner = "";
-    }
+  constructor(model: string) {
+    this.id = model;
+    const parts = model.split("/");
+    // Default to "openai" if we don't get a vendor name
+    this.vendor = parts.length > 1 ? parts[0] : "openai";
+    // If we get a vendor, use the second part, otherwise the whole thing is the model name
+    this.name = parts.length > 1 ? parts[1] : parts[0];
   }
 
   get logoUrl() {
-    const owner = this.owner.toLowerCase();
-    const model = this.modelId.toLowerCase();
+    const vendor = this.vendor;
 
-    if (owner === "openai" || model.startsWith("openai/")) {
+    if (vendor === "openai") {
       return "/openai-logo.png";
     }
 
-    if (owner === "anthropic" || model.startsWith("anthropic/")) {
+    if (vendor === "anthropic") {
       return "/anthropic-logo.png";
     }
 
-    // Google has Palm and Bard, but only currently have access to Palm
-    if (model.startsWith("google/palm")) {
+    if (vendor === "google") {
       return "/palm-logo.png";
     }
 
     // Use the Hugging Face logo, since it's hosted there
     // https://huggingface.co/tiiuae/falcon-40b
-    if (model.startsWith("tiiuae/")) {
+    if (vendor === "tiiuae") {
       return "/hugging-face-logo.png";
     }
 
@@ -43,32 +42,19 @@ export class ChatCraftModel {
     return "/openai-logo.png";
   }
 
-  get id() {
-    return this.modelId;
-  }
-
-  get vendor() {
-    return this.owner;
-  }
-
   get prettyModel(): string {
-    let modelName = this.modelId;
-    if (modelName.includes("/")) {
-      modelName = modelName.split("/")[1];
+    if (this.name.startsWith("gpt-3.5-turbo")) {
+      return this.name.replace("gpt-3.5-turbo", "chat-gpt");
     }
 
-    if (modelName.startsWith("gpt-3.5-turbo")) {
-      return modelName.replace("gpt-3.5-turbo", "chat-gpt");
-    }
-
-    return modelName;
+    return this.name;
   }
 
   toString() {
-    return this.modelId;
+    return this.id;
   }
 
   toJSON() {
-    return this.modelId;
+    return this.id;
   }
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -10,6 +10,17 @@ import { getReferer } from "./utils";
 
 const usingOfficialOpenAI = () => getSettings().apiUrl === OPENAI_API_URL;
 
+// Each provider does their model naming differently, pick the right one
+export const defaultModelForProvider = () => {
+  // OpenAI
+  if (usingOfficialOpenAI()) {
+    return new ChatCraftModel("gpt-3.5-turbo");
+  }
+
+  // OpenRouter.ai
+  return new ChatCraftModel("openai/gpt-3.5-turbo");
+};
+
 export type ChatOptions = {
   model?: ChatCraftModel;
   temperature?: number;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,7 +6,6 @@
  * when you only need to read something.
  */
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
@@ -25,7 +24,7 @@ export type Settings = {
 };
 
 export const defaults: Settings = {
-  model: new ChatCraftModel("gpt-3.5-turbo", "OpenAI"),
+  model: new ChatCraftModel("gpt-3.5-turbo"),
   apiUrl: OPENAI_API_URL,
   enterBehaviour: "send",
   // Disabled by default, since token parsing requires downloading larger deps


### PR DESCRIPTION
This updates our Preferences modal to properly handle changes to the API Key.  It uses no "save" button (you're welcome, @tarasglek), and debounces changes on the input instead.  One issue I ran into is that the models API endpoint for OpenRouter.ai does NOT require an api key (i.e., it always works, so this won't tell us if your key is working or not).

I've also fixed the `useModels()` hook to update whenever the `apiKey` or `apiUrl` are changed.

Doing this work, I've realized that OpenAI and OpenRouter have different model names: OpenRouter includes a vendor `openai/*` and OpenAI does not.  This means switching providers is a bit hairy, since you have to also change the default model, which I've done.

We could do more work to separate how we store the model (without vendor) and how we provide it for the model, depending on the provider.  But I think this is a big edge case we can fix if/when necessary.