### PR TITLE
Refactor Toasts into use-alert.ts hook

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -18,7 +18,6 @@ import {
   Tag,
   Text,
   useDisclosure,
-  useToast,
 } from "@chakra-ui/react";
 import { Link as ReactRouterLink, useFetcher } from "react-router-dom";
 import { MdOutlineChatBubbleOutline } from "react-icons/md";
@@ -31,6 +30,7 @@ import { download, formatDate, formatNumber } from "../lib/utils";
 import ShareModal from "../components/ShareModal";
 import { useSettings } from "../hooks/use-settings";
 import useTitle from "../hooks/use-title";
+import { useAlert } from "../hooks/use-alert";
 
 type ChatHeaderProps = {
   chat: ChatCraftChat;
@@ -38,7 +38,7 @@ type ChatHeaderProps = {
 
 function ChatHeader({ chat }: ChatHeaderProps) {
   const [, copyToClipboard] = useCopyToClipboard();
-  const toast = useToast();
+  const { info, error } = useAlert();
   const fetcher = useFetcher();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [tokens, setTokens] = useState<number | null>(null);
@@ -61,24 +61,16 @@ function ChatHeader({ chat }: ChatHeaderProps) {
   const handleCopyChatClick = () => {
     const text = chat.toMarkdown();
     copyToClipboard(text);
-    toast({
-      colorScheme: "blue",
+    info({
       title: "Chat copied to clipboard",
-      status: "success",
-      position: "top",
-      isClosable: true,
     });
   };
 
   const handleDownloadClick = () => {
     const text = chat.toMarkdown();
     download(text, "chat.md", "text/markdown");
-    toast({
-      colorScheme: "blue",
+    info({
       title: "Chat downloaded as Markdown",
-      status: "success",
-      position: "top",
-      isClosable: true,
     });
   };
 
@@ -100,12 +92,9 @@ function ChatHeader({ chat }: ChatHeaderProps) {
       .save()
       .catch((err) => {
         console.warn("Unable to update summary for chat", err);
-        toast({
+        error({
           title: `Error Updating Chat`,
-          description: "message" in err ? err.message : undefined,
-          status: "error",
-          position: "top",
-          isClosable: true,
+          message: err.message,
         });
       })
       .finally(() => setIsEditing(false));

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -16,7 +16,6 @@ import {
   MenuItem,
   MenuDivider,
   CardFooter,
-  useToast,
 } from "@chakra-ui/react";
 import { LuFunctionSquare } from "react-icons/lu";
 import { useFetcher, useLoaderData } from "react-router-dom";
@@ -31,10 +30,11 @@ import FunctionEditor from "./FunctionEditor";
 import { TbDots } from "react-icons/tb";
 import { download, formatDate } from "../lib/utils";
 import { useLiveQuery } from "dexie-react-hooks";
+import { useAlert } from "../hooks/use-alert";
 
 export default function Function() {
   const [, copyToClipboard] = useCopyToClipboard();
-  const toast = useToast();
+  const { info } = useAlert();
   const fetcher = useFetcher();
 
   const funcId = useLoaderData() as string;
@@ -87,24 +87,16 @@ export default function Function() {
   const handleCopyFunctionClick = () => {
     const text = func.code;
     copyToClipboard(text);
-    toast({
-      colorScheme: "blue",
+    info({
       title: "Function copied to clipboard",
-      status: "success",
-      position: "top",
-      isClosable: true,
     });
   };
 
   const handleDownloadFunctionClick = () => {
     const text = func.code;
     download(text, filename, "text/javascript");
-    toast({
-      colorScheme: "blue",
+    info({
       title: "Function downloaded",
-      status: "success",
-      position: "top",
-      isClosable: true,
     });
   };
 

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -3,7 +3,6 @@ import {
   Flex,
   ButtonGroup,
   IconButton,
-  useToast,
   useClipboard,
   useColorModeValue,
   Text,
@@ -12,6 +11,7 @@ import {
 import { TbCopy, TbDownload, TbRun } from "react-icons/tb";
 
 import { download, formatAsCodeBlock } from "../lib/utils";
+import { useAlert } from "../hooks/use-alert";
 
 type PreHeaderProps = {
   language: string;
@@ -31,33 +31,25 @@ function CodeHeader({
   codeDownloadFilename,
 }: PreHeaderProps) {
   const { onCopy } = useClipboard(code);
-  const toast = useToast();
+  const { info } = useAlert();
   // Only show the "Run" button for JS code blocks, and only when we aren't already loading
   const shouldShowRunButton = (language === "js" || language === "javascript") && onPrompt;
 
   const handleCopy = useCallback(() => {
     onCopy();
-    toast({
+    info({
       title: "Copied to Clipboard",
-      description: "Code was copied to your clipboard.",
-      status: "info",
-      duration: 3000,
-      position: "top",
-      isClosable: true,
+      message: "Code was copied to your clipboard.",
     });
-  }, [onCopy, toast]);
+  }, [onCopy, info]);
 
   const handleDownload = useCallback(() => {
     download(code, codeDownloadFilename ?? "code.txt");
-    toast({
+    info({
       title: "Downloaded",
-      description: "Code was downloaded as a file",
-      status: "info",
-      duration: 3000,
-      position: "top",
-      isClosable: true,
+      message: "Code was downloaded as a file",
     });
-  }, [toast, code, codeDownloadFilename]);
+  }, [info, code, codeDownloadFilename]);
 
   const handleRun = useCallback(async () => {
     if (!onPrompt) {

--- a/src/components/MermaidPreview.tsx
+++ b/src/components/MermaidPreview.tsx
@@ -1,8 +1,9 @@
 import { memo, useCallback, useEffect, useRef } from "react";
-import { Card, CardBody, IconButton, useClipboard, useToast } from "@chakra-ui/react";
+import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
 import mermaid from "mermaid";
 import { TbCopy } from "react-icons/tb";
 import { nanoid } from "nanoid";
+import { useAlert } from "../hooks/use-alert";
 
 type MermaidPreviewProps = {
   children: React.ReactNode & React.ReactNode[];
@@ -10,21 +11,17 @@ type MermaidPreviewProps = {
 
 const MermaidPreview = ({ children }: MermaidPreviewProps) => {
   const { onCopy, value, setValue } = useClipboard("");
-  const toast = useToast();
+  const { info } = useAlert();
   const diagramRef = useRef<HTMLDivElement | null>(null);
   const code = String(children);
 
   const handleCopy = useCallback(() => {
     onCopy();
-    toast({
+    info({
       title: "Copied to Clipboard",
-      description: "Mermaid SVG diagram was copied to your clipboard.",
-      status: "info",
-      duration: 3000,
-      position: "top",
-      isClosable: true,
+      message: "Mermaid SVG diagram was copied to your clipboard.",
     });
-  }, [onCopy, toast]);
+  }, [onCopy, info]);
 
   // Render the diagram as an SVG into our card's body
   useEffect(() => {

--- a/src/components/Message/AiMessage.tsx
+++ b/src/components/Message/AiMessage.tsx
@@ -1,14 +1,5 @@
 import { memo, useCallback, useEffect, useState } from "react";
-import {
-  Box,
-  HStack,
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  useToast,
-} from "@chakra-ui/react";
+import { Box, HStack, IconButton, Menu, MenuButton, MenuItem, MenuList } from "@chakra-ui/react";
 import { TbChevronDown } from "react-icons/tb";
 
 import MessageBase, { type MessageBaseProps } from "./MessageBase";
@@ -20,6 +11,7 @@ import { ChatCraftModel } from "../../lib/ChatCraftModel";
 import useChatOpenAI from "../../hooks/use-chat-openai";
 import NewMessage from "./NewMessage";
 import ModelAvatar from "../ModelAvatar";
+import { useAlert } from "../../hooks/use-alert";
 
 // If there are multiple versions in an AI message, add some UI to switch between them
 function MessageVersionsMenu({
@@ -31,7 +23,7 @@ function MessageVersionsMenu({
   chatId: string;
   isDisabled: boolean;
 }) {
-  const toast = useToast();
+  const { error } = useAlert();
   const { versions } = message;
   if (versions?.length <= 1) {
     return null;
@@ -41,12 +33,9 @@ function MessageVersionsMenu({
     message.switchVersion(versionId);
     message.save(chatId).catch((err) => {
       console.warn("Unable to switch versions", err);
-      toast({
+      error({
         title: `Error Updating Message to Version`,
-        description: "message" in err ? err.message : undefined,
-        status: "error",
-        position: "top",
-        isClosable: true,
+        message: err.message,
       });
     });
   };

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -21,7 +21,6 @@ import {
   Textarea,
   VStack,
   useClipboard,
-  useToast,
 } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
 import { TbDots, TbTrash } from "react-icons/tb";
@@ -42,6 +41,7 @@ import { ChatCraftModel } from "../../lib/ChatCraftModel";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 import { useSettings } from "../../hooks/use-settings";
+import { useAlert } from "../../hooks/use-alert";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -87,7 +87,7 @@ function MessageBase({
   const { id, date, text } = message;
   const { models } = useModels();
   const { onCopy } = useClipboard(text);
-  const toast = useToast();
+  const { info, error } = useAlert();
   const [isHovering, setIsHovering] = useState(false);
   const { settings } = useSettings();
   const [tokens, setTokens] = useState<number | null>(null);
@@ -100,27 +100,19 @@ function MessageBase({
 
   const handleCopy = useCallback(() => {
     onCopy();
-    toast({
+    info({
       title: "Copied to Clipboard",
-      description: "Message text was copied to your clipboard.",
-      status: "info",
-      duration: 3000,
-      position: "top",
-      isClosable: true,
+      message: "Message text was copied to your clipboard.",
     });
-  }, [onCopy, toast]);
+  }, [onCopy, info]);
 
   const handleDownload = useCallback(() => {
     download(text, "message.md");
-    toast({
+    info({
       title: "Downloaded",
-      description: "Message was downloaded as a file",
-      status: "info",
-      duration: 3000,
-      position: "top",
-      isClosable: true,
+      message: "Message was downloaded as a file",
     });
-  }, [toast, text]);
+  }, [info, text]);
 
   const handleSubmit = useCallback(
     (e: FormEvent<HTMLFormElement>) => {
@@ -148,12 +140,9 @@ function MessageBase({
           .save(chatId)
           .catch((err) => {
             console.warn("Unable to update message", err);
-            toast({
+            error({
               title: `Error Updating Message`,
-              description: "message" in err ? err.message : undefined,
-              status: "error",
-              position: "top",
-              isClosable: true,
+              message: err.message,
             });
           })
           .finally(() => onEditingChange(false));
@@ -164,18 +153,15 @@ function MessageBase({
           .save(chatId)
           .catch((err) => {
             console.warn("Unable to update message", err);
-            toast({
+            error({
               title: `Error Updating Message`,
-              description: "message" in err ? err.message : undefined,
-              status: "error",
-              position: "top",
-              isClosable: true,
+              message: err.message,
             });
           })
           .finally(() => onEditingChange(false));
       }
     },
-    [message, toast, chatId, onEditingChange]
+    [message, error, chatId, onEditingChange]
   );
 
   return (

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo } from "react";
-import { Box, useColorMode, useToast } from "@chakra-ui/react";
+import { Box, useColorMode } from "@chakra-ui/react";
 import mermaid from "mermaid";
 
 import Message from "./Message";
@@ -12,6 +12,7 @@ import {
 } from "../lib/ChatCraftMessage";
 import { useSettings } from "../hooks/use-settings";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { useAlert } from "../hooks/use-alert";
 
 type MessagesViewProps = {
   chat: ChatCraftChat;
@@ -38,7 +39,7 @@ function MessagesView({
 }: MessagesViewProps) {
   const { colorMode } = useColorMode();
   const { settings } = useSettings();
-  const toast = useToast();
+  const { error } = useAlert();
   const messages = chat.messages();
   const chatId = chat.id;
 
@@ -64,16 +65,13 @@ function MessagesView({
           await chat.removeMessagesAfter(messageId);
         }
       } catch (err: any) {
-        toast({
+        error({
           title: `Error Deleting Messages`,
-          description: err.message,
-          status: "error",
-          position: "top",
-          isClosable: true,
+          message: err.message,
         });
       }
     },
-    [chat, toast]
+    [chat, error]
   );
 
   // Memoize the previous messages so we don't have to update when newMessage changes

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -12,7 +12,6 @@ import {
   useColorModeValue,
   IconButton,
   ButtonGroup,
-  useToast,
   Input,
   Divider,
 } from "@chakra-ui/react";
@@ -31,6 +30,7 @@ import { formatDate, formatNumber } from "../lib/utils";
 import { SharedChatCraftChat } from "../lib/SharedChatCraftChat";
 import { useUser } from "../hooks/use-user";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
+import { useAlert } from "../hooks/use-alert";
 
 /**
  * Chat Sidebar Items
@@ -53,7 +53,7 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
     isSelected ? "gray.300" : "gray.100",
     isSelected ? "gray.900" : "gray.600"
   );
-  const toast = useToast();
+  const { error } = useAlert();
   const [isEditing, setIsEditing] = useState(false);
   useKey("Escape", () => setIsEditing(false), { event: "keydown" }, [setIsEditing]);
   const selectedRef = useRef<HTMLDivElement>(null);
@@ -86,12 +86,9 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
       .save()
       .catch((err) => {
         console.warn("Unable to update summary for chat", err);
-        toast({
+        error({
           title: `Error Updating Chat`,
-          description: "message" in err ? err.message : undefined,
-          status: "error",
-          position: "top",
-          isClosable: true,
+          message: err.message,
         });
       })
       .finally(() => setIsEditing(false));

--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -1,0 +1,41 @@
+import { useToast } from "@chakra-ui/react";
+
+type AlertArguments = {
+  // Use `id` if you want to avoid duplicate alerts showing
+  id?: string;
+  title: string;
+  message?: string;
+};
+
+export function useAlert() {
+  const toast = useToast();
+
+  const info = ({ id, title, message }: AlertArguments) =>
+    toast({
+      id,
+      title,
+      description: message,
+      colorScheme: "blue",
+      status: "success",
+      position: "top",
+      isClosable: true,
+      duration: 3000,
+    });
+
+  const error = ({ id, title, message }: AlertArguments) =>
+    toast({
+      id,
+      title,
+      description: message,
+      status: "error",
+      position: "top",
+      isClosable: true,
+      // Don't auto-close errors
+      duration: null,
+    });
+
+  return {
+    info,
+    error,
+  };
+}


### PR DESCRIPTION
From https://github.com/tarasglek/chatcraft.org/issues/214#issuecomment-1676429372, this change updates how we do info and error alerts.  The info alerts disappear after 3 seconds, while errors have to be closed manually (i.e. to give the user time to read them).

I've moved all the calls to the Chakra-UI `Toast` component/hook into a new `useAlert()` hook that manages the settings we use.