### PR TITLE
Debounce function editor typing/saving for better UX

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "framer-motion": "^10.12.21",
     "jose": "^4.14.4",
     "langchain": "^0.0.114",
+    "lodash": "^4.17.21",
     "mermaid": "^10.2.4",
     "nanoid": "^4.0.2",
     "react": "^18.2.0",

--- a/src/Function/FunctionEditor.tsx
+++ b/src/Function/FunctionEditor.tsx
@@ -2,15 +2,25 @@ import { Box, useColorMode } from "@chakra-ui/react";
 import CodeMirror from "@uiw/react-codemirror";
 import { javascript } from "@codemirror/lang-javascript";
 import CodeHeader from "../components/CodeHeader";
+import { useState } from "react";
 
 type FunctionEditorProps = {
-  value: string;
+  initialValue: string;
   onChange: (value: string) => void;
   filename?: string;
 };
 
-export default function FunctionEditor({ value, onChange, filename }: FunctionEditorProps) {
+export default function FunctionEditor({ initialValue, onChange, filename }: FunctionEditorProps) {
   const { colorMode } = useColorMode();
+  // Maintain our own version of the code, so typing doesn't depend on db syncing
+  const [value, setValue] = useState(initialValue);
+
+  const handleChange = (value: string) => {
+    // Update view immediately
+    setValue(value);
+    // Parent component can sync to db later (debounced)
+    onChange(value);
+  };
 
   return (
     <Box
@@ -39,7 +49,7 @@ export default function FunctionEditor({ value, onChange, filename }: FunctionEd
             height: "100%",
             marginTop: "-8px",
           }}
-          onChange={onChange}
+          onChange={handleChange}
         />
       </CodeHeader>
     </Box>

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -21,6 +21,7 @@ import {
 import { LuFunctionSquare } from "react-icons/lu";
 import { useFetcher, useLoaderData } from "react-router-dom";
 import { useCopyToClipboard } from "react-use";
+import debounce from "lodash/debounce";
 
 import Header from "../components/Header";
 import Sidebar from "../components/Sidebar";
@@ -63,18 +64,15 @@ export default function Function() {
     return `${func.name}.js`;
   }, [func]);
 
-  const handleCodeChange = async (value: string) => {
+  // Update the function's code in the db, but not on every keystroke
+  const handleSave = debounce((value: string) => {
     if (!func) {
       return;
     }
 
-    try {
-      func.code = value;
-      await func.save();
-    } catch (err) {
-      console.warn(err);
-    }
-  };
+    func.code = value;
+    func.save().catch(console.warn);
+  }, 250);
 
   const handleToggleSidebarVisible = useCallback(() => {
     const newValue = !isSidebarVisible;
@@ -191,8 +189,8 @@ export default function Function() {
               <Card>
                 <CardBody>
                   <FunctionEditor
-                    value={func.code}
-                    onChange={handleCodeChange}
+                    initialValue={func.code}
+                    onChange={handleSave}
                     filename={filename}
                   />
                 </CardBody>


### PR DESCRIPTION
I've noticed that the internal functions editor can lose track of where the cursor should be (e.g., hold down DELETE and it will eventually put the cursor at position 0).  This is happening due to lag in the db saving and getting an updated value to display.

This PR decouples the view state from the backing db state and debounces requests to update the db, while always keeping the view state fast.