### PR TITLE
Improve first-run experience for mic

### DIFF
--- a/src/components/MicIcon.tsx
+++ b/src/components/MicIcon.tsx
@@ -1,38 +1,103 @@
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { IconButton } from "@chakra-ui/react";
 import { TbMicrophone } from "react-icons/tb";
 import { motion, useMotionValue } from "framer-motion";
 
+import { SpeechRecognition } from "../lib/speech-recognition";
+import { useAlert } from "../hooks/use-alert";
+
 type MicIconProps = {
-  onRecordingStart: () => void;
-  onRecordingStop: () => void;
-  onRecordingCancel: () => void;
+  onRecording: () => void;
+  onTranscribing: () => void;
+  onCancel: () => void;
+  onTranscriptionAvailable: (transcription: string) => void;
   isDisabled: boolean;
 };
 
 export default function MicIcon({
-  onRecordingStart,
-  onRecordingStop,
-  onRecordingCancel,
+  onRecording,
+  onTranscribing,
+  onCancel,
+  onTranscriptionAvailable,
   isDisabled = false,
 }: MicIconProps) {
   const [colorScheme, setColorScheme] = useState<"blue" | "red">("blue");
   const [isRecording, setIsRecording] = useState(false);
+  const micIconRef = useRef<HTMLButtonElement | null>(null);
+  const speechRecognitionRef = useRef<SpeechRecognition | null>(null);
+  const { error } = useAlert();
   const x = useMotionValue(0);
 
-  const handleRecordingStart = () => {
-    setIsRecording(true);
-    onRecordingStart();
+  const onRecordingStart = async () => {
+    speechRecognitionRef.current = new SpeechRecognition();
+
+    // Try to get access to the user's microphone. This may or may not work...
+    try {
+      await speechRecognitionRef.current.init();
+    } catch (err) {
+      error({
+        title: "Audio Transcription",
+        message:
+          "Audio transcription requires microphone access. If your browser supports it, please allow this page to access to your microphone in order to record and transcribe speech.",
+      });
+    }
+
+    // See if the user already cancelled the recording while we waited on mic permission
+    if (!speechRecognitionRef.current?.isInitialized) {
+      speechRecognitionRef.current = null;
+      return;
+    }
+
+    // We have mic permission and user is still holding the mic icon. Start recording
+    try {
+      await speechRecognitionRef.current.start();
+      setIsRecording(true);
+      onRecording();
+    } catch (err: any) {
+      console.error(err);
+      error({
+        title: "Speech Recognition Error",
+        message: `Unable to start audio recording: ${err.message}`,
+      });
+      speechRecognitionRef.current = null;
+      setIsRecording(false);
+      onCancel();
+    }
   };
 
-  const handleRecordingStop = () => {
+  const onRecordingStop = async () => {
     setIsRecording(false);
-    onRecordingStop();
+
+    // See if the recording has already been cancelled, or hasn't been started yet
+    const speechRecognition = speechRecognitionRef.current;
+    if (!speechRecognition?.isRecording) {
+      speechRecognitionRef.current = null;
+      return;
+    }
+
+    // Stop the in-progress recording and get a transcript
+    try {
+      onTranscribing();
+      const transcript = await speechRecognition.stop();
+      if (transcript) {
+        onTranscriptionAvailable(transcript);
+      }
+    } catch (err: any) {
+      console.error(err);
+      error({
+        title: "Error Transcribing Speech",
+        message: `There was an error while transcribing: ${err.message}`,
+      });
+    } finally {
+      speechRecognitionRef.current = null;
+    }
   };
 
-  const handleRecordingCancel = () => {
+  const onRecordingCancel = () => {
+    speechRecognitionRef.current?.cancel();
+    speechRecognitionRef.current = null;
     setIsRecording(false);
-    onRecordingCancel();
+    onCancel();
   };
 
   return (
@@ -41,8 +106,6 @@ export default function MicIcon({
       dragConstraints={{ left: 0, right: 0 }}
       dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
       dragElastic={1}
-      onTapStart={() => handleRecordingStart()}
-      onTap={() => handleRecordingStop()}
       onDrag={(_event, info) => {
         if (info.offset.x < -100) {
           setColorScheme("red");
@@ -52,7 +115,7 @@ export default function MicIcon({
       }}
       onDragEnd={(_event, info) => {
         if (info.offset.x < -100) {
-          handleRecordingCancel();
+          onRecordingCancel();
         }
         setColorScheme("blue");
         x.set(0);
@@ -66,8 +129,12 @@ export default function MicIcon({
         icon={<TbMicrophone />}
         variant={isRecording ? "solid" : "ghost"}
         aria-label="Record speech"
-        size="sm"
+        size={isRecording ? "md" : "sm"}
         fontSize="16px"
+        ref={micIconRef}
+        onPointerDown={() => onRecordingStart()}
+        onPointerUp={() => onRecordingStop()}
+        onBlur={() => onRecordingCancel()}
       />
     </motion.div>
   );


### PR DESCRIPTION
Fixes #245

This reworks the state machine for using the mic.  The main change is that I've separated the part where you request access to the audio stream from the start of recording.  This allows for extra checks to happen in the UI when the user takes their finger off the mic icon in order to press the "allow" button in the permissions UI.

I've tested in every browser I have on my Mac, and it's working pretty well.

I don't think I know how to make this perfect, but I think this is about as good as I can get it.  See if you agree.