### PR TITLE
Show error if function can't be loaded

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -129,14 +129,25 @@ function ChatBase({ chat }: ChatBaseProps) {
         const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: true });
         const messagesToSend = singleMessageMode ? [...messages].slice(-2) : messages;
 
+        // If there's any problem loading referenced functions, show an error
+        const onError = (err: Error) => {
+          toast({
+            title: `Error Loading Function`,
+            description: err.message,
+            status: "error",
+            position: "top",
+            isClosable: true,
+          });
+        };
+
         // If there are any functions mentioned in the chat (via @fn or @fn-url),
         // pass those through to the LLM to use if necessary.
-        const functions = await chat.functions();
+        const functions = await chat.functions(onError);
 
         // If the user has specified a single function in this prompt, ask LLM to call it.
         let functionToCall: ChatCraftFunction | undefined;
         if (promptMessage && functions) {
-          const messageFunctions = await promptMessage.functions();
+          const messageFunctions = await promptMessage.functions(onError);
           if (messageFunctions?.length === 1) {
             functionToCall = messageFunctions[0];
           }

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -105,7 +105,7 @@ export class ChatCraftChat {
   }
 
   // Get a list of functions mentioned via @fn or fn-url from db or remote servers
-  async functions() {
+  async functions(onError?: (err: Error) => void) {
     // We scan the entire set of human and system messages in the chat for functions
     const humanAndSystemMessages = this.messages({
       includeAppMessages: false,
@@ -119,7 +119,7 @@ export class ChatCraftChat {
     }
 
     // Load all functions by name/url into ChatCraftFunction objects
-    return loadFunctions([...fnNames]);
+    return loadFunctions([...fnNames], onError);
   }
 
   async tokens() {

--- a/src/lib/ChatCraftFunction.ts
+++ b/src/lib/ChatCraftFunction.ts
@@ -61,7 +61,7 @@ export const parseFunctionNames = (text: string) => {
  * and parse into ChatCraftFunction objects. Any function that can't be loaded
  * by name/URL will be skipped.
  */
-export const loadFunctions = async (fnNames: string[]) => {
+export const loadFunctions = async (fnNames: string[], onError?: (err: Error) => void) => {
   const fromDb = async (fnNames: string[]) => {
     const records = await db.functions
       .where("name")
@@ -75,6 +75,9 @@ export const loadFunctions = async (fnNames: string[]) => {
       urls.map((url) =>
         ChatCraftFunction.fromUrl(new URL(url)).catch((err) => {
           console.warn(`Unable to load remote function ${url}`, err);
+          if (onError) {
+            onError(new Error(`Unable to load remote function at ${url} (${err.message})`));
+          }
           return undefined;
         })
       )

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -364,13 +364,13 @@ export class ChatCraftHumanMessage extends ChatCraftMessage {
   }
 
   // Get a list of functions mentioned via @fn or fn-url from db or remote servers
-  async functions() {
+  async functions(onError?: (err: Error) => void) {
     // Extract all unique function names/urls from the message's text
     const fnNames: Set<string> = new Set();
     parseFunctionNames(this.text).forEach((fnName) => fnNames.add(fnName));
 
     // Load all functions by name/url into ChatCraftFunction objects
-    return loadFunctions([...fnNames]);
+    return loadFunctions([...fnNames], onError);
   }
 
   static fromJSON(message: SerializedChatCraftMessage) {


### PR DESCRIPTION
Fixes #191 

If a chat references a function URL that can't be loaded/parsed, show an error toast so the user is aware of the problem:

<img width="1185" alt="Screenshot 2023-08-01 at 9 29 59 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/1d2d7aa8-255c-4ee1-bda4-47d8bccabd84">