### PR TITLE
I wanna be able to run ES6 modules and TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dexie": "^3.2.4",
     "dexie-export-import": "^4.0.7",
     "dexie-react-hooks": "^1.1.6",
+    "esbuild-wasm": "^0.19.2",
     "framer-motion": "^10.15.0",
     "jose": "^4.14.4",
     "langchain": "^0.0.120",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ dependencies:
   dexie-react-hooks:
     specifier: ^1.1.6
     version: 1.1.6(@types/react@18.2.18)(dexie@3.2.4)(react@18.2.0)
+  esbuild-wasm:
+    specifier: ^0.19.2
+    version: 0.19.2
   framer-motion:
     specifier: ^10.15.0
     version: 10.15.0(react-dom@18.2.0)(react@18.2.0)
@@ -7065,6 +7068,15 @@ packages:
       is-date-object: 1.0.5
       is-symbol: 1.0.4
     dev: true
+
+  /esbuild-wasm@0.19.2:
+    resolution:
+      {
+        integrity: sha512-ak2XIIJKby+Uo3Iqh8wtw4pn2uZcnfLgtcmBHIgkShpun5ZIJsFigWXp7uLt7gXk3QAOCMmv0TSsIxD5qdn+Vw==,
+      }
+    engines: { node: ">=12" }
+    hasBin: true
+    dev: false
 
   /esbuild@0.16.3:
     resolution:

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -39,7 +39,8 @@ async function runJavascript(code: string) {
           "Chatcraft: Evaling code in a module context, must `export default <your val>` at end to return a value"
         );
       }
-      const module = await import("data:text/javascript;base64," + btoa(code) /* @vite-ignore */);
+      const blob = new Blob([code], { type: "text/javascript" });
+      const module = await import(URL.createObjectURL(blob) /* @vite-ignore */);
       return module.default;
     } else {
       throw error;

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -9,10 +9,40 @@ export function isRunnable(language: string) {
   return supportedLanguages.includes(language);
 }
 
-export async function runCode(code: string, language: string) {
-  if (isJS(language)) {
+/**
+ * Run JavaScript code in eval() context, to support returning values from simple expressions `1+1`
+ * and also support `import * as esbuild from 'https://cdn.skypack.dev/esbuild-wasm@0.19.2'` via ES6 modules fallback
+ */
+async function runJS(code: string) {
+  try {
     const fn = new Function(`return eval(${JSON.stringify(code)});`);
     return fn();
+  } catch (error: any) {
+    const msgLower = error.message.toLowerCase();
+    const maybeES6Module =
+      error instanceof SyntaxError &&
+      // Cannot use import statement outside a module
+      // import declarations may only appear at top level of a module
+      msgLower.includes("module") &&
+      msgLower.includes("import");
+    if (maybeES6Module) {
+      // check if code has export.*default regexp
+      if (!/export\s+default\s+/.test(code)) {
+        console.warn(
+          "Chatcraft: Evaling code in a module context, must `export default =` at end to return a value"
+        );
+      }
+      const module = await import("data:text/javascript;base64," + btoa(code));
+      return module.default;
+    } else {
+      throw error;
+    }
+  }
+}
+
+export async function runCode(code: string, language: string) {
+  if (isJS(language)) {
+    return runJS(code);
   }
   throw new Error(`Unsupported language: ${language}`);
 }

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -3,6 +3,7 @@ import * as esbuild from "esbuild-wasm";
 const supportedJS = ["js", "javascript"];
 const supportedTS = ["ts", "typescript"];
 const supportedLanguages = [...supportedJS, ...supportedTS];
+
 function isJavaScript(language: string) {
   return supportedJS.includes(language);
 }
@@ -38,7 +39,7 @@ async function runJavascript(code: string) {
           "Chatcraft: Evaling code in a module context, must `export default <your val>` at end to return a value"
         );
       }
-      const module = await import("data:text/javascript;base64," + btoa(code));
+      const module = await import("data:text/javascript;base64," + btoa(code) /* @vite-ignore */);
       return module.default;
     } else {
       throw error;
@@ -50,7 +51,8 @@ async function compileWithEsbuild(tsCode: string) {
   try {
     await esbuild.initialize({
       // no idea how to load the bundled wasm file from esbuild-wasm in vite
-      wasmURL: "https://cdn.jsdelivr.net/npm/esbuild-wasm@0.19.2/esbuild.wasm",
+      wasmURL:
+        "../../node_modules/.pnpm/esbuild-wasm@0.19.2/node_modules/esbuild-wasm/esbuild.wasm",
     });
   } catch (error: any) {
     if (!error.message.includes('Cannot call "initialize" more than once')) {

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -35,7 +35,7 @@ async function runJavascript(code: string) {
       // check if code has export.*default regexp
       if (!/export\s+default\s+/.test(code)) {
         console.warn(
-          "Chatcraft: Evaling code in a module context, must `export default =` at end to return a value"
+          "Chatcraft: Evaling code in a module context, must `export default <your val>` at end to return a value"
         );
       }
       const module = await import("data:text/javascript;base64," + btoa(code));
@@ -46,15 +46,16 @@ async function runJavascript(code: string) {
   }
 }
 
-let esbuildLoaded = false;
-
 async function compileWithEsbuild(tsCode: string) {
-  if (!esbuildLoaded) {
+  try {
     await esbuild.initialize({
       // no idea how to load the bundled wasm file from esbuild-wasm in vite
       wasmURL: "https://cdn.jsdelivr.net/npm/esbuild-wasm@0.19.2/esbuild.wasm",
     });
-    esbuildLoaded = true;
+  } catch (error: any) {
+    if (!error.message.includes('Cannot call "initialize" more than once')) {
+      throw error;
+    }
   }
   // Compile TypeScript code
   const js = await esbuild.transform(tsCode, {

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -1,0 +1,18 @@
+const supportedJS = ["js", "javascript"];
+const supportedLanguages = supportedJS;
+
+function isJS(language: string) {
+  return supportedJS.includes(language);
+}
+
+export function isRunnable(language: string) {
+  return supportedLanguages.includes(language);
+}
+
+export async function runCode(code: string, language: string) {
+  if (isJS(language)) {
+    const fn = new Function(`return eval(${JSON.stringify(code)});`);
+    return fn();
+  }
+  throw new Error(`Unsupported language: ${language}`);
+}


### PR DESCRIPTION
Now I can https://taras-typescript.console-overthinker-dev.pages.dev/c/chatcraft_dev/0AjZxclU4CWxM_n2dG2bK (having share on dev branches rules!)

Needed some esbuild handholding with chatcraft to get here.

As a fun followup would be fun to add a python wasm runtime via something like https://www.npmjs.com/package/python-wasm