### PR TITLE
Add useAutoScroll() hook and context to fix autoscrolling

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -16,6 +16,7 @@ import { useSettings } from "../hooks/use-settings";
 import { useModels } from "../hooks/use-models";
 import ChatHeader from "./ChatHeader";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
+import { useAutoScroll } from "../hooks/use-autoscroll";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -33,7 +34,8 @@ function ChatBase({ chat }: ChatBaseProps) {
     defaultIsOpen: settings.sidebarVisible,
   });
   const [loading, setLoading] = useState(false);
-  const [shouldAutoScroll, setShouldAutoScroll] = useState(true);
+  const { scrollProgress, shouldAutoScroll, setShouldAutoScroll, scrollBottomRef } =
+    useAutoScroll();
   const messageListRef = useRef<HTMLDivElement | null>(null);
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
   const toast = useToast();
@@ -60,18 +62,33 @@ function ChatBase({ chat }: ChatBaseProps) {
     setSettings({ ...settings, sidebarVisible: newValue });
   }, [isSidebarVisible, settings, setSettings, toggleSidebarVisible]);
 
-  // Auto scroll chat to bottom, but only if user isn't trying to scroll manually
-  // Also add a dependency on the streamingMessage, since its content (and therefore
-  // the height of messageList) will change while streaming, and the chat's date
-  // since we update that whenever the chat is re-saved to the db
+  // Auto scroll chat to bottom (or to bottom of element specified by scrollBottomRef),
+  // but only if user isn't trying to scroll manually. Also add a dependency on the
+  // scrollProgress, since it will increase as a response streams in. Also, use the
+  // chat's date, since we update that whenever the chat is re-saved to the db
   useEffect(() => {
-    if (messageListRef.current && shouldAutoScroll) {
-      const messageList = messageListRef.current;
+    const messageList = messageListRef.current;
+    if (!messageList) {
+      return;
+    }
+
+    if (!shouldAutoScroll) {
+      return;
+    }
+
+    const scrollBottom = scrollBottomRef.current;
+    if (scrollBottom) {
+      // Calculate the new "bottom" based on the scrollBottom element's position
+      const newBottom = scrollBottom.offsetTop + scrollBottom.offsetHeight;
+      messageList.scrollTop = newBottom - messageList.offsetHeight;
+    } else {
+      // Scroll to the bottom of the message list instead
       messageList.scrollTop = messageList.scrollHeight;
     }
-  }, [messageListRef, streamingMessage, shouldAutoScroll, chat.date]);
+  }, [messageListRef, scrollProgress, scrollBottomRef, shouldAutoScroll, chat.date]);
 
