### PR TITLE
Use GitHub login name if user's name is missing

### DIFF
--- a/functions/github.ts
+++ b/functions/github.ts
@@ -47,9 +47,9 @@ export async function requestUserInfo(token: string): Promise<User> {
 
   const { login, name, avatar_url } = (await res.json()) as {
     login: string;
-    name: string;
+    name: string | null;
     avatar_url: string;
   };
 
-  return { username: login, name, avatarUrl: avatar_url };
+  return { username: login, name: name ?? login, avatarUrl: avatar_url };
 }

--- a/src/hooks/use-user.tsx
+++ b/src/hooks/use-user.tsx
@@ -52,6 +52,12 @@ export const UserProvider: FC<{ children: ReactNode }> = ({ children }) => {
         typeof avatarUrl === "string"
       ) {
         setUser({ username, name, avatarUrl });
+      } else {
+        console.warn("ChatCraft ID Token missing expected values, ignoring", {
+          username,
+          name,
+          avatarUrl,
+        });
       }
     } catch (err) {
       console.error("Unable to decode id token", { err, idToken });


### PR DESCRIPTION
Fixes #175 

@steven4354 and I figured out that an account on GitHub may or may not include a user's name (it's optional).  What that happens, and we don't find a name in the cookie, we fail to use the data.

This fixes things so we re-use the GitHub login if the name.

I've also added a warning in the user context/hook, so we know if this happens again. 