### PR TITLE
Improve first-run microphone permissions experience and UX

### DIFF
--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -11,8 +11,16 @@ designed to make it easy for software developers to discuss their code with AI a
 
 ## How to Chat
 
-You can ask questions, copy/paste code, get help with error messages, etc.  Here are
-a few examples to get you started:
+You can ask questions, copy/paste code, get help with error messages, etc.
+
+If you'd like to use your voice instead of typing, press and hold the microphone
+icon, ask your question, and release when done.  Your voice will be transcribed by
+OpenAI and added to the chat as text. You can also cancel an audio recording by
+sliding the icon to the left and releasing.
+
+## Examples
+
+Here are a few examples to get you started:
 
 ### Example 1: Learning Technologies and Concepts
 
@@ -91,10 +99,8 @@ Some commands accept arguments as well.
 ## Functions
 
 Some models support function calling (e.g, OpenAI models). ChatCraft provides a way
-to write, load, and run these functions using a special syntax.
-
-Functions are ES6 Modules that export a default function.  They also include metadata
-about for the function name, description, and input arguments schema.
+to write, load, and run these functions using a special syntax. Functions are ES6 Modules
+written in TypeScript.
 
 To create a function within ChatCraft, use the [/f/new](/f/new) URL, which will create
 a new function and load the editor.


### PR DESCRIPTION
This change improves the first-run experience, and subsequent UX, for working with the microphone.

There are some browser differences in how permissions get handled, but I think I've now covered them all.

On Chrome-based browsers, you can approve the microphone and have it persist over sessions.  Firefox refuses to do this, so you always have to grant it again.  Safari is somewhere in the middle.

I've done the following:

- Added a check to see if audio recording and transcription are supported at all in the browser/session
- Added a function to check for permissions before we start recording.  If we don't have permission, it tries to get it first before we start recording
- Added better error messages when things fail
- Updated the status text we show above the prompt for to indicate if we're recording or transcribing
- Updated the prompt text to indicate how the mic works
- Added help info about the mic and how to use it.

I'm unable to get the browser to not show a "Recording" icon.  This seems to persist for the session where you grant access (i.e., it's not something JS can affect).