### PR TITLE
Add more padding to heading in messages

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -183,7 +183,7 @@ function MessageBase({
       onMouseLeave={() => setIsHovering(false)}
     >
       <Card>
-        <CardHeader p={0} py={1} pr={1}>
+        <CardHeader p={0} pt={3} pb={2} pr={1}>
           <Flex justify="space-between" align="center" ml={5} mr={2}>
             <Flex gap={3}>
               <Box>{avatar}</Box>


### PR DESCRIPTION
I keep noticing that the padding around the message header is too small vs. the rest of the message.  This adds some more space.

### Before

<img width="732" alt="Screenshot 2023-08-10 at 12 46 15 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/8aeaec0d-c8b6-4107-b8f5-46b0052751da">

### After

<img width="733" alt="Screenshot 2023-08-10 at 12 45 24 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/ccb7dfeb-6ea0-4e43-87a2-14dd4fb5687f">
