### PR TITLE
WIP: add bun + mem tracking to support free replit nodes

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,12 +1,5 @@
-run = "vite --host 0.0.0.0"
+run = "bun --bun vite dev --host 0.0.0.0"
 hidden = [".build", ".config", "package-lock.json", "tsconfig.json"]
-
-[packager]
-language = "nodejs"
-  [packager.features]
-  enabledForHosting = false
-  packageSearch = true
-  guessImports = true
 
 [nix]
 channel = "stable-22_11"
@@ -26,4 +19,4 @@ requiredFiles = [".replit", "replit.nix", ".config"]
     start = "typescript-language-server --stdio"
 
 [deployment]
-run = ["sh", "-c", "vite --host 0.0.0.0"]
+run = ["sh", "-c", "bun --bun vite dev --host 0.0.0.0"]

--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-run = "bun"
+run = "(which bun || npm install -g bun) && bun install && bun run dev-bun"
 hidden = [".build", ".config", "package-lock.json", "tsconfig.json"]
 
 [nix]
@@ -7,16 +7,11 @@ channel = "stable-22_11"
 [env]
 XDG_CONFIG_HOME = "$REPL_HOME/.config"
 PATH = "$REPL_HOME/node_modules/.bin:$REPL_HOME/.config/npm/node_global/bin"
-npm_config_prefix = "$REPL_HOME/.config/npm/node_global"
+# npm_config_prefix = "$REPL_HOME/.config/npm/node_global"
 
 [gitHubImport]
 requiredFiles = [".replit", "replit.nix", ".config"]
 
-[languages]
-  [languages.typescript]
-  pattern = "**/{*.ts,*.js,*.tsx,*.jsx,*.json}"
-    [languages.typescript.languageServer]
-    start = "typescript-language-server --stdio"
 
 [deployment]
 run = ["sh", "-c", "npm run dev-bun"]

--- a/.replit
+++ b/.replit
@@ -1,4 +1,4 @@
-run = "bun --bun vite dev --host 0.0.0.0"
+run = "bun"
 hidden = [".build", ".config", "package-lock.json", "tsconfig.json"]
 
 [nix]
@@ -19,4 +19,4 @@ requiredFiles = [".replit", "replit.nix", ".config"]
     start = "typescript-language-server --stdio"
 
 [deployment]
-run = ["sh", "-c", "bun --bun vite dev --host 0.0.0.0"]
+run = ["sh", "-c", "npm run dev-bun"]

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "audit-fix": "yarn-audit-fix",
     "dev": "vite",
+    "dev-bun": "bun --bun vite dev --host 0.0.0.0",
     "dev-functions": "wrangler pages dev -- npm run dev",
     "build": "tsc && vite build",
     "build-bun": "bun bun src/main.tsx --target browser  --smol --outdir build/",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",
+    "bun": "^0.7.0",
     "eslint": "^8.45.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-import": "^2.27.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "dev-functions": "wrangler pages dev -- npm run dev",
     "build": "tsc && vite build",
+    "build-bun": "bun bun src/main.tsx --target browser  --smol --outdir build/",
     "preview": "vite preview",
     "prepare": "husky install",
     "lint": "eslint . --ext .ts,.tsx,.js",

--- a/replit.nix
+++ b/replit.nix
@@ -4,8 +4,8 @@
         pkgs.esbuild
         pkgs.nodejs-18_x
 
-        pkgs.nodePackages.typescript
-        pkgs.nodePackages.typescript-language-server
         pkgs.miniserve
+        pkgs.bun
+        pkgs.time
     ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -5,5 +5,6 @@
 
         pkgs.miniserve
         pkgs.time
+        pkgs.pstree
     ];
 }

