### PR TITLE
Fix overflow, sizing on mobile

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -21,6 +21,7 @@ import {
   Textarea,
   VStack,
   useClipboard,
+  useMediaQuery,
 } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
 import { TbDots, TbTrash } from "react-icons/tb";
@@ -91,6 +92,7 @@ function MessageBase({
   const [isHovering, setIsHovering] = useState(false);
   const { settings } = useSettings();
   const [tokens, setTokens] = useState<number | null>(null);
+  const [isNarrowScreen] = useMediaQuery("(max-width: 400px)");
 
   useEffect(() => {
     if (settings.countTokens) {
@@ -190,7 +192,7 @@ function MessageBase({
                     _dark={{ color: "gray.300" }}
                   >
                     <Link as={ReactRouterLink} to={`/c/${chatId}#${id}`}>
-                      {formatDate(date)}
+                      {formatDate(date, isNarrowScreen)}
                     </Link>
                   </Text>
                   {headingMenu}

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -170,7 +170,7 @@ function SystemMessage(props: SystemMessageProps) {
     <MessageBase
       {...props}
       avatar={avatar}
-      heading="ChatCraft (System Prompt)"
+      heading="System Prompt"
       headingMenu={
         <SystemPromptVersionsMenu
           onChange={handleSystemPromptVersionChange}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -10,7 +10,6 @@ export const formatDate = (d: Date, short = false) =>
   short
     ? new Intl.DateTimeFormat(undefined, {
         dateStyle: "short",
-        timeStyle: "short",
       }).format(d)
     : new Intl.DateTimeFormat(undefined, {
         year: "numeric",


### PR DESCRIPTION
I've been testing on mobile a bunch while doing the audio transcription work, and a few things were bugging me.  This fixes the overflow and overlapping issues in the system prompt on mobile.

<img width="996" alt="Screenshot 2023-09-12 at 3 39 33 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/37e5b3da-ae9f-47d4-bcd9-a6ab0bdc7301">
<img width="318" alt="Screenshot 2023-09-12 at 3 39 15 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/a7d3474e-b486-45d3-ac3d-d8b9163f7f24">
