### PR TITLE
Initial experiment adding slash commands

### DIFF
--- a/functions/api/proxy.ts
+++ b/functions/api/proxy.ts
@@ -1,0 +1,61 @@
+import { errorResponse, createResourcesForEnv } from "../utils";
+
+interface Env {
+  JWT_SECRET: string;
+}
+
+// Transform known HTML URLs to get raw content
+const fixUrl = (url: string) =>
+  url
+    // Deal with GitHub HTML URLs to code.  For example:
+    // https://github.com/<owner>/<repo>/blob/<branch>/<path> -> https://raw.githubusercontent.com
+    .replace(/^https:\/\/github\.com\/(.*)\/blob\/(.*)$/, "https://raw.githubusercontent.com/$1/$2")
+    // Fix gist URLs to get /raw data vs. HTML
+    .replace(
+      /^https:\/\/gist\.github\.com\/([a-zA-Z0-9_-]+)\/([a-f0-9]+)$/,
+      "https://gist.githubusercontent.com/$1/$2/raw"
+    );
+
+// GET https://chatcraft.org/api/proxy?url=<encoded url...>
+// Must include JWT in cookie, and user must match token owner
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const { ENVIRONMENT } = env;
+  const { tokenProvider } = createResourcesForEnv(ENVIRONMENT, request.url);
+
+  // There should be tokens in the cookies
+  const { accessToken } = tokenProvider.getTokens(request);
+  if (!accessToken) {
+    return errorResponse(403, "Missing Access Token");
+  }
+
+  // Make sure the access token is valid and has API role
+  try {
+    const payload = await tokenProvider.verifyToken(accessToken, env.JWT_SECRET);
+    if (!payload) {
+      return errorResponse(403, "Invalid Access Token");
+    }
+
+    // Make sure this user has the `api` role
+    if (payload.role !== "api") {
+      return errorResponse(403, "Access Token missing 'api' role");
+    }
+  } catch (err) {
+    return errorResponse(400, err.message);
+  }
+
+  // Proxy the request to url
+  try {
+    const urlParam = new URL(request.url).searchParams.get("url");
+    if (!urlParam) {
+      return errorResponse(400, "Missing url query param");
+    }
+
+    // Some URLs have better alternatives to get at the raw data
+    const url = fixUrl(urlParam);
+
+    return fetch(url, { headers: { "User-Agent": "chatcraft.org" } });
+  } catch (err) {
+    console.error(err);
+    return errorResponse(500, `Unable to proxy url: ${err.message}`);
+  }
+};

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "tiktoken": "^1.0.10"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20230807.0",
+    "@cloudflare/workers-types": "^4.20230814.0",
     "@types/cookie": "^0.5.1",
     "@types/lodash": "^4.14.196",
     "@types/react": "^18.2.18",
@@ -67,7 +67,7 @@
     "vite-plugin-wasm": "^3.2.2",
     "vitest": "^0.33.0",
     "vitest-environment-miniflare": "^2.14.0",
-    "wrangler": "^3.5.0"
+    "wrangler": "^3.5.1"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ dependencies:
 
 devDependencies:
   "@cloudflare/workers-types":
-    specifier: ^4.20230807.0
-    version: 4.20230807.0
+    specifier: ^4.20230814.0
+    version: 4.20230814.0
   "@types/cookie":
     specifier: ^0.5.1
     version: 0.5.1
@@ -161,8 +161,8 @@ devDependencies:
     specifier: ^2.14.0
     version: 2.14.0(vitest@0.33.0)
   wrangler:
-    specifier: ^3.5.0
-    version: 3.5.0
+    specifier: ^3.5.1
+    version: 3.5.1
 
 packages:
   /@aashutoshrathi/word-wrap@1.2.6:
@@ -3091,10 +3091,10 @@ packages:
       mime: 3.0.0
     dev: true
 
-  /@cloudflare/workerd-darwin-64@1.20230807.0:
+  /@cloudflare/workerd-darwin-64@1.20230814.1:
     resolution:
       {
-        integrity: sha512-p1XgkX6OcomFSRSHiIo6XbWB40sMExnFUWtZFfSvB7oNmkrtEvUCI3iuh+ibFI5IDSZqsRKyIHx6Oe22Z0ei5A==,
+        integrity: sha512-aQUO7q7qXl+SVtOiMMlVKLNOSeL6GX43RKeflwzsD74dGgyHPiSfw5KCvXhkVbyN7u+yYF6HyFdaIvHLfn5jyA==,
       }
     engines: { node: ">=16" }
     cpu: [x64]
