### PR TITLE
Support parsing R Markdown code blocks {python} vs. python

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -69,8 +69,10 @@ function Markdown({ previewCode, isLoading, onPrompt, children }: MarkdownProps)
             );
           }
 
-          // Look for named code blocks (e.g., `language-html`)
-          const match = /language-(\w+)/.exec(className || "");
+          // Look for named code blocks (e.g., `language-html`) allowing for
+          // R Markdown code blocks as well, which look like {r} vs. r or
+          // {python} vs. python
+          const match = /language-{?(\w+)/.exec(className || "");
           const language = (match && match[1]) || "text";
 
           // Include rendered versions of some code blocks before the code


### PR DESCRIPTION
I've been working on a bunch of R code with my daughters recently, and noticed we don't support [R Markdown code blocks](https://www.rstudio.com/wp-content/uploads/2015/02/rmarkdown-cheatsheet.pdf), which use `{...}` to wrap the language: `{r}` or `{python}` etc.

This fixes our regex to support it:

<img width="909" alt="Screenshot 2023-09-28 at 9 40 39 AM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/e5aea0d6-6066-4ef9-8c65-655090a97b62">
