### PR TITLE
Tell LLM to use function if mentioned in prompt

### DIFF
--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -38,7 +38,12 @@ function useChatOpenAI() {
       {
         model = settings.model,
         functions,
-      }: { model?: ChatCraftModel; functions?: ChatCraftFunction[] } = {}
+        functionToCall,
+      }: {
+        model?: ChatCraftModel;
+        functions?: ChatCraftFunction[];
+        functionToCall?: ChatCraftFunction;
+      } = {}
     ) => {
       // When we're streaming, use this message to hold the content as it comes.
       // Later we'll replace it with the full response.
@@ -48,6 +53,7 @@ function useChatOpenAI() {
       const chat = chatWithLLM(messages, {
         model,
         functions,
+        functionToCall,
         onPause() {
           setPaused(true);
         },

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -10,6 +10,7 @@ import {
 import db, { type ChatCraftMessageTable } from "./db";
 import { ChatCraftModel } from "./ChatCraftModel";
 import { countTokens, defaultModelForProvider } from "./ai";
+import { loadFunctions, parseFunctionNames } from "./ChatCraftFunction";
 
 export class ChatCraftAiMessageVersion {
   id: string;
@@ -360,6 +361,16 @@ export class ChatCraftHumanMessage extends ChatCraftMessage {
       text: this.text,
       user: this.user,
     };
+  }
+
+  // Get a list of functions mentioned via @fn or fn-url from db or remote servers
+  async functions() {
+    // Extract all unique function names/urls from the message's text
+    const fnNames: Set<string> = new Set();
+    parseFunctionNames(this.text).forEach((fnName) => fnNames.add(fnName));
+
+    // Load all functions by name/url into ChatCraftFunction objects
+    return loadFunctions([...fnNames]);
   }
 
   static fromJSON(message: SerializedChatCraftMessage) {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -29,6 +29,7 @@ export const defaultModelForProvider = () => {
 export type ChatOptions = {
   model?: ChatCraftModel;
   functions?: ChatCraftFunction[];
+  functionToCall?: ChatCraftFunction;
   respondWithText?: boolean;
   temperature?: number;
   onFinish?: (message: ChatCraftAiMessage | ChatCraftFunctionCallMessage) => void;
@@ -86,6 +87,7 @@ export const chatWithLLM = (messages: ChatCraftMessage[], options: ChatOptions =
     temperature,
     model = getSettings().model,
     functions,
+    functionToCall,
   } = options;
 
   // Allow the stream to be cancelled
@@ -181,6 +183,16 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
         functions:
           model.supportsFunctionCalling && functions
             ? functions.map((fn) => fn.toLangChainFunction())
+            : undefined,
+        /**
+         * If function(s) are provided, see if the caller wants a particular
+         * function to be called by name.  If not, let the LLM decide ("auto").
+         */
+        function_call:
+          model.supportsFunctionCalling && functions
+            ? functionToCall?.name
+              ? { name: functionToCall.name }
+              : "auto"
             : undefined,
       },
       CallbackManager.fromHandlers({


### PR DESCRIPTION
Fixes #185
Fixes #177 

When a chat includes functions (`fn` or `fn-url`), we send those functions to the LLM.  Previously, we let the LLM decide whether or not to call a function.  However, this PR changes things so that if a user explicitly mentions a **single** function in the current prompt, we ask the LLM to use it.  If previous messages, or the system prompt, included functions, we still let it decide.

In this example you can see that the LLM doesn't actually need a function to answer `1+1`.  However, when I mention the `sum` function in the prompt, it uses it.

<img width="1082" alt="Screenshot 2023-07-29 at 8 39 30 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/8f6cc02a-89ea-4a83-995b-7bf2fb3dabe3">

NOTE: this code needs to land after my earlier PRs, since I fixed some bugs that this exposes.