@@ -3103,10 +3103,10 @@ packages:
     dev: true
     optional: true
 
-  /@cloudflare/workerd-darwin-arm64@1.20230807.0:
+  /@cloudflare/workerd-darwin-arm64@1.20230814.1:
     resolution:
       {
-        integrity: sha512-HjhjRFPvDg3Sh4TXyz38Z+AhaLA+0AiAmYKRadcnKhysjOaTew86POS3xdaKiZ3xG83J7rsLcqajW54znbmCkg==,
+        integrity: sha512-U2mcgi+AiuI/4EY5Wk/GmygiNoCNw/V2mcHmxESqe4r6XbJYOzBdEsjnqJ05rqd0JlEM8m64jRtE6/qBnQHygg==,
       }
     engines: { node: ">=16" }
     cpu: [arm64]
@@ -3115,10 +3115,10 @@ packages:
     dev: true
     optional: true
 
-  /@cloudflare/workerd-linux-64@1.20230807.0:
+  /@cloudflare/workerd-linux-64@1.20230814.1:
     resolution:
       {
-        integrity: sha512-PPuGKoRILFTlZDC7uGXgrYBucopqkvicaov/ypbPmUVb/DfrXGqftEkNbXlyiXY1g0t10wXRiSZWi7hOBOIH7w==,
+        integrity: sha512-Q4kITXLTCuG2i2Z01fbb5AjVRRIf3+lS4ZVsFbTbIwtcOOG4Ozcw7ee7tKsFES7hFqR4Eg9gMG4/aS0mmi+L2g==,
       }
     engines: { node: ">=16" }
     cpu: [x64]
@@ -3127,10 +3127,10 @@ packages:
     dev: true
     optional: true
 
-  /@cloudflare/workerd-linux-arm64@1.20230807.0:
+  /@cloudflare/workerd-linux-arm64@1.20230814.1:
     resolution:
       {
-        integrity: sha512-ESAf2tXarK8dJl07voa/NI2BBpH1duldfgeQQQmor437A3+gSqQSBhAEmh05bjHy6dYHXgZtwLPky+LL6hmyBA==,
+        integrity: sha512-BX5SaksXw+pkREVw3Rw2eSNXplqZw+14CcwW/5x/4oq/C6yn5qCvKxJfM7pukJGMI4wkJPOYops7B3g27FB/HA==,
       }
     engines: { node: ">=16" }
     cpu: [arm64]
@@ -3139,10 +3139,10 @@ packages:
     dev: true
     optional: true
 
-  /@cloudflare/workerd-windows-64@1.20230807.0:
+  /@cloudflare/workerd-windows-64@1.20230814.1:
     resolution:
       {
-        integrity: sha512-DYKkLtT4lNRdVx+2fbYgPxdF7ypJn9bT2HYMZ93N7XPwaKFx2svBRMrZkwBcvwuNb+99Z0jnaQwdcFnHcFLzZA==,
+        integrity: sha512-GWHqfyhsG/1wm2W8afkYX3q3fWXUWWD8NGtHfAs6ZVTHdW3mmYyMhKR0lc6ptBwz5i5aXRlP2S+CxxxwwDbKpw==,
       }
     engines: { node: ">=16" }
     cpu: [x64]
@@ -3151,10 +3151,10 @@ packages:
     dev: true
     optional: true
 
-  /@cloudflare/workers-types@4.20230807.0:
+  /@cloudflare/workers-types@4.20230814.0:
     resolution:
       {
-        integrity: sha512-gQczWuGE2rxmpzOCNn0zLbx8Xz0gqspdE9S7tu4Xax39q1csgO/E9flcS+KG3GHB522ugOh84inmABDhpeJnvQ==,
+        integrity: sha512-+jHiGjZg2UpULZSSHmHLqUG45TLg1s+uppSMlGvMn0u/xyFsRX9HX6b8Ydg/oHSp3jfSuPtX05GSvtgRAmrWTg==,
       }
     dev: true
 
@@ -4305,7 +4305,7 @@ packages:
       }
     engines: { node: ">=16.13" }
     dependencies:
-      "@cloudflare/workers-types": 4.20230807.0
+      "@cloudflare/workers-types": 4.20230814.0
       "@miniflare/cache": 2.14.0
       "@miniflare/core": 2.14.0
       "@miniflare/d1": 2.14.0
@@ -10083,10 +10083,10 @@ packages:
     engines: { node: ">=10" }
     dev: true
 