-  // Disable auto scroll when we're loading and the user scrolls up to read previous content
+  // Disable auto scroll when we're in the middle of streaming and the user scrolls
+  // up to read previous content.
   const handleScroll = useCallback(() => {
     const messageList = messageListRef.current;
     if (!messageList) {
@@ -79,25 +96,36 @@ function ChatBase({ chat }: ChatBaseProps) {
     }
 
     // We need a "fudge factor" here, or it constantly loses auto scroll
-    // as content streams in and the container is auto scroll in the
+    // as content streams in and the container is auto-scrolled in the
     // previous useEffect.
-    const scrollThreshold = 50;
-    const atBottom =
-      messageList.scrollTop + messageList.clientHeight >=
-      messageList.scrollHeight - scrollThreshold;
+    const scrollThreshold = 100;
+    const scrollBottom = scrollBottomRef.current;
+    let atBottom: boolean;
+    if (scrollBottom) {
+      // If scrollBottom exists, consider the user to be at the bottom if the bottom of
+      // the scrollBottom element is within the viewport
+      const scrollBottomBottom = scrollBottom.offsetTop + scrollBottom.offsetHeight;
+      atBottom =
+        messageList.scrollTop + messageList.clientHeight >= scrollBottomBottom - scrollThreshold;
+    } else {
+      // If scrollBottom doesn't exist, use the bottom of the message list
+      atBottom =
+        messageList.scrollTop + messageList.clientHeight >=
+        messageList.scrollHeight - scrollThreshold;
+    }
 
     // Disable auto scrolling if the user scrolls up
     // while messages are being streamed
-    if (loading && shouldAutoScroll && !atBottom) {
+    if (scrollProgress && shouldAutoScroll && !atBottom) {
       setShouldAutoScroll(false);
     }
 
     // Re-enable it if the user scrolls back to
     // the bottom while messages are streaming
-    if (loading && !shouldAutoScroll && atBottom) {
+    if (scrollProgress && !shouldAutoScroll && atBottom) {
       setShouldAutoScroll(true);
     }
-  }, [loading, shouldAutoScroll, setShouldAutoScroll, messageListRef]);
+  }, [scrollBottomRef, scrollProgress, shouldAutoScroll, setShouldAutoScroll, messageListRef]);
 
   // If the user manually scrolls, stop auto scrolling
   useEffect(() => {
@@ -113,7 +141,6 @@ function ChatBase({ chat }: ChatBaseProps) {
   // Handle prompt form submission
   const onPrompt = useCallback(
     async (prompt?: string) => {
-      setShouldAutoScroll(true);
       setLoading(true);
 
       try {
@@ -184,7 +211,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         console.error(err);
       } finally {
         setLoading(false);
-        setShouldAutoScroll(true);
+        setShouldAutoScroll(false);
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -226,7 +253,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
           {
             /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
-            !shouldAutoScroll && (
+            scrollProgress && !shouldAutoScroll && (
               <Flex
                 w="100%"
                 maxW="900px"

--- a/src/Chat/LocalChat.tsx
+++ b/src/Chat/LocalChat.tsx
@@ -3,6 +3,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import ChatBase from "./ChatBase";
+import { AutoScrollProvider } from "../hooks/use-autoscroll";
 
 // Load a chat from the database locally
 export default function LocalChat() {
@@ -13,6 +14,9 @@ export default function LocalChat() {
     }
   }, [chatId]);
 
-  // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} /> : null;
+  return chat ? (
+    <AutoScrollProvider>
+      <ChatBase chat={chat} />
+    </AutoScrollProvider>
+  ) : null;
 }

--- a/src/Chat/RemoteChat.tsx
+++ b/src/Chat/RemoteChat.tsx
@@ -2,11 +2,15 @@ import { useLoaderData } from "react-router-dom";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import ChatBase from "./ChatBase";
+import { AutoScrollProvider } from "../hooks/use-autoscroll";
 
 // Load a chat from over the network as a JSON blob (already available via loader)
 export default function RemoteChat() {
   const chat = useLoaderData() as ChatCraftChat;
 
-  // TODO: need some kind of error handling here if `chat` doesn't exist
-  return chat ? <ChatBase chat={chat} /> : null;
+  return chat ? (
+    <AutoScrollProvider>
+      <ChatBase chat={chat} />
+    </AutoScrollProvider>
+  ) : null;
 }

--- a/src/components/Message/NewMessage.tsx
+++ b/src/components/Message/NewMessage.tsx
@@ -2,6 +2,7 @@ import { Box, Button, ButtonGroup } from "@chakra-ui/react";
 
 import { ChatCraftAiMessage } from "../../lib/ChatCraftMessage";
 import AiMessage from "./AiMessage";
+import { useAutoScroll } from "../../hooks/use-autoscroll";
 
 type NewMessageProps = {
   message: ChatCraftAiMessage;
@@ -12,6 +13,8 @@ type NewMessageProps = {
 };
 
 function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewMessageProps) {
+  const { scrollBottomRef } = useAutoScroll();
+
   return (
     <>
       <AiMessage
@@ -23,7 +26,7 @@ function NewMessage({ message, chatId, isPaused, onTogglePause, onCancel }: NewM
         isLoading
         heading={message.model.prettyModel}
       />
-      <Box textAlign="center">
+      <Box textAlign="center" ref={scrollBottomRef}>
         <ButtonGroup>
           <Button variant="outline" size="xs" onClick={() => onCancel()}>
             Cancel

--- a/src/hooks/use-autoscroll.tsx
+++ b/src/hooks/use-autoscroll.tsx
@@ -1,0 +1,57 @@
+import {
+  useState,
+  createContext,
+  useContext,
+  useRef,
+  type ReactNode,
+  type RefObject,
+  type FC,
+} from "react";
+
+type AutoScrollContextType = {
+  // When streaming, and scrolling is happening, scrollProgress increases.
+  // Reset back to 0 when not streaming/scrolling.
+  scrollProgress: number;
+  incrementScrollProgress: () => void;
+  resetScrollProgress: () => void;
+  scrollBottomRef: RefObject<HTMLDivElement>;
+  shouldAutoScroll: boolean;
+  setShouldAutoScroll: (value: boolean) => void;
+};
+
+const AutoScrollContext = createContext<AutoScrollContextType>({
+  scrollProgress: 0,
+  incrementScrollProgress: () => {
+    /* do nothing */
+  },
+  resetScrollProgress: () => {
+    /* do nothing */
+  },
+  scrollBottomRef: { current: null },
+  shouldAutoScroll: false,
+  setShouldAutoScroll: () => {
+    /* do nothing */
+  },
+});
+
+export const useAutoScroll = () => useContext(AutoScrollContext);
+
+export const AutoScrollProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [scrollProgress, setScrollProgress] = useState(0);
+  const [shouldAutoScroll, setShouldAutoScroll] = useState(false);
+  const scrollBottomRef = useRef<HTMLDivElement>(null);
+
+  const value = {
+    scrollProgress,
+    incrementScrollProgress() {
+      setScrollProgress((currentValue) => currentValue + 1);
+    },
+    resetScrollProgress() {
+      setScrollProgress(0);
+    },
+    scrollBottomRef,
+    shouldAutoScroll,
+    setShouldAutoScroll,
+  };
+  return <AutoScrollContext.Provider value={value}>{children}</AutoScrollContext.Provider>;
+};


### PR DESCRIPTION
Fixes #105 

This fixes a bunch of bugs in how the auto scrolling feature works.  Specifically:

1. Adds a new React context and hook `useAutoScroll()`.  This keeps track of a React ref that points to the "bottom" of the message list (i.e. where we should auto scroll to in the messages), whether or not the UI should autoscroll, and also the current progress of scrolling (i.e., every time there's some new content added that requires autoscroll logic to fire).  Previously a bunch of this stuff was done as state in `ChatBase`, but I needed to share it across components.
2. When we render the `NewMessage` component, we use it as our "bottom."  This works both when doing a normal chat, and also retrying with a different LLM midway through the chat.
3. When the content of what we're streaming (i.e., a new AI Message) changes, we increment the `scrollProgress` in the autoscroll context, telling effects in the UI to fire and perform various autoscroll logic.
4. When we aren't streaming a response (i.e., `scrollProgress === 0`), we no longer scroll the whole chat (e.g., when deleting or editing a message part-way through).
5. I've increased the fudge-factor threshold for when to break autoscrolling as the user scrolls up.  Previously, it was happening too easily when the LLM added "tall" content (e.g., an iframe or mermaid diagram).  I think using `100` pixels is better.

A key idea to how this code works:

- `useChatOpenAI()` is usable in different parts of the app without sharing logic.  That is, the `streamingMessage` you get back is specific to the component where you're working.  Retrying a message with an LLM won't trigger any logic in the main chat, which also uses the same hook (i.e., it's just a hook, not a shared context).
- `useAutoScroll()` is shared across all the chat-related components in the app.  If you update something in it, it affects all other parts of the app (i.e., it's a context vs. only a hook).

I need to spend more time testing this, and thinking through the code, but I think it's just about ready to go, and makes the UI so much better to use!

Try it and see if you notice any problems.