### PR TITLE
Add margin to top of HTML preview, fix #203

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -28,7 +28,7 @@ const HtmlPreview = ({ children }: HtmlPreviewProps) => {
         color="gray.600"
         variant="ghost"
       />
-      <CardBody p={2}>
+      <CardBody mt={6} p={2}>
         <chakra.iframe w="100%" minHeight="200px" frameBorder="0" src={url}></chakra.iframe>
       </CardBody>
     </Card>


### PR DESCRIPTION
Added a margin to the top of the web content so it doesn't interfere.

<img width="864" alt="Screenshot 2023-09-29 at 12 03 05 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/1f9307fa-763d-48c9-bef7-77e65746a1ca">
