### PR TITLE
Rework PromptForm into Desktop and Mobile versions

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -26,11 +26,12 @@ import { AiOutlineEdit } from "react-icons/ai";
 import { useCopyToClipboard, useKey } from "react-use";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { download, formatDate, formatNumber } from "../lib/utils";
+import { download, formatCurrency, formatDate, formatNumber } from "../lib/utils";
 import ShareModal from "../components/ShareModal";
 import { useSettings } from "../hooks/use-settings";
 import useTitle from "../hooks/use-title";
 import { useAlert } from "../hooks/use-alert";
+import { useCost } from "../hooks/use-cost";
 
 type ChatHeaderProps = {
   chat: ChatCraftChat;
@@ -42,6 +43,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
   const fetcher = useFetcher();
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [tokens, setTokens] = useState<number | null>(null);
+  const { cost } = useCost();
   const [isEditing, setIsEditing] = useState(false);
   const { settings } = useSettings();
   const title = useTitle(chat);
@@ -200,9 +202,14 @@ function ChatHeader({ chat }: ChatHeaderProps) {
               </Text>
             </Link>
             {settings.countTokens && tokens && (
-              <Tag size="sm" variant="outline" colorScheme="gray">
-                {formatNumber(tokens)} Tokens
-              </Tag>
+              <Flex gap={2}>
+                <Tag size="sm" variant="outline" colorScheme="gray">
+                  {formatNumber(tokens)} Tokens
+                </Tag>
+                <Tag key="token-cost" size="sm" variant="outline" colorScheme="gray">
+                  {formatCurrency(cost)}
+                </Tag>
+              </Flex>
             )}
           </Flex>
         </CardFooter>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -92,7 +92,7 @@ function MessageBase({
   const [isHovering, setIsHovering] = useState(false);
   const { settings } = useSettings();
   const [tokens, setTokens] = useState<number | null>(null);
-  const [isNarrowScreen] = useMediaQuery("(max-width: 400px)");
+  const [isNarrowScreen] = useMediaQuery("(max-width: 480px)");
 
   useEffect(() => {
     if (settings.countTokens) {

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -21,7 +21,6 @@ import {
   Textarea,
   VStack,
   useClipboard,
-  useMediaQuery,
 } from "@chakra-ui/react";
 import ResizeTextarea from "react-textarea-autosize";
 import { TbDots, TbTrash } from "react-icons/tb";
@@ -43,6 +42,7 @@ import { useAlert } from "../../hooks/use-alert";
 
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
+import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -92,7 +92,7 @@ function MessageBase({
   const [isHovering, setIsHovering] = useState(false);
   const { settings } = useSettings();
   const [tokens, setTokens] = useState<number | null>(null);
-  const [isNarrowScreen] = useMediaQuery("(max-width: 480px)");
+  const isNarrowScreen = useMobileBreakpoint();
 
   useEffect(() => {
     if (settings.countTokens) {

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -19,7 +19,6 @@ type MessagesViewProps = {
   newMessage?: ChatCraftAiMessage;
   isLoading: boolean;
   onRemoveMessage: (message: ChatCraftMessage) => void;
-  singleMessageMode: boolean;
   isPaused: boolean;
   onTogglePause: () => void;
   onCancel: () => void;
@@ -31,7 +30,6 @@ function MessagesView({
   newMessage,
   isLoading,
   onRemoveMessage,
-  singleMessageMode,
   isPaused,
   onTogglePause,
   onCancel,
@@ -76,23 +74,7 @@ function MessagesView({
 
   // Memoize the previous messages so we don't have to update when newMessage changes
   const prevMessages = useMemo(() => {
-    // When we're in singleMessageMode, we collapse all but the final message
-    if (singleMessageMode) {
-      const lastMessage = messages.at(-1);
-      if (lastMessage) {
-        return (
-          <Message
-            message={lastMessage}
-            chatId={chatId}
-            isLoading={isLoading}
-            onDeleteClick={() => memoizedOnRemoveMessage(lastMessage)}
-            onPrompt={onPrompt}
-          />
-        );
-      }
-    }
-
-    // Otherwise, show all messages in order, unless the only message in the chat
+    // Show all messages in order, unless the only message in the chat
     // is the system prompt AND the user has not entered an API Key. In this case
     // we'll show an instruction message instead (see below).
     if (
@@ -130,7 +112,6 @@ function MessagesView({
     messages,
     settings.apiKey,
     chatId,
-    singleMessageMode,
     onPrompt,
     isLoading,
     memoizedOnRemoveMessage,

--- a/src/components/MicIcon.tsx
+++ b/src/components/MicIcon.tsx
@@ -7,6 +7,9 @@ import { SpeechRecognition } from "../lib/speech-recognition";
 import { useAlert } from "../hooks/use-alert";
 
 type MicIconProps = {
+  variant: "ghost" | "outline";
+  size: "md" | "sm";
+  fontSize?: string;
   onRecording: () => void;
   onTranscribing: () => void;
   onCancel: () => void;
@@ -15,6 +18,9 @@ type MicIconProps = {
 };
 
 export default function MicIcon({
+  variant,
+  size,
+  fontSize = "16px",
   onRecording,
   onTranscribing,
   onCancel,
@@ -127,10 +133,10 @@ export default function MicIcon({
         isDisabled={isDisabled}
         colorScheme={colorScheme}
         icon={<TbMicrophone />}
-        variant={isRecording ? "solid" : "ghost"}
+        variant={isRecording ? "solid" : variant}
         aria-label="Record speech"
-        size={isRecording ? "md" : "sm"}
-        fontSize="16px"
+        size={isRecording ? "md" : size}
+        fontSize={fontSize}
         ref={micIconRef}
         onPointerDown={() => onRecordingStart()}
         onPointerUp={() => onRecordingStop()}

--- a/src/components/NewButton.tsx
+++ b/src/components/NewButton.tsx
@@ -1,18 +1,31 @@
-import { Button, Menu, MenuButton, MenuList, MenuItem, MenuDivider } from "@chakra-ui/react";
+import {
+  Button,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  MenuDivider,
+  IconButton,
+} from "@chakra-ui/react";
 import { Link as ReactRouterLink } from "react-router-dom";
 import { TbPlus } from "react-icons/tb";
 
 type NewButtonProps = {
   forkUrl?: string;
   variant?: "outline" | "solid" | "ghost";
+  iconOnly?: boolean;
 };
 
-function NewButton({ forkUrl, variant = "outline" }: NewButtonProps) {
+function NewButton({ forkUrl, variant = "outline", iconOnly = false }: NewButtonProps) {
   return (
     <Menu>
-      <MenuButton as={Button} size="sm" variant={variant} rightIcon={<TbPlus />}>
-        New
-      </MenuButton>
+      {iconOnly ? (
+        <MenuButton as={IconButton} size="md" variant="outline" icon={<TbPlus />} isRound />
+      ) : (
+        <MenuButton as={Button} size="sm" variant={variant} rightIcon={<TbPlus />}>
+          New
+        </MenuButton>
+      )}
       <MenuList>
         <MenuItem as={ReactRouterLink} to="/new">
           Clear Chat

--- a/src/components/PromptForm/AudioStatus.tsx
+++ b/src/components/PromptForm/AudioStatus.tsx
@@ -1,0 +1,36 @@
+import { Flex, Text } from "@chakra-ui/react";
+import { TbMicrophone } from "react-icons/tb";
+import { MdOutlineTranscribe } from "react-icons/md";
+
+import { formatSeconds } from "../../lib/utils";
+
+type AudioStatusProps = {
+  isRecording: boolean;
+  recordingSeconds: number;
+  isTranscribing: boolean;
+};
+
+export default function AudioStatus({
+  isTranscribing,
+  isRecording,
+  recordingSeconds,
+}: AudioStatusProps) {
+  if (isTranscribing) {
+    return (
+      <Flex alignItems="center" gap={2}>
+        <MdOutlineTranscribe /> Transcribing...
+      </Flex>
+    );
+  }
+
+  if (isRecording) {
+    return (
+      <Flex alignItems="center" gap={2}>
+        <TbMicrophone /> Recording...
+        <Text>{formatSeconds(recordingSeconds)}</Text>
+      </Flex>
+    );
+  }
+
+  return <span />;
+}

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -21,15 +21,15 @@ import {
 } from "@chakra-ui/react";
 import { CgChevronUpO, CgChevronDownO } from "react-icons/cg";
 import { TbChevronUp, TbMicrophone } from "react-icons/tb";
-import AutoResizingTextarea from "./AutoResizingTextarea";
+import AutoResizingTextarea from "../AutoResizingTextarea";
 
-import { useSettings } from "../hooks/use-settings";
-import { useModels } from "../hooks/use-models";
-import { isMac, isWindows, formatCurrency } from "../lib/utils";
-import NewButton from "./NewButton";
-import { useCost } from "../hooks/use-cost";
-import MicIcon from "./MicIcon";
-import { isTranscriptionSupported } from "../lib/speech-recognition";
+import { useSettings } from "../../hooks/use-settings";
+import { useModels } from "../../hooks/use-models";
+import { isMac, isWindows, formatCurrency } from "../../lib/utils";
+import NewButton from "../NewButton";
+import { useCost } from "../../hooks/use-cost";
+import MicIcon from "../MicIcon";
+import { isTranscriptionSupported } from "../../lib/speech-recognition";
 
 type SpeechRecognitionHintProps = {
   isRecording: boolean;
@@ -90,7 +90,7 @@ function KeyboardHint({ isVisible, isExpanded }: KeyboardHintProps) {
   );
 }
 
-type PromptFormProps = {
+type DesktopPromptFormProps = {
   forkUrl: string;
   onSendClick: (prompt: string) => void;
   // Whether or not to automatically manage the height of the prompt.
@@ -105,7 +105,7 @@ type PromptFormProps = {
   previousMessage?: string;
 };
 
-function PromptForm({
+function DesktopPromptForm({
   forkUrl,
   onSendClick,
   isExpanded,
@@ -115,7 +115,7 @@ function PromptForm({
   inputPromptRef,
   isLoading,
   previousMessage,
-}: PromptFormProps) {
+}: DesktopPromptFormProps) {
   const [prompt, setPrompt] = useState("");
   // Has the user started typing?
   const [isDirty, setIsDirty] = useState(false);
@@ -194,7 +194,6 @@ function PromptForm({
   };
 
   const handleTranscriptionAvailable = (transcription: string) => {
-    console.log("transcript available");
     // Use this transcript as our prompt
     onSendClick(transcription);
     setIsRecording(false);
@@ -266,6 +265,8 @@ function PromptForm({
                     {isTranscriptionSupported() && (
                       <InputRightElement mr={2}>
                         <MicIcon
+                          variant="ghost"
+                          size="sm"
                           isDisabled={isLoading}
                           onRecording={handleRecording}
                           onTranscribing={handleTranscribing}
@@ -297,6 +298,8 @@ function PromptForm({
                     {isTranscriptionSupported() && (
                       <InputRightElement>
                         <MicIcon
+                          variant="ghost"
+                          size="sm"
                           isDisabled={isLoading}
                           onRecording={handleRecording}
                           onTranscribing={handleTranscribing}
@@ -354,4 +357,4 @@ function PromptForm({
   );
 }
 
-export default PromptForm;
+export default DesktopPromptForm;

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -3,13 +3,11 @@ import { IconButton } from "@chakra-ui/react";
 import { TbMicrophone } from "react-icons/tb";
 import { motion, useMotionValue } from "framer-motion";
 
-import { SpeechRecognition } from "../lib/speech-recognition";
-import { useAlert } from "../hooks/use-alert";
+import { SpeechRecognition } from "../../lib/speech-recognition";
+import { useAlert } from "../../hooks/use-alert";
+import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 
 type MicIconProps = {
-  variant: "ghost" | "outline";
-  size: "md" | "sm";
-  fontSize?: string;
   onRecording: () => void;
   onTranscribing: () => void;
   onCancel: () => void;
@@ -18,21 +16,20 @@ type MicIconProps = {
 };
 
 export default function MicIcon({
-  variant,
-  size,
-  fontSize = "16px",
   onRecording,
   onTranscribing,
   onCancel,
   onTranscriptionAvailable,
   isDisabled = false,
 }: MicIconProps) {
+  const isMobile = useMobileBreakpoint();
   const [colorScheme, setColorScheme] = useState<"blue" | "red">("blue");
   const [isRecording, setIsRecording] = useState(false);
   const micIconRef = useRef<HTMLButtonElement | null>(null);
   const speechRecognitionRef = useRef<SpeechRecognition | null>(null);
   const { error } = useAlert();
   const x = useMotionValue(0);
+  const xCancelOffset = isMobile ? -50 : -100;
 
   const onRecordingStart = async () => {
     speechRecognitionRef.current = new SpeechRecognition();
@@ -113,14 +110,14 @@ export default function MicIcon({
       dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
       dragElastic={1}
       onDrag={(_event, info) => {
-        if (info.offset.x < -100) {
+        if (info.offset.x < xCancelOffset) {
           setColorScheme("red");
         } else {
           setColorScheme("blue");
         }
       }}
       onDragEnd={(_event, info) => {
-        if (info.offset.x < -100) {
+        if (info.offset.x < xCancelOffset) {
           onRecordingCancel();
         }
         setColorScheme("blue");
@@ -133,10 +130,10 @@ export default function MicIcon({
         isDisabled={isDisabled}
         colorScheme={colorScheme}
         icon={<TbMicrophone />}
-        variant={isRecording ? "solid" : variant}
+        variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
         aria-label="Record speech"
-        size={isRecording ? "md" : size}
-        fontSize={fontSize}
+        size="md"
+        fontSize="18px"
         ref={micIconRef}
         onPointerDown={() => onRecordingStart()}
         onPointerUp={() => onRecordingStop()}

--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -1,53 +1,14 @@
 import { FormEvent, KeyboardEvent, useEffect, useState, type RefObject } from "react";
-import {
-  Box,
-  ButtonGroup,
-  chakra,
-  Flex,
-  IconButton,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  Text,
-} from "@chakra-ui/react";
-import { TbChevronUp, TbSend, TbMicrophone } from "react-icons/tb";
-import { MdOutlineTranscribe } from "react-icons/md";
+import { Box, chakra, Flex } from "@chakra-ui/react";
 import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
-import { useModels } from "../../hooks/use-models";
-import { isMac, isWindows, formatSeconds } from "../../lib/utils";
+import { isMac, isWindows } from "../../lib/utils";
 import NewButton from "../NewButton";
-import MicIcon from "../MicIcon";
+import MicIcon from "./MicIcon";
 import { isTranscriptionSupported } from "../../lib/speech-recognition";
-
-type AudioStatusProps = {
-  isRecording: boolean;
-  recordingSeconds: number;
-  isTranscribing: boolean;
-};
-
-function AudioStatus({ isTranscribing, isRecording, recordingSeconds }: AudioStatusProps) {
-  if (isTranscribing) {
-    return (
-      <Flex alignItems="center" gap={2}>
-        <MdOutlineTranscribe /> Transcribing...
-      </Flex>
-    );
-  }
-
-  if (isRecording) {
-    return (
-      <Flex alignItems="center" gap={2}>
-        <TbMicrophone /> Recording...
-        <Text>{formatSeconds(recordingSeconds)}</Text>
-      </Flex>
-    );
-  }
-
-  return <span />;
-}
+import PromptSendButton from "./PromptSendButton";
+import AudioStatus from "./AudioStatus";
 
 type MobilePromptFormProps = {
   forkUrl: string;
@@ -67,8 +28,7 @@ function MobilePromptForm({
   const [prompt, setPrompt] = useState("");
   // Has the user started typing?
   const [isDirty, setIsDirty] = useState(false);
-  const { settings, setSettings } = useSettings();
-  const { models } = useModels();
+  const { settings } = useSettings();
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
@@ -174,25 +134,21 @@ function MobilePromptForm({
     onSendClick(transcription);
   };
 
-  // Skip showing anything if we don't have an API Key to use
-  if (!settings.apiKey) {
-    return null;
-  }
-
-  // If we have an API Key in storage, show the mobile chat form
   return (
     <Box flex={1} w="100%" h="100%" px={1}>
       <chakra.form onSubmit={handlePromptSubmit} h="100%">
-        <Flex mt={2} pb={2} px={1} alignItems="center" gap={2}>
+        <Flex mt={2} pb={2} px={1} alignItems="end" gap={2}>
           <NewButton forkUrl={forkUrl} variant="outline" iconOnly />
 
           <Box flex={1}>
             {inputType === "audio" ? (
-              <AudioStatus
-                isRecording={isRecording}
-                isTranscribing={isTranscribing}
-                recordingSeconds={recordingSeconds}
-              />
+              <Box py={2} px={1}>
+                <AudioStatus
+                  isRecording={isRecording}
+                  isTranscribing={isTranscribing}
+                  recordingSeconds={recordingSeconds}
+                />
+              </Box>
             ) : (
               <AutoResizingTextarea
                 ref={inputPromptRef}
@@ -204,16 +160,13 @@ function MobilePromptForm({
                 bg="white"
                 _dark={{ bg: "gray.700" }}
                 overflowY="auto"
-                pr={isTranscriptionSupported() ? 8 : undefined}
+                placeholder="Ask a question"
               />
             )}
           </Box>
 
           {isTranscriptionSupported() && (
             <MicIcon
-              variant="outline"
-              size="md"
-              fontSize="18px"
               isDisabled={isLoading}
               onRecording={handleRecording}
               onTranscribing={handleTranscribing}
@@ -222,34 +175,7 @@ function MobilePromptForm({
             />
           )}
 
-          <ButtonGroup>
-            <Menu>
-              <MenuButton
-                as={IconButton}
-                isRound
-                variant="outline"
-                size="md"
-                aria-label="Choose Model"
-                title="Choose Model"
-                icon={<TbChevronUp />}
-              />
-              <MenuList>
-                {models.map((model) => (
-                  <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
-                    {model.prettyModel}
-                  </MenuItem>
-                ))}
-              </MenuList>
-            </Menu>
-            <IconButton
-              type="submit"
-              size="md"
-              isRound
-              aria-label="Submit"
-              isLoading={isLoading}
-              icon={<TbSend />}
-            />
-          </ButtonGroup>
+          <PromptSendButton isLoading={isLoading} />
         </Flex>
       </chakra.form>
     </Box>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -1,0 +1,90 @@
+import {
+  Button,
+  ButtonGroup,
+  IconButton,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+} from "@chakra-ui/react";
+import { TbChevronUp, TbSend } from "react-icons/tb";
+
+import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
+import { useSettings } from "../../hooks/use-settings";
+import { useModels } from "../../hooks/use-models";
+
+type PromptSendButtonProps = {
+  isLoading: boolean;
+};
+
+function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
+  const { settings, setSettings } = useSettings();
+  const { models } = useModels();
+
+  return (
+    <ButtonGroup variant="outline" isAttached>
+      <Menu>
+        <IconButton
+          type="submit"
+          size="md"
+          variant="solid"
+          isRound
+          aria-label="Submit"
+          isLoading={isLoading}
+          icon={<TbSend />}
+        />
+        <MenuButton
+          as={IconButton}
+          size="md"
+          isRound
+          variant="solid"
+          aria-label="Choose Model"
+          title="Choose Model"
+          icon={<TbChevronUp />}
+        />
+        <MenuList>
+          {models.map((model) => (
+            <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+              {model.prettyModel}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+    </ButtonGroup>
+  );
+}
+
+function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
+  const { settings, setSettings } = useSettings();
+  const { models } = useModels();
+
+  return (
+    <ButtonGroup isAttached>
+      <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
+        Ask {settings.model.prettyModel}
+      </Button>
+      <Menu>
+        <MenuButton
+          as={IconButton}
+          size="sm"
+          aria-label="Choose Model"
+          title="Choose Model"
+          icon={<TbChevronUp />}
+        />
+        <MenuList>
+          {models.map((model) => (
+            <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+              {model.prettyModel}
+            </MenuItem>
+          ))}
+        </MenuList>
+      </Menu>
+    </ButtonGroup>
+  );
+}
+
+export default function PromptSendButton(props: PromptSendButtonProps) {
+  const isMobile = useMobileBreakpoint();
+
+  return isMobile ? <MobilePromptSendButton {...props} /> : <DesktopPromptSendButton {...props} />;
+}

--- a/src/components/PromptForm/index.tsx
+++ b/src/components/PromptForm/index.tsx
@@ -1,0 +1,26 @@
+import { type RefObject } from "react";
+import { useMediaQuery } from "@chakra-ui/react";
+
+import MobilePromptForm from "./MobilePromptForm";
+import DesktopPromptForm from "./DesktopPromptForm";
+
+export type PromptFormProps = {
+  forkUrl: string;
+  onSendClick: (prompt: string) => void;
+  // Whether or not to automatically manage the height of the prompt.
+  // When `isExpanded` is `false`, Shit+Enter adds rows. Otherwise,
+  // the height is determined automatically by the parent.
+  isExpanded: boolean;
+  toggleExpanded: () => void;
+  singleMessageMode: boolean;
+  onSingleMessageModeChange: (value: boolean) => void;
+  inputPromptRef: RefObject<HTMLTextAreaElement>;
+  isLoading: boolean;
+  previousMessage?: string;
+};
+
+export default function PromptForm(props: PromptFormProps) {
+  const [isMobile] = useMediaQuery("(max-width: 480px)");
+
+  return isMobile ? <MobilePromptForm {...props} /> : <DesktopPromptForm {...props} />;
+}

--- a/src/components/PromptForm/index.tsx
+++ b/src/components/PromptForm/index.tsx
@@ -1,8 +1,9 @@
 import { type RefObject } from "react";
-import { useMediaQuery } from "@chakra-ui/react";
 
 import MobilePromptForm from "./MobilePromptForm";
 import DesktopPromptForm from "./DesktopPromptForm";
+import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
+import { useSettings } from "../../hooks/use-settings";
 
 export type PromptFormProps = {
   forkUrl: string;
@@ -12,15 +13,19 @@ export type PromptFormProps = {
   // the height is determined automatically by the parent.
   isExpanded: boolean;
   toggleExpanded: () => void;
-  singleMessageMode: boolean;
-  onSingleMessageModeChange: (value: boolean) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
   isLoading: boolean;
   previousMessage?: string;
 };
 
 export default function PromptForm(props: PromptFormProps) {
-  const [isMobile] = useMediaQuery("(max-width: 480px)");
+  const { settings } = useSettings();
+  const isMobile = useMobileBreakpoint();
+
+  // Skip showing anything if we don't have an API Key to use
+  if (!settings.apiKey) {
+    return null;
+  }
 
   return isMobile ? <MobilePromptForm {...props} /> : <DesktopPromptForm {...props} />;
 }

--- a/src/hooks/use-mobile-breakpoint.ts
+++ b/src/hooks/use-mobile-breakpoint.ts
@@ -1,0 +1,10 @@
+import { useMediaQuery } from "@chakra-ui/react";
+
+// Use 480 as our upper limit for the "mobile" experience.
+const mobileMediaQuery = "(max-width: 480px)";
+
+export default function useMobileBreakpoint() {
+  const [isMobile] = useMediaQuery(mobileMediaQuery);
+
+  return isMobile;
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,6 +6,17 @@ export const formatNumber = (n: number) => (n ? n.toLocaleString() : "0");
 export const formatCurrency = (n: number) =>
   Intl.NumberFormat(undefined, { style: "currency", currency: "USD" }).format(n);
 
+export const formatSeconds = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+
+  const minutesString = minutes < 10 ? "0" + minutes : minutes.toString();
+  const secondsString: string =
+    remainingSeconds < 10 ? "0" + remainingSeconds : remainingSeconds.toString();
+
+  return `${minutesString}:${secondsString}`;
+};
+
 export const formatDate = (d: Date, short = false) =>
   short
     ? new Intl.DateTimeFormat(undefined, {


### PR DESCRIPTION
I'm starting to experiment with a better prompt form, and first up is the mobile experience.  I've been looking at how various mobile apps do this (Messages on iOS, Telegram, WhatsApp) and have tried to create something more appropriate for use on a small screen with your fingers:

<img width="344" alt="Screenshot 2023-09-20 at 9 15 01 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/029e0488-e130-4d32-aa60-05ad7478f8b9">

A few things to call out:

- The form now takes up almost no height (fixes #50).  The input element has been greatly reduced in size.  It will expand vertically if the text requires it, but I think audio is the ideal way to enter a prompt on mobile.
- Single Message Mode has been removed
- Input expansion and keyboard hints have been removed
- The token cost for the session has been moved to the header for the chat (I'm not sure about this, there there is no good place for it):

<img width="323" alt="Screenshot 2023-09-21 at 7 49 09 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/aa0b8343-2535-41ba-bfd8-798a35cb7c1f">

- The "New +" button has been changed to "+" and moved to the left of the input.  Clicking it brings up the same menu of options:

<img width="334" alt="Screenshot 2023-09-21 at 7 50 05 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/f5d19565-03f2-4af8-b974-9484af06c403">

7. The "Ask" button/model chooser has been separated into two buttons.  The up-arrow lets you choose a model, and the "Ask" button has been shortened to a "send" arrow.

<img width="327" alt="Screenshot 2023-09-21 at 7 50 33 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/fc7fdf05-e5ef-4fd7-8416-e89c659bc803">

9. The Mic button has been moved out of the input element so that attempting to press it doesn't accidentally activate/focus the input box on mobile.  It works the same as before (hold to record, slide-left to cancel).
10. While recording/transcribing, the input element is replaced with a status indicator showing the progress of the recording or transcription:

<img width="331" alt="Screenshot 2023-09-21 at 7 45 17 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/2257f454-753c-4549-9ef3-dd9058abdf16">
