### PR TITLE
Add Delete Messages Before/After feature

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -287,8 +287,7 @@ function ChatBase({ chat }: ChatBaseProps) {
           <ScrollRestoration />
 
           <MessagesView
-            messages={chat.messages()}
-            chatId={chat.id}
+            chat={chat}
             newMessage={streamingMessage}
             isLoading={loading}
             onRemoveMessage={(message) => chat.removeMessage(message.id)}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -56,7 +56,9 @@ export interface MessageBaseProps {
   isLoading: boolean;
   hidePreviews?: boolean;
   onPrompt?: (prompt?: string) => void;
+  onDeleteBeforeClick?: () => void;
   onDeleteClick?: () => void;
+  onDeleteAfterClick?: () => void;
   onRetryClick?: (model: ChatCraftModel) => void;
   disableFork?: boolean;
   disableEdit?: boolean;
@@ -74,7 +76,9 @@ function MessageBase({
   footer,
   isLoading,
   hidePreviews,
+  onDeleteBeforeClick,
   onDeleteClick,
+  onDeleteAfterClick,
   onPrompt,
   onRetryClick,
   disableFork,
@@ -277,9 +281,19 @@ function MessageBase({
                       {editing ? "Cancel Editing" : "Edit"}
                     </MenuItem>
                   )}
+                  {onDeleteBeforeClick && (
+                    <MenuItem onClick={() => onDeleteBeforeClick()} color="red.400">
+                      Delete Messages Before
+                    </MenuItem>
+                  )}
                   {onDeleteClick && (
                     <MenuItem onClick={() => onDeleteClick()} color="red.400">
-                      Delete
+                      Delete Message
+                    </MenuItem>
+                  )}
+                  {onDeleteAfterClick && (
+                    <MenuItem onClick={() => onDeleteAfterClick()} color="red.400">
+                      Delete Messages After
                     </MenuItem>
                   )}
                 </MenuList>

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -21,7 +21,9 @@ type MessageProps = {
   isLoading: boolean;
   hidePreviews?: boolean;
   onPrompt?: (prompt?: string) => void;
+  onDeleteBeforeClick?: () => void;
   onDeleteClick?: () => void;
+  onDeleteAfterClick?: () => void;
   disableFork?: boolean;
   disableEdit?: boolean;
 };
@@ -31,7 +33,9 @@ function Message({
   chatId,
   isLoading,
   hidePreviews,
+  onDeleteBeforeClick,
   onDeleteClick,
+  onDeleteAfterClick,
   onPrompt,
   disableFork,
   disableEdit,
@@ -55,7 +59,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
         disableFork={disableFork}
         disableEdit={message.readonly && disableEdit}
       />
@@ -75,7 +81,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
         disableFork={disableFork}
         disableEdit={message.readonly && disableEdit}
       />
@@ -92,7 +100,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
         disableFork={true}
         disableEdit={message.readonly && disableEdit}
       />
@@ -109,7 +119,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        /* We can't delete anything before the system message, since it's first */
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
       />
     );
   }
@@ -124,7 +136,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
       />
     );
   }
@@ -139,7 +153,9 @@ function Message({
         isLoading={isLoading}
         hidePreviews={hidePreviews}
         onPrompt={onPrompt}
+        onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
+        onDeleteAfterClick={onDeleteAfterClick}
       />
     );
   }


### PR DESCRIPTION
Part of #210

This adds two new menu items to a message:

1. Delete Messages Before - will remove all messages from the chat *before* this message (but not including it).  The system message is not affected.
2. Delete Messages After - will remove all messages from the chat *after* this message (but not including it).

These options only appear if they make sense (e.g., you can't delete messages after last message, etc).