### PR TITLE
Lazily load the IframeResizer only when needed

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -1,7 +1,8 @@
-import { memo, useMemo, type ReactNode } from "react";
+import { lazy, memo, useMemo, type ReactNode } from "react";
 import { Card, CardBody, IconButton } from "@chakra-ui/react";
 import { TbExternalLink } from "react-icons/tb";
-import IframeResizer from "iframe-resizer-react";
+
+const IframeResizer = lazy(() => import("iframe-resizer-react"));
 
 type HtmlPreviewProps = {
   children: ReactNode & ReactNode[];


### PR DESCRIPTION
@mingming-ma I realized that we can save some download size in the bundle by not loading this until needed (we don't show previews that often), using React's `lazy` function, see https://react.dev/reference/react/lazy.

Can you test this and make sure it still works OK for you?