### PR TITLE
Rework New > Clear to reuse current tab, not lose data

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -336,7 +336,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         <Box maxW="900px" mx="auto" h="100%">
           {chat.readonly ? (
             <Flex w="100%" h="45px" justify="end" align="center" p={2}>
-              <NewButton forkUrl={`./fork`} variant="solid" disableClear={chat.readonly} />
+              <NewButton forkUrl={`./fork`} variant="solid" />
             </Flex>
           ) : (
             <PromptForm

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -149,7 +149,7 @@ export default function Search() {
 
       <GridItem>
         <Flex w="100%" maxW="900px" mx="auto" h="45px" justify="end" align="center" p={2}>
-          <NewButton variant="solid" disableClear={true} />
+          <NewButton variant="solid" />
         </Flex>
       </GridItem>
     </Grid>

--- a/src/components/NewButton.tsx
+++ b/src/components/NewButton.tsx
@@ -4,17 +4,20 @@ import { TbPlus } from "react-icons/tb";
 
 type NewButtonProps = {
   forkUrl?: string;
-  disableClear?: boolean;
   variant?: "outline" | "solid" | "ghost";
 };
 
-function NewButton({ forkUrl, variant = "outline", disableClear }: NewButtonProps) {
+function NewButton({ forkUrl, variant = "outline" }: NewButtonProps) {
   return (
     <Menu>
       <MenuButton as={Button} size="sm" variant={variant} rightIcon={<TbPlus />}>
         New
       </MenuButton>
       <MenuList>
+        <MenuItem as={ReactRouterLink} to="/new">
+          Clear Chat
+        </MenuItem>
+        <MenuDivider />
         <MenuItem as={ReactRouterLink} to="/new" target="_blank">
           New Blank Chat...
         </MenuItem>
@@ -22,14 +25,6 @@ function NewButton({ forkUrl, variant = "outline", disableClear }: NewButtonProp
           <MenuItem as={ReactRouterLink} to={forkUrl} target="_blank">
             New Duplicate Chat...
           </MenuItem>
-        )}
-        {!disableClear && (
-          <>
-            <MenuDivider />
-            <MenuItem as={ReactRouterLink} to="./reset-messages">
-              Clear Messages
-            </MenuItem>
-          </>
         )}
       </MenuList>
     </Menu>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -87,27 +87,6 @@ export default createBrowserRouter([
       return redirect("/");
     },
   },
-  // Reset the current set of messages in a chat
-  {
-    path: "/c/:id/reset-messages",
-    async loader({ params }) {
-      const { id } = params;
-      if (!id) {
-        return redirect(`/`);
-      }
-
-      try {
-        const chat = await ChatCraftChat.find(id);
-        if (chat) {
-          await chat.resetMessages();
-        }
-      } catch (err) {
-        console.warn("Unable to reset chat messages", { id, err });
-      }
-
-      return redirect(`/c/${id}`);
-    },
-  },
   // Fork an existing local chat and redirect to it. If a `messageId` is included,
   // use that as our starting message vs. whole chat (partial fork)
   {


### PR DESCRIPTION
This updates how the "Clear" logic works.  We've had users complain of losing work, and the way that "Clear" used to work was part of it.  In the past, "Clear" would delete the messages for the current chat from the db, which also clears them from the UI.  This is obvious if you understand what it does, but not what many expect.

Therefore, we're going to try something different:

- `Clear Chat` - create a new chat in the current tab (i.e., re-use this window).  No data is deleted, previous chat is available in db as before
- `New Blank Chat...` - create a new chat in a new tab

So they do the same thing, but how the tabs work is different.

I haven't removed the `/clear` command, which still deletes the data.  We also have `/new`, so I'm not sure if I need to?