### PR TITLE
Add errorElement with better fatal error UX

### DIFF
--- a/src/AppError.tsx
+++ b/src/AppError.tsx
@@ -1,0 +1,97 @@
+import {
+  Flex,
+  Grid,
+  GridItem,
+  Heading,
+  Center,
+  Card,
+  CardBody,
+  CardHeader,
+  Text,
+  Container,
+  Icon,
+  CardFooter,
+  Button,
+  Box,
+  Code,
+} from "@chakra-ui/react";
+import { MdErrorOutline } from "react-icons/md";
+
+import Header from "./components/Header";
+import { useRouteError } from "react-router-dom";
+
+export default function AppError() {
+  const err = useRouteError() as any;
+  console.error(err);
+
+  return (
+    <Grid
+      w="100%"
+      h="100%"
+      gridTemplateRows="min-content 1fr"
+      gridTemplateColumns="1fr"
+      bgGradient="linear(to-b, white, gray.100)"
+      _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
+    >
+      <GridItem colSpan={2}>
+        <Header searchText={""} onToggleSidebar={() => {}} />
+      </GridItem>
+
+      <GridItem>
+        <Flex direction="column" h="100%" maxH="100%" px={1}>
+          <Center h="100%">
+            <Card size="md">
+              <CardHeader>
+                <Flex align="center" gap={2} ml={4}>
+                  <Icon as={MdErrorOutline} boxSize={5} />
+                  <Heading as="h2" size="md">
+                    Error
+                  </Heading>
+                </Flex>
+              </CardHeader>
+              <CardBody>
+                <Container>
+                  <Flex direction="column" gap={4}>
+                    <Code colorScheme="gray" variant="outline">
+                      {err ? err.toString() : "Unknown Error"}
+                    </Code>
+                    <Text>
+                      Please <strong>close all other ChatCraft tabs and refresh</strong>.
+                    </Text>
+                    <Text>
+                      If the problem persists,{" "}
+                      <a
+                        href="https://github.com/tarasglek/chatcraft.org"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="GitHub Repository"
+                        title="GitHub Repository"
+                        style={{ textDecoration: "underline" }}
+                      >
+                        file an issue
+                      </a>{" "}
+                      so we can investigate further. See the DevTools Console for more error info.
+                    </Text>
+                  </Flex>
+                </Container>
+              </CardBody>
+              <CardFooter>
+                <Box w="100%" textAlign="right">
+                  <Button
+                    colorScheme="red"
+                    size="sm"
+                    onClick={() => {
+                      location.href = "/";
+                    }}
+                  >
+                    Refresh
+                  </Button>
+                </Box>
+              </CardFooter>
+            </Card>
+          </Center>
+        </Flex>
+      </GridItem>
+    </Grid>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,7 +28,7 @@ import { useUser } from "../hooks/use-user";
 
 type HeaderProps = {
   chatId?: string;
-  inputPromptRef: RefObject<HTMLTextAreaElement>;
+  inputPromptRef?: RefObject<HTMLTextAreaElement>;
   searchText?: string;
   onToggleSidebar: () => void;
 };

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -48,7 +48,7 @@ async function isStoragePersisted() {
 type PreferencesModalProps = {
   isOpen: boolean;
   onClose: () => void;
-  finalFocusRef: RefObject<HTMLTextAreaElement>;
+  finalFocusRef?: RefObject<HTMLTextAreaElement>;
 };
 
 function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalProps) {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,6 +7,7 @@ import Search, { loader as searchLoader } from "./Search";
 import db from "./lib/db";
 import { ChatCraftFunction, initialFunctionCode } from "./lib/ChatCraftFunction";
 import Function from "./Function";
+import AppError from "./AppError";
 
 export default createBrowserRouter([
   // Load the user's most recent chat, or start a new one the first time
@@ -24,6 +25,7 @@ export default createBrowserRouter([
 
       return redirect("/new");
     },
+    errorElement: <AppError />,
   },
   // Create a new chat
   {
@@ -33,6 +35,16 @@ export default createBrowserRouter([
       await chat.save();
       return redirect(`/c/${chat.id}`);
     },
+    errorElement: <AppError />,
+  },
+  {
+    path: "/c/new",
+    async loader() {
+      const chat = new ChatCraftChat();
+      await chat.save();
+      return redirect(`/c/${chat.id}`);
+    },
+    errorElement: <AppError />,
   },
 
   // People shouldn't end-up here, so create a new chat if they do
@@ -58,6 +70,7 @@ export default createBrowserRouter([
       return id;
     },
     element: <LocalChat />,
+    errorElement: <AppError />,
   },
   // Delete a chat from the local db
   {
@@ -123,6 +136,7 @@ export default createBrowserRouter([
 
       return redirect(`/c/${forked.id}`);
     },
+    errorElement: <AppError />,
   },
 
   // Loading a shared chat remotely as JSON, which will be readonly
@@ -142,6 +156,7 @@ export default createBrowserRouter([
       }
     },
     element: <RemoteChat />,
+    errorElement: <AppError />,
   },
 
   // Fork a remote chat into the local db
@@ -185,6 +200,7 @@ export default createBrowserRouter([
 
       return redirect(`/c/${forked.id}`);
     },
+    errorElement: <AppError />,
   },
 
   // Search. Process `GET /s?q=...` and return results
@@ -192,6 +208,7 @@ export default createBrowserRouter([
     path: "/s",
     loader: searchLoader,
     element: <Search />,
+    errorElement: <AppError />,
   },
 
   // Functions
@@ -202,11 +219,13 @@ export default createBrowserRouter([
       await func.save();
       return redirect(`/f/${func.id}`);
     },
+    errorElement: <AppError />,
   },
   // People shouldn't end-up here, so create a new function if they do
   {
     path: "/f",
     element: <Navigate to="/f/new" />,
+    errorElement: <AppError />,
   },
   // Load a function from the local db, making sure it exists first
   {
@@ -223,6 +242,7 @@ export default createBrowserRouter([
       return id;
     },
     element: <Function />,
+    errorElement: <AppError />,
   },
   // Delete a function from the local db
   {


### PR DESCRIPTION
Fixes #181
Fixes #149 

This adds top-level error handling via [`errorElement` in React Router](https://reactrouter.com/en/main/route/error-element).  If our routes fail, we'll show better error UI.

The vast majority of errors are handled, and those that aren't are likely show-stoppers (e.g., database not accessible for some reason).

In the case of database connection issues, closing other tabs and reloading should fix.

<img width="980" alt="Screenshot 2023-07-27 at 12 09 22 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/6315d489-8b2f-413e-bff4-84b92a20d5d8">

In the example above, you can see that my db won't open locally because it's version is newer than the one it wants to use on my current branch (i.e., I ran a migration on another branch).  This is an example of what a db error would look like.