### PR TITLE
Audio recording and speech recogntion

### DIFF
--- a/src/components/MicIcon.tsx
+++ b/src/components/MicIcon.tsx
@@ -1,24 +1,24 @@
 import { useState } from "react";
 import { IconButton } from "@chakra-ui/react";
 import { TbMicrophone } from "react-icons/tb";
-import { motion, useSpring } from "framer-motion";
-
-// import { useSettings } from "../hooks/use-settings";
+import { motion, useMotionValue } from "framer-motion";
 
 type MicIconProps = {
   onRecordingStart: () => void;
   onRecordingStop: () => void;
   onRecordingCancel: () => void;
+  isDisabled: boolean;
 };
 
 export default function MicIcon({
   onRecordingStart,
   onRecordingStop,
   onRecordingCancel,
+  isDisabled = false,
 }: MicIconProps) {
-  const spring = useSpring(0, { stiffness: 530, damping: 25 });
   const [colorScheme, setColorScheme] = useState<"blue" | "red">("blue");
   const [isRecording, setIsRecording] = useState(false);
+  const x = useMotionValue(0);
 
   const handleRecordingStart = () => {
     setIsRecording(true);
@@ -55,11 +55,13 @@ export default function MicIcon({
           handleRecordingCancel();
         }
         setColorScheme("blue");
+        x.set(0);
       }}
-      style={{ x: spring }}
+      style={{ x }}
     >
       <IconButton
         isRound
+        isDisabled={isDisabled}
         colorScheme={colorScheme}
         icon={<TbMicrophone />}
         variant={isRecording ? "solid" : "ghost"}

--- a/src/components/MicIcon.tsx
+++ b/src/components/MicIcon.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import { IconButton } from "@chakra-ui/react";
+import { TbMicrophone } from "react-icons/tb";
+import { motion, useSpring } from "framer-motion";
+
+// import { useSettings } from "../hooks/use-settings";
+
+type MicIconProps = {
+  onRecordingStart: () => void;
+  onRecordingStop: () => void;
+  onRecordingCancel: () => void;
+};
+
+export default function MicIcon({
+  onRecordingStart,
+  onRecordingStop,
+  onRecordingCancel,
+}: MicIconProps) {
+  const spring = useSpring(0, { stiffness: 530, damping: 25 });
+  const [colorScheme, setColorScheme] = useState<"blue" | "red">("blue");
+  const [isRecording, setIsRecording] = useState(false);
+
+  const handleRecordingStart = () => {
+    setIsRecording(true);
+    onRecordingStart();
+  };
+
+  const handleRecordingStop = () => {
+    setIsRecording(false);
+    onRecordingStop();
+  };
+
+  const handleRecordingCancel = () => {
+    setIsRecording(false);
+    onRecordingCancel();
+  };
+
+  return (
+    <motion.div
+      drag="x"
+      dragConstraints={{ left: 0, right: 0 }}
+      dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
+      dragElastic={1}
+      onTapStart={() => handleRecordingStart()}
+      onTap={() => handleRecordingStop()}
+      onDrag={(_event, info) => {
+        if (info.offset.x < -100) {
+          setColorScheme("red");
+        } else {
+          setColorScheme("blue");
+        }
+      }}
+      onDragEnd={(_event, info) => {
+        if (info.offset.x < -100) {
+          handleRecordingCancel();
+        }
+        setColorScheme("blue");
+      }}
+      style={{ x: spring }}
+    >
+      <IconButton
+        isRound
+        colorScheme={colorScheme}
+        icon={<TbMicrophone />}
+        variant={isRecording ? "solid" : "ghost"}
+        aria-label="Record speech"
+        size="sm"
+        fontSize="16px"
+      />
+    </motion.div>
+  );
+}

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, KeyboardEvent, useEffect, useState, type RefObject } from "react";
+import { FormEvent, KeyboardEvent, useEffect, useState, type RefObject, useRef } from "react";
 import {
   Box,
   Button,
@@ -20,7 +20,7 @@ import {
   InputRightElement,
 } from "@chakra-ui/react";
 import { CgChevronUpO, CgChevronDownO } from "react-icons/cg";
-import { TbChevronUp, TbMicrophone } from "react-icons/tb";
+import { TbChevronUp } from "react-icons/tb";
 
 import AutoResizingTextarea from "./AutoResizingTextarea";
 
@@ -29,6 +29,8 @@ import { useModels } from "../hooks/use-models";
 import { isMac, isWindows, formatCurrency } from "../lib/utils";
 import NewButton from "./NewButton";
 import { useCost } from "../hooks/use-cost";
+import MicIcon from "./MicIcon";
+import { SpeechRecognition } from "../lib/speech-recognition";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -93,6 +95,7 @@ function PromptForm({
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
   const { cost } = useCost();
+  const speechRecognitionRef = useRef<SpeechRecognition>();
 
   // If the user clears the prompt, allow up-arrow again
   useEffect(() => {
@@ -150,6 +153,23 @@ function PromptForm({
     }
   };
 
+  const onRecordingStart = () => {
+    speechRecognitionRef.current = new SpeechRecognition();
+    speechRecognitionRef.current.start();
+  };
+
+  const onRecordingStop = () => {
+    if (speechRecognitionRef.current) {
+      speechRecognitionRef.current.stop();
+    }
+  };
+
+  const onRecordingCancel = () => {
+    if (speechRecognitionRef.current) {
+      speechRecognitionRef.current.cancel();
+    }
+  };
+
   return (
     <Flex direction="column" h="100%" px={1}>
       {settings.apiKey && (
@@ -189,18 +209,6 @@ function PromptForm({
                 h={isExpanded ? "100%" : undefined}
               >
                 {isExpanded ? (
-                  /**
- *     <InputGroup size="md">
-      <Input {...props} pr="4.5rem" type={show ? "text" : "password"} />
-      <InputRightElement width="4.5rem">
-        <Button variant="ghost" h="1.75rem" size="sm" onClick={() => setShow(!show)}>
-          {show ? "Hide" : "Show"}
-        </Button>
-      </InputRightElement>
-    </InputGroup>
-
- */
-
                   <InputGroup h="100%">
                     <Textarea
                       ref={inputPromptRef}
@@ -213,22 +221,15 @@ function PromptForm({
                       onChange={(e) => setPrompt(e.target.value)}
                       bg="white"
                       _dark={{ bg: "gray.700" }}
-                      placeholder={
-                        !isLoading
-                          ? "Type your question or use /help for more information"
-                          : undefined
-                      }
+                      placeholder={!isLoading ? "Type your question or use /help" : undefined}
                       overflowY="auto"
                       pr={12}
                     />
                     <InputRightElement mr={2}>
-                      <IconButton
-                        isRound
-                        icon={<TbMicrophone />}
-                        variant="ghost"
-                        aria-label="Record speech"
-                        size="sm"
-                        fontSize="16px"
+                      <MicIcon
+                        onRecordingStart={onRecordingStart}
+                        onRecordingStop={onRecordingStop}
+                        onRecordingCancel={onRecordingCancel}
                       />
                     </InputRightElement>
                   </InputGroup>
@@ -243,22 +244,15 @@ function PromptForm({
                       onChange={(e) => setPrompt(e.target.value)}
                       bg="white"
                       _dark={{ bg: "gray.700" }}
-                      placeholder={
-                        !isLoading
-                          ? "Type your question or use /help for more information"
-                          : undefined
-                      }
+                      placeholder={!isLoading ? "Type your question or use /help" : undefined}
                       overflowY="auto"
                       pr={8}
                     />
                     <InputRightElement>
-                      <IconButton
-                        isRound
-                        icon={<TbMicrophone />}
-                        variant="ghost"
-                        aria-label="Record speech"
-                        size="sm"
-                        fontSize="16px"
+                      <MicIcon
+                        onRecordingStart={onRecordingStart}
+                        onRecordingStop={onRecordingStop}
+                        onRecordingCancel={onRecordingCancel}
                       />
                     </InputRightElement>
                   </InputGroup>

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -160,9 +160,11 @@ function PromptForm({
 
   const onRecordingStop = async () => {
     if (speechRecognitionRef.current) {
+      // How do I make exceptions here show up in toast?
       const transcript = await speechRecognitionRef.current.stop();
       if (transcript) {
-        setPrompt(transcript);
+        // this feels much better than setPrompt then force user to click
+        onSendClick(transcript);
       }
     }
   };

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -16,9 +16,11 @@ import {
   Textarea,
   HStack,
   Tag,
+  InputGroup,
+  InputRightElement,
 } from "@chakra-ui/react";
 import { CgChevronUpO, CgChevronDownO } from "react-icons/cg";
-import { TbChevronUp } from "react-icons/tb";
+import { TbChevronUp, TbMicrophone } from "react-icons/tb";
 
 import AutoResizingTextarea from "./AutoResizingTextarea";
 
@@ -187,41 +189,79 @@ function PromptForm({
                 h={isExpanded ? "100%" : undefined}
               >
                 {isExpanded ? (
-                  <Textarea
-                    ref={inputPromptRef}
-                    h="100%"
-                    resize="none"
-                    isDisabled={isLoading}
-                    onKeyDown={handleKeyDown}
-                    autoFocus={true}
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    bg="white"
-                    _dark={{ bg: "gray.700" }}
-                    placeholder={
-                      !isLoading
-                        ? "Type your question or use /help for more information"
-                        : undefined
-                    }
-                    overflowY="auto"
-                  />
+                  /**
+ *     <InputGroup size="md">
+      <Input {...props} pr="4.5rem" type={show ? "text" : "password"} />
+      <InputRightElement width="4.5rem">
+        <Button variant="ghost" h="1.75rem" size="sm" onClick={() => setShow(!show)}>
+          {show ? "Hide" : "Show"}
+        </Button>
+      </InputRightElement>
+    </InputGroup>
+
+ */
+
+                  <InputGroup h="100%">
+                    <Textarea
+                      ref={inputPromptRef}
+                      h="100%"
+                      resize="none"
+                      isDisabled={isLoading}
+                      onKeyDown={handleKeyDown}
+                      autoFocus={true}
+                      value={prompt}
+                      onChange={(e) => setPrompt(e.target.value)}
+                      bg="white"
+                      _dark={{ bg: "gray.700" }}
+                      placeholder={
+                        !isLoading
+                          ? "Type your question or use /help for more information"
+                          : undefined
+                      }
+                      overflowY="auto"
+                      pr={12}
+                    />
+                    <InputRightElement mr={2}>
+                      <IconButton
+                        isRound
+                        icon={<TbMicrophone />}
+                        variant="ghost"
+                        aria-label="Record speech"
+                        size="sm"
+                        fontSize="16px"
+                      />
+                    </InputRightElement>
+                  </InputGroup>
                 ) : (
-                  <AutoResizingTextarea
-                    ref={inputPromptRef}
-                    onKeyDown={handleKeyDown}
-                    isDisabled={isLoading}
-                    autoFocus={true}
-                    value={prompt}
-                    onChange={(e) => setPrompt(e.target.value)}
-                    bg="white"
-                    _dark={{ bg: "gray.700" }}
-                    placeholder={
-                      !isLoading
-                        ? "Type your question or use /help for more information"
-                        : undefined
-                    }
-                    overflowY="auto"
-                  />
+                  <InputGroup h="100%">
+                    <AutoResizingTextarea
+                      ref={inputPromptRef}
+                      onKeyDown={handleKeyDown}
+                      isDisabled={isLoading}
+                      autoFocus={true}
+                      value={prompt}
+                      onChange={(e) => setPrompt(e.target.value)}
+                      bg="white"
+                      _dark={{ bg: "gray.700" }}
+                      placeholder={
+                        !isLoading
+                          ? "Type your question or use /help for more information"
+                          : undefined
+                      }
+                      overflowY="auto"
+                      pr={8}
+                    />
+                    <InputRightElement>
+                      <IconButton
+                        isRound
+                        icon={<TbMicrophone />}
+                        variant="ghost"
+                        aria-label="Record speech"
+                        size="sm"
+                        fontSize="16px"
+                      />
+                    </InputRightElement>
+                  </InputGroup>
                 )}
               </Box>
 

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -158,9 +158,12 @@ function PromptForm({
     speechRecognitionRef.current.start();
   };
 
-  const onRecordingStop = () => {
+  const onRecordingStop = async () => {
     if (speechRecognitionRef.current) {
-      speechRecognitionRef.current.stop();
+      const transcript = await speechRecognitionRef.current.stop();
+      if (transcript) {
+        setPrompt(transcript);
+      }
     }
   };
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -107,6 +107,21 @@ function parseOpenAIResponse(response: OpenAI.Chat.ChatCompletion) {
   return { content, functionName, functionArgs };
 }
 
+export const transcribe = async (audio: File): Promise<string> => {
+  const { apiKey, apiUrl } = getSettings();
+  if (!apiKey) {
+    throw new Error("Missing API Key");
+  }
+
+  const transcription = new OpenAI.Audio.Transcriptions(createClient(apiKey, apiUrl).openai).create(
+    {
+      file: audio,
+      model: "whisper-1",
+    }
+  );
+  return (await transcription).text;
+};
+
 export const chatWithLLM = (messages: ChatCraftMessage[], options: ChatOptions = {}) => {
   const {
     onData,

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -11,7 +11,7 @@ import { getSettings, OPENAI_API_URL } from "./settings";
 
 import type { Tiktoken } from "tiktoken/lite";
 
-const usingOfficialOpenAI = () => getSettings().apiUrl === OPENAI_API_URL;
+export const usingOfficialOpenAI = () => getSettings().apiUrl === OPENAI_API_URL;
 
 const createClient = (apiKey: string, apiUrl?: string) => {
   // If we're using OpenRouter, add extra headers
@@ -107,19 +107,19 @@ function parseOpenAIResponse(response: OpenAI.Chat.ChatCompletion) {
   return { content, functionName, functionArgs };
 }
 
-export const transcribe = async (audio: File): Promise<string> => {
+export const transcribe = async (audio: File) => {
   const { apiKey, apiUrl } = getSettings();
   if (!apiKey) {
-    throw new Error("Missing API Key");
+    throw new Error("Missing OpenAI API Key");
   }
 
-  const transcription = new OpenAI.Audio.Transcriptions(createClient(apiKey, apiUrl).openai).create(
-    {
-      file: audio,
-      model: "whisper-1",
-    }
-  );
-  return (await transcription).text;
+  const { openai } = createClient(apiKey, apiUrl);
+  const transcriptions = new OpenAI.Audio.Transcriptions(openai);
+  const transcription = await transcriptions.create({
+    file: audio,
+    model: "whisper-1",
+  });
+  return transcription.text;
 };
 
 export const chatWithLLM = (messages: ChatCraftMessage[], options: ChatOptions = {}) => {

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,14 +1,50 @@
+type RecordingInProgress = () => Promise<Blob>;
+/**
+ * Openai supports: m4a mp3 webm mp4 mpga wav mpeg
+ * of these audio/webm is supported by chrome, firefox
+ * and audio/mp3 is supported by safari
+ */
+async function startRecording(): Promise<RecordingInProgress> {
+  const recordedChunks: BlobPart[] = [];
+  let stopRecordingResolve: (value: Blob) => void;
+  const audioDataPromise = new Promise<Blob>((resolve) => {
+    stopRecordingResolve = resolve;
+  });
+  const mimeType = "audio/webm";
+  const stream: MediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  const mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
+
+  mediaRecorder.ondataavailable = function (e) {
+    if (e.data.size > 0) {
+      recordedChunks.push(e.data);
+    }
+  };
+
+  mediaRecorder.onstop = function () {
+    const blob = new Blob(recordedChunks, {
+      type: mimeType,
+    });
+    stopRecordingResolve(blob);
+  };
+
+  mediaRecorder.start();
+
+  return () => {
+    mediaRecorder.stop();
+    return audioDataPromise;
+  };
+}
+
 export class SpeechRecognition {
-  private _isRecording: boolean;
   private _isCancelled: boolean;
+  private _recording = null as RecordingInProgress | null;
 
   constructor() {
-    this._isRecording = false;
     this._isCancelled = false;
   }
 
   get isRecording() {
-    return this._isRecording;
+    return this._recording !== null;
   }
 
   get isCancelled() {
@@ -16,7 +52,7 @@ export class SpeechRecognition {
   }
 
   async start() {
-    if (this._isRecording) {
+    if (this.isRecording) {
       throw new Error("Recording already started");
     }
 
@@ -25,7 +61,7 @@ export class SpeechRecognition {
     }
 
     console.log("Recording started...");
-    this._isRecording = true;
+    this._recording = await startRecording();
   }
 
   async stop() {
@@ -34,21 +70,26 @@ export class SpeechRecognition {
       return;
     }
 
-    if (!this._isRecording) {
+    const stopFunc = this._recording;
+    if (!stopFunc) {
       throw new Error("No recording in progress");
     }
 
+    const result = await stopFunc();
+    console.log("recorded", result.type, result.size);
+
     console.log("Recording stopped");
-    this._isRecording = false;
+    this._recording = null;
   }
 
   async cancel() {
-    if (!this._isRecording) {
+    const stopFunc = this._recording;
+    if (!stopFunc) {
       throw new Error("No recording in progress");
     }
-
+    stopFunc();
+    this._recording = null;
     console.log("Recording cancelled.");
     this._isCancelled = true;
-    this._isRecording = false;
   }
 }

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -40,7 +40,7 @@ export class SpeechRecognition {
         this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
       } catch (e: any) {
         if (e.name === "NotSupportedError") {
-          mimeType = "audio/mp3";
+          mimeType = "audio/mp4";
           this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
         } else {
           throw e;

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -75,6 +75,9 @@ export class SpeechRecognition {
       if (this.isRecording) {
         this._mediaRecorder.start();
       } else {
+        console.log(
+          `Recording cancelled, prior to cancellation mediaRecorder is: ${this._mediaRecorder.state}`
+        );
         this._mediaRecorder = null;
       }
     })();

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,4 +1,3 @@
-import { an } from "vitest/dist/types-198fd1d9";
 import { transcribe } from "./ai";
 
 export class SpeechRecognition {

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,0 +1,54 @@
+export class SpeechRecognition {
+  private _isRecording: boolean;
+  private _isCancelled: boolean;
+
+  constructor() {
+    this._isRecording = false;
+    this._isCancelled = false;
+  }
+
+  get isRecording() {
+    return this._isRecording;
+  }
+
+  get isCancelled() {
+    return this._isCancelled;
+  }
+
+  async start() {
+    if (this._isRecording) {
+      throw new Error("Recording already started");
+    }
+
+    if (this._isCancelled) {
+      throw new Error("Recording cancelled");
+    }
+
+    console.log("Recording started...");
+    this._isRecording = true;
+  }
+
+  async stop() {
+    if (this._isCancelled) {
+      // Recording already stopped via `.cancel()`, ignore this.
+      return;
+    }
+
+    if (!this._isRecording) {
+      throw new Error("No recording in progress");
+    }
+
+    console.log("Recording stopped");
+    this._isRecording = false;
+  }
+
+  async cancel() {
+    if (!this._isRecording) {
+      throw new Error("No recording in progress");
+    }
+
+    console.log("Recording cancelled.");
+    this._isCancelled = true;
+    this._isRecording = false;
+  }
+}

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,123 +1,113 @@
 import { transcribe } from "./ai";
 
-type RecordingInProgress = () => Promise<File>;
-/**
- * Openai supports: m4a mp3 webm mp4 mpga wav mpeg
- * of these audio/webm is supported by chrome, firefox
- * and audio/mp3 is supported by safari
- */
-async function startRecording(): Promise<RecordingInProgress> {
-  const recordedChunks: BlobPart[] = [];
-  let stopRecordingResolve: (value: File) => void;
-  const audioDataPromise = new Promise<File>((resolve) => {
-    stopRecordingResolve = resolve;
-  });
-
-  let stream: MediaStream;
-  try {
-    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-  } catch (e: any) {
-    if (e.name === "NotAllowedError") {
-      throw new Error("Recording permission denied");
-    }
-    throw e;
-  }
-
-  let mimeType = "audio/webm";
-  let mediaRecorder: MediaRecorder;
-  // Handle Safari not supporting webm
-  try {
-    mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
-  } catch (e: any) {
-    if (e.name === "NotSupportedError") {
-      mimeType = "audio/mp3";
-      mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
-    } else {
-      throw e;
-    }
-  }
-
-  mediaRecorder.ondataavailable = function (e) {
-    if (e.data.size > 0) {
-      recordedChunks.push(e.data);
-    }
-  };
-
-  mediaRecorder.onstop = function () {
-    const file = new File(recordedChunks, mimeType.replace("/", "."), {
-      type: mimeType,
-    });
-    stopRecordingResolve(file);
-  };
-
-  mediaRecorder.start();
-
-  return () => {
-    mediaRecorder.stop();
-    return audioDataPromise;
-  };
-}
-
 export class SpeechRecognition {
-  private _isCancelled: boolean;
-  private _recording = null as RecordingInProgress | null;
-
-  constructor() {
-    this._isCancelled = false;
-  }
+  private _recordingPromise: Promise<File> | null = null;
+  private _mediaRecorder: MediaRecorder | null = null;
 
   get isRecording() {
-    return this._recording !== null;
+    return this._recordingPromise !== null;
   }
 
-  get isCancelled() {
-    return this._isCancelled;
-  }
-
-  async start() {
+  async start(): Promise<void> {
     if (this.isRecording) {
       throw new Error("Recording already started");
     }
 
-    if (this._isCancelled) {
-      throw new Error("Recording cancelled");
-    }
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    let recordingPromiseResolve: (value: File) => void;
+    const audioDataPromise = new Promise<File>((resolve) => {
+      recordingPromiseResolve = resolve;
+    });
 
-    console.log("Recording started...");
-    this._recording = await startRecording();
+    // wrap this up into a promise that runs after we return callback so we can cancel while accepting/rejecting permissions
+    const initPromise = (async () => {
+      const recordedChunks: BlobPart[] = [];
+
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      } catch (e: any) {
+        if (e.name === "NotAllowedError") {
+          throw new Error("Recording permission denied");
+        }
+        throw e;
+      }
+
+      let mimeType = "audio/webm";
+      // Handle Safari not supporting webm
+      try {
+        this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
+      } catch (e: any) {
+        if (e.name === "NotSupportedError") {
+          mimeType = "audio/mp3";
+          this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
+        } else {
+          throw e;
+        }
+      }
+
+      this._mediaRecorder.ondataavailable = function (e) {
+        if (!self.isRecording) {
+          // Recording cancelled
+          if (self._mediaRecorder) {
+            self._mediaRecorder.stop();
+          }
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        if (e.data.size > 0) {
+          recordedChunks.push(e.data);
+        }
+      };
+
+      this._mediaRecorder.onstop = function () {
+        if (!self.isRecording) {
+          return;
+        }
+        const fname = mimeType.replace("/", ".");
+        const file = new File(recordedChunks, fname, {
+          type: mimeType,
+        });
+        recordingPromiseResolve(file);
+      };
+
+      if (this.isRecording) {
+        this._mediaRecorder.start();
+      } else {
+        this._mediaRecorder = null;
+      }
+    })();
+    this._recordingPromise = initPromise.then(() => audioDataPromise);
+    await initPromise;
   }
 
   async stop(): Promise<string | null> {
-    if (this._isCancelled) {
-      // Recording already stopped via `.cancel()`
-      console.warn("Recording cancelled");
+    const recordingPromise = this._recordingPromise;
+    const mediaRecorder = this._mediaRecorder;
+    if (!mediaRecorder && recordingPromise) {
+      // If we have a recording promise but no mediaRecorder, means we got prompted for permissions and had to abort recording to accept/reject
+      this._recordingPromise = null;
+      return null;
+    } else if (mediaRecorder) {
+      mediaRecorder.stop();
+      this._mediaRecorder = null;
+    }
+    if (!recordingPromise) {
       return null;
     }
-
-    const stopFunc = this._recording;
-    if (!stopFunc) {
-      throw new Error("No recording in progress");
-    }
-
-    const filePromise = stopFunc();
-    this._recording = null;
-
-    const file = await filePromise;
+    const file = await recordingPromise;
+    this._recordingPromise = null;
     // log stats
-    console.log(`Recording stopped. File size: ${file.size} bytes. File type: ${file.type}`);
     const transcription = await transcribe(file);
-
     return transcription;
   }
 
   async cancel() {
-    const stopFunc = this._recording;
-    if (!stopFunc) {
+    if (!this.isRecording) {
       throw new Error("No recording in progress");
     }
-    stopFunc();
-    this._recording = null;
-    console.log("Recording cancelled.");
-    this._isCancelled = true;
+    this._recordingPromise = null;
+    this.stop();
   }
 }

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -37,19 +37,24 @@ export class SpeechRecognition {
         throw e;
       }
 
-      let mimeType = "audio/webm";
-      // Handle Safari not supporting webm
-      try {
-        this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
-      } catch (e: any) {
-        if (e.name === "NotSupportedError") {
-          const nextMimeType = "audio/mp4;codecs=avc1";
-          console.log(`${e}: ${mimeType} not supported, trying ${nextMimeType}`);
-          mimeType = nextMimeType;
+      const mimeTypeList = ["audio/webm", "audio/mp4"];
+      let mimeType = mimeTypeList[0];
+      for (const mimeTypeCandidate of mimeTypeList) {
+        mimeType = mimeTypeCandidate;
+        // Handle Safari not supporting webm
+        try {
           this._mediaRecorder = new MediaRecorder(stream, { mimeType: mimeType });
-        } else {
+          console.log(`Using mimeType: ${mimeType}`);
+        } catch (e: any) {
+          if (e.name === "NotSupportedError") {
+            console.log(`${e}: ${mimeType} not supported`);
+            continue;
+          }
           throw e;
         }
+      }
+      if (!this._mediaRecorder) {
+        throw new Error(`No supported mimeType found in: ${mimeTypeList}`);
       }
 
       this._mediaRecorder.ondataavailable = function (e) {

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -66,10 +66,11 @@ export class SpeechRecognition {
     this._recording = await startRecording();
   }
 
-  async stop() {
+  async stop(): Promise<string | null> {
     if (this._isCancelled) {
-      // Recording already stopped via `.cancel()`, ignore this.
-      return;
+      // Recording already stopped via `.cancel()`
+      console.warn("Recording cancelled");
+      return null;
     }
 
     const stopFunc = this._recording;
@@ -77,13 +78,13 @@ export class SpeechRecognition {
       throw new Error("No recording in progress");
     }
 
-    const file = await stopFunc();
-    console.log("recorded", file.type, file.size);
-    const transcription = await transcribe(file);
-    console.log("transcription", transcription);
-
-    console.log("Recording stopped");
+    const filePromise = stopFunc();
     this._recording = null;
+
+    const file = await filePromise;
+    const transcription = await transcribe(file);
+
+    return transcription;
   }
 
   async cancel() {


### PR DESCRIPTION
Fixes #237 

This is an initial piece of the puzzle for audio recording and speech recognition.  Specifically, it does the following:

- Adds a Mic icon to the inside-right of the prompt text area
- Touching/clicking the Mic icon triggers the logic for audio recording, releasing the icon stops it
- While recording, if you drag to the left, eventually it goes red (indicating you can cancel the in-progress recording).  Releasing when the icon is dragged to the left cancels the current recording.  I've implemented a "spring" animation to make this work.  See what you think (I'm not a pro at animations).
- Adds a new class, `SpeechRecognition` which has hooks for starting/stopping/aborting a recording.

<img width="705" alt="Screenshot 2023-09-06 at 12 46 24 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/d3e8f419-e2a2-4b0a-8538-a554ce2cb565">

@tarasglek, [over to you!](https://github.com/tarasglek/chatcraft.org/issues/237#issuecomment-1704346905).

Once we know how were doing audio+recognition, we will need to add UI for loading models and/or permissions on first-use.

We shouldn't land this until we have a good first-run story figured out.