### PR TITLE
Ability to set and reset default system prompt

### DIFF
--- a/src/components/DefaultSystemPromptModal.tsx
+++ b/src/components/DefaultSystemPromptModal.tsx
@@ -1,0 +1,96 @@
+import { RefObject, useState } from "react";
+import {
+  Button,
+  Flex,
+  FormControl,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalFooter,
+  ModalBody,
+  ModalCloseButton,
+  VStack,
+  Text,
+  Textarea,
+} from "@chakra-ui/react";
+import { debounce } from "lodash";
+
+import { useSettings } from "../hooks/use-settings";
+import { defaultSystemPrompt } from "../lib/system-prompt";
+
+type DefaultSystemPromptModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  finalFocusRef?: RefObject<HTMLTextAreaElement>;
+};
+
+function DefaultSystemPromptModal({
+  isOpen,
+  onClose,
+  finalFocusRef,
+}: DefaultSystemPromptModalProps) {
+  const [prompt, setPrompt] = useState(defaultSystemPrompt());
+  const { settings, setSettings } = useSettings();
+
+  // Update the default prompt, but not on every keystroke
+  const handleSave = debounce((value: string) => {
+    setSettings({ ...settings, customSystemPrompt: value });
+  }, 250);
+
+  // When the prompt changes, update state, and trigger a save for later
+  const handleUpdate = (value: string) => {
+    setPrompt(value);
+    handleSave(value);
+  };
+
+  // Reset the default system prompt back to the app's default
+  const handleReset = () => {
+    setSettings({ ...settings, customSystemPrompt: undefined });
+    setPrompt(defaultSystemPrompt());
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" finalFocusRef={finalFocusRef}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Default System Prompt</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <VStack gap={4}>
+            <Text fontSize="sm">
+              The default system prompt is used as the first message in every chat. It provides the
+              LLM important context, behavioral cues, and expectations about responses and desired
+              response formats.
+            </Text>
+
+            <Text as="em" fontSize="sm">
+              NOTE: changes to the default system prompt will take effect in new chats, but
+              won&apos;t affect existing ones.
+            </Text>
+
+            <FormControl>
+              <Textarea
+                autoFocus
+                rows={15}
+                value={prompt}
+                onChange={(e) => handleUpdate(e.target.value)}
+              />
+            </FormControl>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter>
+          <Flex w="100%" justifyContent="space-between">
+            <Text fontSize="sm">Reset to the default ChatCraft system prompt</Text>
+            <Button size="xs" colorScheme="red" onClick={() => handleReset()}>
+              Reset
+            </Button>
+          </Flex>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default DefaultSystemPromptModal;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -24,6 +24,7 @@ import { TbSearch } from "react-icons/tb";
 import { Form } from "react-router-dom";
 
 import PreferencesModal from "./PreferencesModal";
+import DefaultSystemPromptModal from "./DefaultSystemPromptModal";
 import { useUser } from "../hooks/use-user";
 
 type HeaderProps = {
@@ -35,7 +36,16 @@ type HeaderProps = {
 
 function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderProps) {
   const { toggleColorMode } = useColorMode();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const {
+    isOpen: isPrefModalOpen,
+    onOpen: onPrefModalOpen,
+    onClose: onPrefModalClose,
+  } = useDisclosure();
+  const {
+    isOpen: isSysPromptModalOpen,
+    onOpen: onSysPromptModalOpen,
+    onClose: onSysPromptModalClose,
+  } = useDisclosure();
   const { user, login, logout } = useUser();
 
   const handleLoginLogout = useCallback(() => {
@@ -115,7 +125,8 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
               variant="ghost"
             />
             <MenuList>
-              <MenuItem onClick={onOpen}>Settings...</MenuItem>
+              <MenuItem onClick={onPrefModalOpen}>Settings...</MenuItem>
+              <MenuItem onClick={onSysPromptModalOpen}>Default System Prompt...</MenuItem>
               <MenuItem onClick={handleLoginLogout}>
                 {user ? (
                   "Logout"
@@ -141,7 +152,16 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
         </Box>
       </ButtonGroup>
 
-      <PreferencesModal isOpen={isOpen} onClose={onClose} finalFocusRef={inputPromptRef} />
+      <PreferencesModal
+        isOpen={isPrefModalOpen}
+        onClose={onPrefModalClose}
+        finalFocusRef={inputPromptRef}
+      />
+      <DefaultSystemPromptModal
+        isOpen={isSysPromptModalOpen}
+        onClose={onSysPromptModalClose}
+        finalFocusRef={inputPromptRef}
+      />
     </Flex>
   );
 }

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -35,13 +35,13 @@ import {
   ChatCraftAiMessageVersion,
   ChatCraftMessage,
 } from "../../lib/ChatCraftMessage";
-import { useModels } from "../../hooks/use-models";
 import { ChatCraftModel } from "../../lib/ChatCraftModel";
+import { useModels } from "../../hooks/use-models";
+import { useSettings } from "../../hooks/use-settings";
+import { useAlert } from "../../hooks/use-alert";
 
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
-import { useSettings } from "../../hooks/use-settings";
-import { useAlert } from "../../hooks/use-alert";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -1,13 +1,111 @@
 import { memo } from "react";
-import { Avatar, Button, Flex, Text, useDisclosure } from "@chakra-ui/react";
+import {
+  Avatar,
+  Button,
+  Container,
+  Divider,
+  Flex,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
+  Text,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { TbChevronDown, TbStar, TbStarFilled } from "react-icons/tb";
 
 import MessageBase, { type MessageBaseProps } from "./MessageBase";
-import { createSystemPromptSummary } from "../../lib/system-prompt";
+import { createSystemPromptSummary, defaultSystemPrompt } from "../../lib/system-prompt";
+import db from "../../lib/db";
+import { ChatCraftSystemMessage } from "../../lib/ChatCraftMessage";
+import { useAlert } from "../../hooks/use-alert";
 
-type SystemMessageProps = Omit<MessageBaseProps, "avatar">;
+function SystemPromptVersionsMenu({
+  onChange,
+  isStarred,
+  onStarClick,
+}: {
+  onChange: (value: string) => void;
+  isStarred: boolean;
+  onStarClick: () => void;
+}) {
+  const prevSystemPrompts = useLiveQuery<string[], string[]>(
+    async () => {
+      // Get all starred System Messages, sorted by date
+      const records = await db.messages
+        .where("type")
+        .equals("system")
+        .and((m) => m.starred === true)
+        .sortBy("date");
+      if (!records) {
+        return [];
+      }
+
+      // Create a unique set of prompt strings and return
+      const uniq = new Set<string>();
+      records.reverse().forEach((message) => {
+        const { text } = message;
+        uniq.add(text);
+      });
+
+      return Promise.resolve([defaultSystemPrompt(), ...uniq]);
+    },
+    [],
+    []
+  );
+
+  const title = isStarred ? "Unstar System Prompt" : "Star System Prompt";
+
+  return (
+    <Flex align="center">
+      <IconButton
+        size="sm"
+        aria-label={title}
+        title={title}
+        icon={isStarred ? <TbStarFilled /> : <TbStar />}
+        variant="ghost"
+        onClick={() => onStarClick()}
+      />
+      <Menu placement="bottom-end" isLazy={true}>
+        <MenuButton
+          as={IconButton}
+          size="xs"
+          variant="ghost"
+          icon={<TbChevronDown title={`${prevSystemPrompts.length} Previous System Prompts`} />}
+        />
+        <MenuList>
+          {prevSystemPrompts.map((systemPrompt, idx, arr) => (
+            <MenuItem
+              key={systemPrompt}
+              value={systemPrompt}
+              onClick={() => onChange(systemPrompt)}
+            >
+              <Container>
+                <Text noOfLines={3} title={systemPrompt}>
+                  {systemPrompt}
+                </Text>
+                {idx < arr.length - 1 && <Divider mt={4} />}
+              </Container>
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+    </Flex>
+  );
+}
+
+type SystemMessageProps = Omit<MessageBaseProps, "avatar" | "message"> & {
+  message: ChatCraftSystemMessage;
+};
 
 function SystemMessage(props: SystemMessageProps) {
-  const { message, editing, onEditingChange } = props;
+  const { chatId, message, editing, onEditingChange } = props;
+  const { isOpen, onToggle } = useDisclosure();
+  const summaryText = createSystemPromptSummary(message);
+  const { error } = useAlert();
+
   const avatar = (
     <Avatar
       size="sm"
@@ -19,29 +117,26 @@ function SystemMessage(props: SystemMessageProps) {
     />
   );
 
-  const { isOpen, onToggle } = useDisclosure();
-  const summaryText = createSystemPromptSummary(message);
-
   // If we're showing the whole prompt, don't bother with the "More..." button
   const footer =
     message.text.length > summaryText.length ? (
-      <Flex w="100%" justify="space-between" align="center">
-        <Button size="sm" variant="ghost" onClick={() => onToggle()}>
-          {isOpen ? "Less" : "More..."}
-        </Button>
-        {!editing && (
+      !editing && (
+        <Flex w="100%" justify="space-between" align="center">
+          <Button size="sm" variant="ghost" onClick={() => onToggle()}>
+            {isOpen ? "Show Less" : "Show More..."}
+          </Button>
           <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
-            <Text fontSize="2xs" as="em">
+            <Text fontSize="xs" as="em">
               Edit to customize
             </Text>
           </Button>
-        )}
-      </Flex>
+        </Flex>
+      )
     ) : (
       <Flex w="100%" justify="flex-end" align="center">
         {!editing && (
           <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
-            <Text fontSize="2xs" as="em">
+            <Text fontSize="xs" as="em">
               Edit to customize
             </Text>
           </Button>
@@ -49,11 +144,40 @@ function SystemMessage(props: SystemMessageProps) {
       </Flex>
     );
 
+  const handleSystemPromptVersionChange = (systemPrompt: string) => {
+    message.text = systemPrompt;
+    message.save(chatId).catch((err) => {
+      console.warn("Unable to update system prompt", err);
+      error({
+        title: `Error Switching System Prompt`,
+        message: err.message,
+      });
+    });
+  };
+
+  const handleStarredChanged = () => {
+    message.starred = !message.starred;
+    message.save(chatId).catch((err) => {
+      console.warn("Unable to update system prompt", err);
+      error({
+        title: `Error changing starred for System Prompt`,
+        message: err.message,
+      });
+    });
+  };
+
   return (
     <MessageBase
       {...props}
       avatar={avatar}
       heading="ChatCraft (System Prompt)"
+      headingMenu={
+        <SystemPromptVersionsMenu
+          onChange={handleSystemPromptVersionChange}
+          isStarred={!!message.starred}
+          onStarClick={handleStarredChanged}
+        />
+      }
       summaryText={!isOpen ? summaryText : undefined}
       footer={footer}
     />

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -43,6 +43,7 @@ export type SerializedChatCraftMessage = {
   func?: FunctionCallParams | FunctionCallResult;
   text: string;
   versions?: { id: string; date: string; model: string; text: string }[];
+  starred?: boolean;
 };
 
 export class ChatCraftMessage {
@@ -394,18 +395,24 @@ export class ChatCraftHumanMessage extends ChatCraftMessage {
 }
 
 export class ChatCraftSystemMessage extends ChatCraftMessage {
+  starred?: boolean;
+
   constructor({
     id,
     date,
     text,
     readonly,
+    starred,
   }: {
     id?: string;
     date?: Date;
     text: string;
     readonly?: boolean;
+    starred?: boolean;
   }) {
     super({ id, date, type: "system", text, readonly });
+
+    this.starred = starred;
   }
 
   clone() {
@@ -420,7 +427,19 @@ export class ChatCraftSystemMessage extends ChatCraftMessage {
       date: new Date(message.date),
       text: message.text,
       readonly: true,
+      starred: message.starred,
     });
+  }
+
+  toDB(chatId: string): ChatCraftMessageTable {
+    return {
+      id: this.id,
+      date: this.date,
+      chatId,
+      type: this.type,
+      text: this.text,
+      starred: this.starred,
+    };
   }
 
   static fromDB(message: ChatCraftMessageTable) {
@@ -428,6 +447,7 @@ export class ChatCraftSystemMessage extends ChatCraftMessage {
       id: message.id,
       date: message.date,
       text: message.text,
+      starred: message.starred,
     });
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -21,6 +21,7 @@ export type ChatCraftMessageTable = {
   func?: FunctionCallParams | FunctionCallResult;
   text: string;
   versions?: { id: string; date: Date; model: string; text: string }[];
+  starred?: boolean;
 };
 
 export type SharedChatCraftChatTable = {
@@ -102,6 +103,10 @@ class ChatCraftDatabase extends Dexie {
     // Version 6 Migration - adds functions table, .func to chats table
     this.version(6).stores({
       functions: "id, date, name, description",
+    });
+    // Version 7 Migration - adds .starred to messages table
+    this.version(7).stores({
+      messages: "id, date, chatId, type, model, user, text, versions, starred",
     });
 
     this.chats = this.table("chats");

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -22,6 +22,7 @@ export type Settings = {
   countTokens: boolean;
   sidebarVisible: boolean;
   alwaysSendFunctionResult: boolean;
+  customSystemPrompt?: string;
 };
 
 export const defaults: Settings = {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -1,7 +1,7 @@
 import { ChatCraftSystemMessage } from "./ChatCraftMessage";
 import { getSettings } from "./settings";
 
-const defaultSystemPrompt = `I am ChatCraft, a web-based, expert programming AI assistant. I help programmers learn, experiment, and be more creative with code.
+const defaultSystemPromptText = `I am ChatCraft, a web-based, expert programming AI assistant. I help programmers learn, experiment, and be more creative with code.
 
 I follow these rules when responding:
 
@@ -12,34 +12,34 @@ I follow these rules when responding:
 - If using functions, only use the specific functions I have been provided with
 `;
 
-const justShowMeTheCodeRule =
+const justShowMeTheCodeText =
   "- When responding with code, ONLY return the code and NOTHING else (i.e., don't explain ANYTHING)";
 
-const buildSystemPrompt = () => {
-  const { justShowMeTheCode } = getSettings();
+export const defaultSystemPrompt = () => {
+  const { justShowMeTheCode, customSystemPrompt } = getSettings();
 
-  let systemPrompt = defaultSystemPrompt;
+  let systemPrompt = customSystemPrompt ?? defaultSystemPromptText;
   if (justShowMeTheCode) {
-    systemPrompt += justShowMeTheCodeRule;
+    systemPrompt += justShowMeTheCodeText;
   }
   return systemPrompt;
 };
 
-// Compare the given system prompt to the default system prompts we use
-const isDefaultSystemPrompt = (message: ChatCraftSystemMessage) =>
-  message.text === buildSystemPrompt();
-
 export function createSystemMessage() {
-  return new ChatCraftSystemMessage({ text: buildSystemPrompt() });
+  return new ChatCraftSystemMessage({ text: defaultSystemPrompt() });
 }
 
 // A shorter version of the system prompt to show if we don't want to reveal the whole thing
 export function createSystemPromptSummary(message: ChatCraftSystemMessage) {
-  if (isDefaultSystemPrompt(message)) {
-    return "I am ChatCraft, a web-based, expert programming AI assistant. I help programmers learn, experiment, and be more creative with code...";
+  // Grab first line of text, truncate to 250 characters
+  let { text } = message;
+  text = text.split("\n")[0];
+  text = text.length > 250 ? `${text.slice(0, 250).trim()}...` : text;
+
+  // See if we need to add ...
+  if (text.length < message.text.length) {
+    text += "...";
   }
 
-  // Grab first few lines of text, and add ellipses if necessary to indicate more
-  const { text } = message;
-  return text.length > 250 ? `${message.text.slice(0, 250).trim()}...` : message.text;
+  return text;
 }


### PR DESCRIPTION
Fixes #138, addresses part of https://github.com/tarasglek/chatcraft.org/issues/194#issuecomment-1661036662.

When we create a new chat, we always begin with a default system prompt.  The text of this system prompt is baked into the app's code.  We allow the user to edit it in the current message, but you can't use it again in a new chat.

This change allows the default system prompt to be overridden by a user (or reset back to the default).  The process is this:

1. User edits the current system prompt
2. In the 3-dots menu for the system prompt, a new set of options is shown when the system prompt has been changed (i.e., it is NOT shown if it's not needed):
    1. Users can set the default system prompt to the current system prompt (i.e., override)
    2. Users can reset the overridden system prompt back to the default (i.e., reset)

Here's a video showing how this works in practice (sorry it's small, GitHub won't let me post anything > 10M):

https://github.com/tarasglek/chatcraft.org/assets/427398/2491af38-6bca-4c89-b981-b7fbb69f9450

@steven4354 can you try this and comment?  NOTE: I'm not tackling the part about saving multiple custom prompts and choosing between them, mainly because I'm not sure how to do the UI.  I wonder if we should start with this and iterate?  Maybe you have ideas now.