-  /miniflare@3.20230801.0:
+  /miniflare@3.20230814.1:
     resolution:
       {
-        integrity: sha512-jXl++AYc3PDMu9cxeMbFgzrnbgwU8VIkw49cdpOaIAz7jQgPcLuNLOyAw3G+uaLELnILHs81MM67fGR1hAc62A==,
+        integrity: sha512-LMgqd1Ut0+fnlvQepVbbBYQczQnyuuap8bgUwOyPETka0S9NR9NxMQSNaBgVZ0uOaG7xMJ/OVTRlz+TGB86PWA==,
       }
     engines: { node: ">=16.13" }
     dependencies:
@@ -10102,7 +10102,7 @@ packages:
       source-map-support: 0.5.21
       stoppable: 1.1.0
       undici: 5.22.1
-      workerd: 1.20230807.0
+      workerd: 1.20230814.1
       ws: 8.13.0
       youch: 3.2.3
       zod: 3.21.4
@@ -13434,26 +13434,26 @@ packages:
       workbox-core: 7.0.0
     dev: true
 
-  /workerd@1.20230807.0:
+  /workerd@1.20230814.1:
     resolution:
       {
-        integrity: sha512-yDdHld8wm5lQ6M/WYD68tIzbAmPjcgAoVAYhAHQFaXZSpryjIw9mT3O/NEloyZ8xiickpoPuNSQ4ffxPLao2+Q==,
+        integrity: sha512-zJeSEteXuAD+bpYJT8WvzTAHvIAkKPVxOV+Jy6zCLKz5e08N3OUbAF+wrvGWc8b2aB1sj+IYsdXfkv4puH+qXQ==,
       }
     engines: { node: ">=16" }
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      "@cloudflare/workerd-darwin-64": 1.20230807.0
-      "@cloudflare/workerd-darwin-arm64": 1.20230807.0
-      "@cloudflare/workerd-linux-64": 1.20230807.0
-      "@cloudflare/workerd-linux-arm64": 1.20230807.0
-      "@cloudflare/workerd-windows-64": 1.20230807.0
+      "@cloudflare/workerd-darwin-64": 1.20230814.1
+      "@cloudflare/workerd-darwin-arm64": 1.20230814.1
+      "@cloudflare/workerd-linux-64": 1.20230814.1
+      "@cloudflare/workerd-linux-arm64": 1.20230814.1
+      "@cloudflare/workerd-windows-64": 1.20230814.1
     dev: true
 
-  /wrangler@3.5.0:
+  /wrangler@3.5.1:
     resolution:
       {
-        integrity: sha512-lvYo2JUxRXdobzd0hs96FT354DvKAYoAiPslceEpKmr0oHCreMWhU5AStfZwg1PEaJJZCwP17LqA5GgjvQ6zyg==,
+        integrity: sha512-CnrKId+pmjTfLSidM9Ut7lUDCFWEtJyY3JT3Dk+TgYHvu2zVmMgUeQQZHZfvpVN5eaEZifNQr90KEvMLy7MhHw==,
       }
     engines: { node: ">=16.13.0" }
     hasBin: true
@@ -13464,7 +13464,7 @@ packages:
       blake3-wasm: 2.1.5
       chokidar: 3.5.3
       esbuild: 0.16.3
-      miniflare: 3.20230801.0
+      miniflare: 3.20230814.1
       nanoid: 3.3.6
       path-to-regexp: 6.2.1
       selfsigned: 2.1.1

