### PR TITLE
Handle sending function results back to LLM in UI

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -112,13 +112,15 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   // Handle prompt form submission
   const onPrompt = useCallback(
-    async (prompt: string) => {
+    async (prompt?: string) => {
       setShouldAutoScroll(true);
       setLoading(true);
 
       try {
-        // Add this prompt message to the chat
-        await chat.addMessage(new ChatCraftHumanMessage({ text: prompt, user }));
+        if (prompt) {
+          // Add this prompt message to the chat
+          await chat.addMessage(new ChatCraftHumanMessage({ text: prompt, user }));
+        }
 
         // In single-message-mode, trim messages to last few. Otherwise send all.
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
@@ -152,6 +154,11 @@ function ChatBase({ chat }: ChatBaseProps) {
           const result = await func.invoke(response.func.params);
           // Add this result message to the chat
           await chat.addMessage(result);
+
+          // If the user has opted to always send function results back to LLM, do it now
+          if (settings.alwaysSendFunctionResult) {
+            onPrompt();
+          }
         }
       } catch (err: any) {
         toast({
@@ -167,6 +174,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         setShouldAutoScroll(true);
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [user, chat, singleMessageMode, setLoading, setShouldAutoScroll, callChatApi, toast]
   );
 

--- a/src/components/Message/FunctionResultMessage.tsx
+++ b/src/components/Message/FunctionResultMessage.tsx
@@ -1,19 +1,21 @@
 import { memo } from "react";
 
-import { Avatar } from "@chakra-ui/react";
+import { Avatar, Button, Checkbox, Flex, Text } from "@chakra-ui/react";
 import { LuFunctionSquare } from "react-icons/lu";
 
 import MessageBase, { type MessageBaseProps } from "./MessageBase";
 import { formatFunctionName } from "../../lib/ChatCraftFunction";
 import { ChatCraftFunctionResultMessage } from "../../lib/ChatCraftMessage";
+import { useSettings } from "../../hooks/use-settings";
 
 type FunctionMessageProps = Omit<MessageBaseProps, "avatar" | "message"> & {
   message: ChatCraftFunctionResultMessage;
 };
 
 function FunctionResultMessage(props: FunctionMessageProps) {
-  const { message, ...rest } = props;
+  const { message, onPrompt, ...rest } = props;
   const functionName = formatFunctionName(message.func.id, message.func.name);
+  const { settings, setSettings } = useSettings();
 
   const avatar = (
     <Avatar
@@ -23,11 +25,34 @@ function FunctionResultMessage(props: FunctionMessageProps) {
       title={functionName}
     />
   );
+
+  const footer = onPrompt && (
+    <Flex justify="space-between" w="100%">
+      <Text fontSize="sm">Send result for processing</Text>
+
+      <Flex gap={2} align="center">
+        <Checkbox
+          isChecked={settings.alwaysSendFunctionResult}
+          onChange={(e) => setSettings({ ...settings, alwaysSendFunctionResult: e.target.checked })}
+          size="sm"
+        >
+          Always send
+        </Checkbox>
+        {!settings.alwaysSendFunctionResult && (
+          <Button size="xs" onClick={() => onPrompt()}>
+            Send
+          </Button>
+        )}
+      </Flex>
+    </Flex>
+  );
+
   return (
     <MessageBase
       {...rest}
       message={message}
       avatar={avatar}
+      footer={footer}
       heading={`Result: ${functionName}`}
       disableFork={true}
       disableEdit={true}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -55,7 +55,7 @@ export interface MessageBaseProps {
   footer?: ReactNode;
   isLoading: boolean;
   hidePreviews?: boolean;
-  onPrompt?: (prompt: string) => void;
+  onPrompt?: (prompt?: string) => void;
   onDeleteClick?: () => void;
   onRetryClick?: (model: ChatCraftModel) => void;
   disableFork?: boolean;

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -20,7 +20,7 @@ type MessageProps = {
   chatId: string;
   isLoading: boolean;
   hidePreviews?: boolean;
-  onPrompt?: (prompt: string) => void;
+  onPrompt?: (prompt?: string) => void;
   onDeleteClick?: () => void;
   disableFork?: boolean;
   disableEdit?: boolean;

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -22,7 +22,7 @@ type MessagesViewProps = {
   isPaused: boolean;
   onTogglePause: () => void;
   onCancel: () => void;
-  onPrompt: (prompt: string) => void;
+  onPrompt: (prompt?: string) => void;
 };
 
 function MessagesView({

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -647,9 +647,11 @@ export class ChatCraftFunctionResultMessage extends ChatCraftMessage {
   }
 
   toLangChainMessage() {
-    const { name, result } = this.func;
+    // LangChain needs a string, so send the text vs. raw func.result value
+    const { text } = this;
+    const { name } = this.func;
 
-    return new FunctionMessage(result, name);
+    return new FunctionMessage(text, name);
   }
 
   static fromJSON(message: SerializedChatCraftMessage) {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -21,6 +21,7 @@ export type Settings = {
   justShowMeTheCode: boolean;
   countTokens: boolean;
   sidebarVisible: boolean;
+  alwaysSendFunctionResult: boolean;
 };
 
 export const defaults: Settings = {
@@ -31,6 +32,8 @@ export const defaults: Settings = {
   countTokens: false,
   justShowMeTheCode: false,
   sidebarVisible: false,
+  // Disabled by default, so we don't waste tokens
+  alwaysSendFunctionResult: false,
 };
 
 export const key = "settings";


### PR DESCRIPTION
Fixes #184 

When a function result comes back, we need a way to send it to the LLM for further processing (e.g., if result is part of a larger discussion, and we need to continue).  This adds UI in a function result message to allow sending the result back to the LLM.

Users can either manually send, or specify that results should always be sent.  Their preference is remembered.

### User must manually click "Send" by default
<img width="947" alt="Screenshot 2023-07-29 at 7 34 06 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/14e62aae-f0f7-4dca-9416-02ee6a368e1c">

### Checking "Always Send" does it automatically
<img width="948" alt="Screenshot 2023-07-29 at 7 33 57 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/dd2bd8b4-5478-433d-bcd2-8d32d467197a">

I wonder if the preference to "Always Send" should be true by default, which would mimic what OpenAI docs do for function calling.  I think OpenAI imagines that function calls/results are internal to an app vs. something you display (I like that we display it, just reflecting on what they do).