### PR TITLE
Add more whitespace around desktop prompt elements

### DIFF
--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -163,8 +163,8 @@ function DesktopPromptForm({
     <Flex dir="column" w="100%" h="100%">
       <Card flex={1} my={4} mx={1}>
         <chakra.form onSubmit={handlePromptSubmit} h="100%">
-          <CardBody h="100%" py={4} px={6}>
-            <VStack w="100%" h="100%" gap={2}>
+          <CardBody h="100%" p={6}>
+            <VStack w="100%" h="100%" gap={3}>
               <InputGroup h="100%" bg="white" _dark={{ bg: "gray.700" }}>
                 <Flex w="100%" h="100%">
                   {inputType === "audio" ? (


### PR DESCRIPTION
I've been using the new prompt form design for a few days, and it has felt too "tight".  This opens it up a bit with more whitespace:

<img width="931" alt="Screenshot 2023-09-28 at 9 25 58 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/d549c3c5-9c73-4fd2-bcc0-6310fcd43ca9">
