### PR TITLE
Allow re-sending final message if human

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -182,17 +182,25 @@ function ChatBase({ chat }: ChatBaseProps) {
       }
 
       // Not a slash command, so pass this prompt to LLM
+      const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: true });
       try {
         let promptMessage: ChatCraftHumanMessage | undefined;
+        // If the prompt text exist, package it up as a human message and add to the chat
         if (prompt) {
           // Add this prompt message to the chat
           promptMessage = new ChatCraftHumanMessage({ text: prompt, user });
           await chat.addMessage(promptMessage);
+        } else {
+          // If there isn't any prompt text, see if the final message in the chat was a human
+          // message. If it was, we'll allow sending that through again (e.g., if you modified
+          // something) and want to try again.  Otherwise bail now.
+          if (!(messages.at(-1) instanceof ChatCraftHumanMessage)) {
+            return;
+          }
         }
 
         // In single-message-mode, trim messages to last few. Otherwise send all.
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
-        const messages = chat.messages({ includeAppMessages: false, includeSystemMessages: true });
         const messagesToSend = singleMessageMode ? [...messages].slice(-2) : messages;
 
         // If there's any problem loading referenced functions, show an error

--- a/src/components/PromptForm.tsx
+++ b/src/components/PromptForm.tsx
@@ -143,10 +143,6 @@ function PromptForm({
   const handlePromptSubmit = (e: FormEvent) => {
     e.preventDefault();
     const value = prompt.trim();
-    if (!value.length) {
-      return;
-    }
-
     setPrompt("");
     onSendClick(value);
   };


### PR DESCRIPTION
A pattern I get myself into a lot:

- Get into a long chat
- Go back and delete a bunch of things, mostly responses
- Update something in the final human prompt
- Want to retry this final prompt

The way I do it now is to copy the prompt, delete it, then paste into the prompt form and send.

This change allows clicking the "Ask" button with nothing in the prompt.  If the final message is a human message, it will send the chat as-is vs. adding anything new.  This is perfect for cases where you have edited and want to retry.

If the final message isn't a human message, there's no point re-sending without adding context, since the AI will usually just repeat itself.