--- a/replit.nix
+++ b/replit.nix
@@ -1,11 +1,9 @@
 { pkgs }: {
     deps = [
-        pkgs.yarn
         pkgs.esbuild
         pkgs.nodejs-18_x
 
         pkgs.miniserve
-        pkgs.bun
         pkgs.time
     ];
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -5,7 +5,7 @@ import { ChatCraftMessage } from "./ChatCraftMessage";
 import { ChatCraftModel } from "./ChatCraftModel";
 import { getSettings, OPENAI_API_URL } from "./settings";
 
-import type { Tiktoken } from "tiktoken/lite";
+// import type { Tiktoken } from "tiktoken/lite";
 import { getReferer } from "./utils";
 
 const usingOfficialOpenAI = () => getSettings().apiUrl === OPENAI_API_URL;
@@ -208,24 +208,12 @@ export async function validateOpenAiApiKey(apiKey: string) {
 }
 
 // Cache this instance on first use
-let encoding: Tiktoken;
+// let encoding: Tiktoken;
 
 // TODO: If we're using OpenRouter, we have to alter our token counting logic for other models...
-export const countTokens = async (text: string) => {
-  if (!encoding) {
-    // Warn if this happens when it shouldn't. The UI should only
-    // be calling `countTokens()` if we have the setting enabled
-    if (!getSettings().countTokens) {
-      console.trace("Unexpected call to countTokens() when settings.countTokens not set");
-    }
-
-    // We don't bundle these, but load them dynamically at runtime if needed due to size
-    const { Tiktoken } = await import("tiktoken/lite");
-    const cl100k_base = await import("tiktoken/encoders/cl100k_base.json");
-    encoding = new Tiktoken(cl100k_base.bpe_ranks, cl100k_base.special_tokens, cl100k_base.pat_str);
-  }
-
-  return encoding.encode(text).length;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const countTokens = async (_text: string) => {
+  return 0;
 };
 
 export const countTokensInMessages = async (messages: ChatCraftMessage[]) => {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,71 +10,16 @@ import { join } from "node:path";
 // It includes 180+ languages defined as .js files.  We only want to pre-cache
 // some of these in our service worker.  See full list in:
 // https://github.com/react-syntax-highlighter/react-syntax-highlighter/tree/master/src/languages/hljs
-const languagesDir = "node_modules/react-syntax-highlighter/dist/esm/languages/hljs";
-const includedLanguages = ["css.js", "javascript.js", "typescript.js", "python.js"];
 
 // bash.js -> assets/bash-*.js
-const filenameToGlob = (prefix: string, filename: string) => {
-  const [basename, extname] = filename.split(".");
-  return join(prefix, `${basename}-*.${extname}`);
-};
 
 // Language glob patterns to include
-function buildLanguageGlobPatterns(prefix: string) {
-  return includedLanguages.map((filename) => filenameToGlob(prefix, filename));
-}
 
 // Language glob patterns to exclude
-function buildLanguageIgnoreGlobPatterns(prefix: string) {
-  const languageFiles = readdirSync(languagesDir);
-
-  // Turn ['bash.js', ...] into ['assets/bash-*.js', ...]
-  // filtering out the languages we want to bundle.
-  return languageFiles
-    .filter((filename) => !includedLanguages.includes(filename))
-    .map((filename) => filenameToGlob(prefix, filename));
-}
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    wasm(),
-    // https://vite-pwa-org.netlify.app/guide/
-    VitePWA({
-      registerType: "autoUpdate",
-      manifest: {
-        name: "ChatCraft.org",
-        short_name: "ChatCraft",
-        icons: [
-          { src: "/android-chrome-192x192.png", sizes: "192x192", type: "image/png" },
-          {
-            src: "/android-chrome-512x512.png",
-            sizes: "512x512",
-            type: "image/png",
-            purpose: "any maskable",
-          },
-        ],
-        theme_color: "#ffffff",
-        background_color: "#ffffff",
-        display: "standalone",
-      },
-      workbox: {
-        globIgnores: [
-          // Ignore all languages we don't explicitly include as part of `includedLanguages`
-          ...buildLanguageIgnoreGlobPatterns("**/assets/"),
-          // Ignore large tiktoken assets (load them at runtime if needed)
-          "**/assets/tiktoken-*.js",
-          "**/assets/cl100k_base*.js",
-        ],
-        globPatterns: [
-          "*.{ico,png}",
-          "**/assets/*.{js,json,css,ico,png,svg}",
-          ...buildLanguageGlobPatterns("**/assets/"),
-        ],
-      },
-    }),
-  ],
+  plugins: [react()],
   build: {
     chunkSizeWarningLimit: 2000,
     outDir: "build",


### PR DESCRIPTION
I noticed that bun is a lot faster and can use less ram than vite.
### vite
```bash
`which time` -v pnpm vite build
```
Results in
```
User time (seconds): 27.39
Maximum resident set size (kbytes): 2172708
```
Which is over the replit 1gb limit

### bun
```bash
`which time` -v pnpm build-bun
```
Whereas bun(without minification) gets us down to 800mb
```
User time (seconds): 0.96
Maximum resident set size (kbytes): 798232
```

Downside is that bun doesn't produce a working site yet

This is pretty hopeless to get to work with bun directly. bun is too immature, they announced vite support in latest release.