--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -1,0 +1,137 @@
+import { memo } from "react";
+
+import MessageBase, { type MessageBaseProps } from "../MessageBase";
+import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
+
+const helpText = `## ChatCraft.org Help
+
+ChatCraft.org lets you chat with large language models (LLM) from various vendors and
+store your chat history locally in your browser. It has many many [features](https://github.com/tarasglek/chatcraft.org/blob/main/README.md)
+designed to make it easy for software developers to discuss their code with AI and each other.
+
+## How to Chat
+
+You can ask questions, copy/paste code, get help with error messages, etc.  Here are
+a few examples to get you started:
+
+### Example 1: Learning Technologies and Concepts
+
+> I'm trying to learn React, and a I need a basic intro with some diagrams and links
+
+You can ask for code examples, links to tutorials, diagrams and more.  You can also
+try copy/pasting some text for a web site and asking for more explanation:
+
+> I don't understand what this paragraph means, explain it in more simple terms:
+>
+> ...paste the text that you don't understand here...
+
+### Example 2: Writing Code with AI
+
+> Give me a regular expression for working with license plates in the US. I'm working in python.
+
+When you know what you want to do, but not **how** exactly, talking with AI can help
+you accomplish your task more quickly.
+
+All code has bugs, even code written by AI.  You'll often need to ask for clarification
+or edit the code yourself to get to your desired end goal.
+
+### Example 3: Solving Tasks
+
+> I need to trim the first 5 seconds from a video. I'm on a Mac and want to use ffmpeg.
+
+AI is great at helping find the syntax for common problems without wasting time searching
+through documentation.
+
+### Example 4: Understanding Code and Errors
+
+> I'm writing the function below, and when I run it I get an error. What does it mean?
+>
+> \`\`\`
+> ...function...
+> \`\`\`
+> 
+> \`\`\`
+> ...text of error message
+> \`\`\`
+
+When you're stuck on a problem and need "another set of eyes," asking AI to read through
+your code and errors can help you find your bug.
+
+## Markdown support
+
+If you're [comfortable with Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), you can
+use it anywhere in your prompt, and the LLMs will do the same. ChatCraft knows how to render Markdown.
+
+For example, similar to GitHub, if you [wrap code in triple-backtick code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks), ChatCraft will
+properly display it for you.  You can also specify the language to use (e.g., typescript):
+
+\`\`\`typescript
+function greeting(name: string) {
+  return "Hello " + name;
+}
+\`\`\`
+
+You can also use [headings](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#headings), [lists](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#lists), [tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables#creating-a-table), [links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links),
+etc. to create more readable text. 
+
+## Commands
+
+You can use "slash" commands to help accomplish various tasks. Any prompt that begins
+with a "/" (e.g., "/help") will be interpreted as a command that ChatCraft should run.
+Some commands accept arguments as well.
+
+| Command | Description |
+|-----|------|
+| /help         | Shows this help message. |
+| /new          | Creates a new chat. |
+| /clear        | Erases all messages in the current chat. |
+| /summary&nbsp;[max-length] | Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500). |
+| /import&nbsp;<url> | Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command. |
+
+## Functions
+
+Some models support function calling (e.g, OpenAI models). ChatCraft provides a way
+to write, load, and run these functions using a special syntax.
+
+Functions are ES6 Modules that export a default function.  They also include metadata
+about for the function name, description, and input arguments schema.
+
+To create a function within ChatCraft, use the [/f/new](/f/new) URL, which will create
+a new function and load the editor.
+
+You can also host your function module somewhere (e.g., [gist.github.com](https:/gist.github.com))
+and have ChatCraft load it dynamically.
+
+During your chat, you can ask a model to use your function by using the following syntax in your prompt:
+
+- \`@fn:name\` - use a function called 'name' stored locally within ChatCraft (i.e., written in editor)
+- \`@fn-url:url\` - use a function hosted at the given 'url'. ChatCraft will attempt to load and parse it.
+
+Functions mentioned in the chat's System Prompt are suggestions for the LLM, whereas a function
+you define in a message is an instruction to use the function.  For example, the following
+prompt will cause the LLM to use the sum function:
+
+> add 1334134, 1324134, and 135223452 @fn:sum
+
+If you instead wanted to make the LLM aware of the sum function, and let it choose when to use it,
+customize the System Prompt to include it:
+
+> - When you need to add numbers, use @fn:sum
+
+## Getting More Help
+
+ChatCraft is still very young and evolving quickly. If you want to talk more about a problem,
+have an idea for a feature, or think you've found a bug, get in touch with us:
+
+- [GitHub](https://github.com/tarasglek/chatcraft.org)
+- [Discord](https://discord.gg/PE2GWHnR)
+`;
+
+function Help(props: MessageBaseProps) {
+  // Override the text of the message
+  const message = new ChatCraftAppMessage({ ...props.message, text: helpText });
+
+  return <MessageBase {...props} message={message} />;
+}
+
+export default memo(Help);

--- a/src/components/Message/AppMessage/index.tsx
+++ b/src/components/Message/AppMessage/index.tsx
@@ -4,6 +4,7 @@ import { Avatar } from "@chakra-ui/react";
 import MessageBase, { type MessageBaseProps } from "../MessageBase";
 import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
 import Instructions from "./Instructions";
+import Help from "./Help";
 
 type AppMessageProps = Omit<MessageBaseProps, "avatar">;
 
