### PR TITLE
Use OpenAI client to get list of models vs. fetch()

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "esbuild-wasm": "^0.19.2",
     "framer-motion": "^10.15.0",
     "jose": "^4.14.4",
-    "openai": "^4.0.0",
+    "openai": "^4.3.0",
     "lodash": "^4.17.21",
     "mermaid": "^10.3.0",
     "nanoid": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,8 +51,8 @@ dependencies:
     specifier: ^4.0.2
     version: 4.0.2
   openai:
-    specifier: ^4.0.0
-    version: 4.0.0
+    specifier: ^4.3.0
+    version: 4.3.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -10119,10 +10119,10 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
-  /openai@4.0.0:
+  /openai@4.3.0:
     resolution:
       {
-        integrity: sha512-UHv70gIw20pxu9tiUueE9iS+4U4eTGiTgQr+zlJ5aX4oj6LUUp+7mBn0xAqilawftwUB/biohPth2vcZFmoNYw==,
+        integrity: sha512-ObF5jxvZoQbCNAI6FiiNkzFDinBRbu4KPm73/PKCy9UvjI24kPpnN9kK56rtPDVYxfk78C0A2SK0bJAE633BuQ==,
       }
     hasBin: true
     dependencies:


### PR DESCRIPTION
Fixes #232 

This updates the code that queries the list of models so it uses the official client vs. doing a raw `fetch()`.  I'm hoping this will help us avoid issues.

I've also bumped the OpenAI client version to reflect the current release.