@@ -31,6 +32,12 @@ function AppMessage(props: AppMessageProps) {
         disableFork={true}
         disableEdit={true}
       />
+    );
+  }
+
+  if (ChatCraftAppMessage.isHelp(message)) {
+    return (
+      <Help {...props} avatar={avatar} heading={heading} disableFork={true} disableEdit={true} />
     );
   }
 

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -200,7 +200,7 @@ function PromptForm({
                     _dark={{ bg: "gray.700" }}
                     placeholder={
                       !isLoading
-                        ? "Type your question. Include @fn:name or @fn-url:https://... to call functions"
+                        ? "Type your question or use /help for more information"
                         : undefined
                     }
                     overflowY="auto"
@@ -217,7 +217,7 @@ function PromptForm({
                     _dark={{ bg: "gray.700" }}
                     placeholder={
                       !isLoading
-                        ? "Type your question. Include @fn:name or @fn-url:https://... to call functions"
+                        ? "Type your question or use /help for more information"
                         : undefined
                     }
                     overflowY="auto"

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -1,0 +1,23 @@
+import { ChatCraftChat } from "./ChatCraftChat";
+
+export abstract class ChatCraftCommand {
+  constructor(public command: string) {}
+
+  // This method should be overridden by subclasses to implement the command
+  abstract execute(chat: ChatCraftChat, user: User | undefined, args?: string[]): Promise<void>;
+
+  // Parses the command and arguments from an input string
+  static parseCommand(input: string): { command: string; args: string[] } | null {
+    const match = input.match(/^\/(\w+)(?:\s+(.*))?$/);
+    if (!match) return null;
+
+    const [, command, argString] = match;
+    const args = argString ? argString.split(/\s+/) : [];
+    return { command, args };
+  }
+
+  // Checks if a string is a command.
+  static isCommand(input: string): boolean {
+    return input.startsWith("/");
+  }
+}

--- a/src/lib/ChatCraftCommandRegistry.ts
+++ b/src/lib/ChatCraftCommandRegistry.ts
@@ -1,0 +1,31 @@
+// NOTE: import commands/index.ts to get all commands registered and the registry itself
+
+import { ChatCraftChat } from "./ChatCraftChat";
+import { ChatCraftCommand } from "./ChatCraftCommand";
+
+export class ChatCraftCommandRegistry {
+  private static commands: Map<string, ChatCraftCommand> = new Map();
+
+  static registerCommand(command: ChatCraftCommand): void {
+    this.commands.set(command.command, command);
+  }
+
+  static getCommand(input: string) {
+    const parsed = ChatCraftCommand.parseCommand(input);
+    if (!parsed) {
+      return null;
+    }
+
+    const command = this.commands.get(parsed.command);
+    if (!command) {
+      return null;
+    }
+
+    return (chat: ChatCraftChat, user: User | undefined) =>
+      command.execute(chat, user, parsed.args);
+  }
+
+  static isCommand(input: string): boolean {
+    return ChatCraftCommand.isCommand(input);
+  }
+}

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -1,0 +1,12 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+
+export class ClearCommand extends ChatCraftCommand {
+  constructor() {
+    super("clear");
+  }
+
+  async execute(chat: ChatCraftChat) {
+    return chat.resetMessages();
+  }
+}

--- a/src/lib/commands/HelpCommand.ts
+++ b/src/lib/commands/HelpCommand.ts
@@ -1,0 +1,13 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { ChatCraftAppMessage } from "../ChatCraftMessage";
+
+export class HelpCommand extends ChatCraftCommand {
+  constructor() {
+    super("help");
+  }
+
+  async execute(chat: ChatCraftChat) {
+    return chat.addMessage(new ChatCraftAppMessage({ text: "app:help" }));
+  }
+}

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -1,0 +1,70 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { ChatCraftHumanMessage } from "../ChatCraftMessage";
+
+// To keep this small, just deal with some common cases vs doing proper parser/list
+const guessType = (contentType: string | null) => {
+  if (!contentType) {
+    return "text";
+  }
+  contentType = contentType.toLowerCase().trim();
+
+  const typeMap: { [key: string]: string } = {
+    "text/html": "html",
+    "text/javascript": "javascript",
+    "application/javascript": "javascript",
+    "application/xml": "xml",
+    "application/atom+xml": "xml",
+    "application/rss+xml": "xml",
+    "application/json": "json",
+    "text/css": "css",
+    "text/markdown": "markdown",
+    "text/yaml": "yaml",
+    "text/x-python": "python",
+  };
+
+  for (const key in typeMap) {
+    if (contentType.startsWith(key)) {
+      return typeMap[key];
+    }
+  }
+
+  return "text";
+};
+
+export class ImportCommand extends ChatCraftCommand {
+  constructor() {
+    super("import");
+  }
+
+  async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {
+    if (!user) {
+      throw new Error("you must be logged-in before you can use the /import command");
+    }
+
+    if (!(args && args[0])) {
+      throw new Error("must include a URL in command arguments");
+    }
+
+    const [url] = args;
+
+    const res = await fetch(`/api/proxy?url=${encodeURIComponent(url)}`);
+    if (!res.ok) {
+      throw new Error(`Unable to proxy request for URL: ${res.statusText}`);
+    }
+
+    // TODO: deal with different various content-type values to parse text out
+    const type = guessType(res.headers.get("content-type"));
+    const content = (await res.text()).trim();
+
+    const command = `**Command**: import [${url}](${url})`;
+    const text =
+      `${command}\n\n` +
+      // If it's already markdown, dump it into the message as is;
+      // otherwise, wrap it in a code block with appropriate type
+      (type === "markdown" ? `${content}` : `\`\`\`${type}\n${content}`) +
+      `\n\`\`\``;
+
+    return chat.addMessage(new ChatCraftHumanMessage({ user, text }));
+  }
+}

--- a/src/lib/commands/NewCommand.ts
+++ b/src/lib/commands/NewCommand.ts
@@ -1,0 +1,11 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+
+export class NewCommand extends ChatCraftCommand {
+  constructor() {
+    super("new");
+  }
+
+  async execute() {
+    location.href = "/c/new";
+  }
+}

--- a/src/lib/commands/SummaryCommand.ts
+++ b/src/lib/commands/SummaryCommand.ts
@@ -1,0 +1,32 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { ChatCraftHumanMessage, ChatCraftSystemMessage } from "../ChatCraftMessage";
+import { chatWithLLM } from "../ai";
+
+export class SummaryCommand extends ChatCraftCommand {
+  constructor() {
+    super("summary");
+  }
+
+  async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {
+    const wordCount = Number(args?.[0]) ?? 500;
+
+    const systemChatMessage = new ChatCraftSystemMessage({
+      text: `You are an expert at summarizing chat history. You respond ONLY with the summary text and focus on the main content of the chat, NEVER mentioning the process, participants, and DON'T refer to "the chat"; that is, give a content summary and not a statement like "The chat involved..."`,
+    });
+
+    const summarizeInstruction = new ChatCraftHumanMessage({
+      text: `Summarize in ${wordCount} words or fewer.`,
+    });
+
+    const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: false });
+
+    return chatWithLLM([systemChatMessage, ...messages, summarizeInstruction]).promise.then(
+      (message) => {
+        const command = `**Command**: summary`;
+        const text = `${command}\n\n${message.text}`;
+        chat.addMessage(new ChatCraftHumanMessage({ user, text }));
+      }
+    );
+  }
+}

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -1,0 +1,15 @@
+import { ChatCraftCommandRegistry } from "../ChatCraftCommandRegistry";
+export { ChatCraftCommandRegistry };
+
+import { NewCommand } from "./NewCommand";
+import { ClearCommand } from "./ClearCommand";
+import { SummaryCommand } from "./SummaryCommand";
+import { HelpCommand } from "./HelpCommand";
+import { ImportCommand } from "./ImportCommand";
+
+// Register all our commands
+ChatCraftCommandRegistry.registerCommand(new NewCommand());
+ChatCraftCommandRegistry.registerCommand(new ClearCommand());
+ChatCraftCommandRegistry.registerCommand(new SummaryCommand());
+ChatCraftCommandRegistry.registerCommand(new HelpCommand());
+ChatCraftCommandRegistry.registerCommand(new ImportCommand());


### PR DESCRIPTION
This is an initial attempt to add "slash commands."  I'm not 100% sure about the UX yet, so I'm hoping that we can play with this PR and figure it out together.

A command is something a user enters in the prompt, and starts with `/`.  Currently, there are 4 commands defined:

1. `/new` creates a new blank chat
2. `/clear` clears the messages in the current chat
3. `/summary` or `/summary <word count>` creates a summary of the current chat, using `word count`.  For example, `/summary 15` would summarize in at most 15 words
4. `/github <github code URL>` fetches the file at the given GitHub URL and adds it to the chat as if you copy/pasted it.  For example: `/github https://github.com/tarasglek/chatcraft.org/blob/main/src/lib/summarize.ts`

See what you think and we can iterate.