### PR TITLE
Fix viewport scroll bug

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -88,6 +88,10 @@ function ChatBase({ chat }: ChatBaseProps) {
     forceScroll();
   }, [forceScroll, scrollProgress, shouldAutoScroll, chat.date]);
 
+  useEffect(() => {
+    document.getElementById("topAnchor")?.scrollIntoView();
+  }, [chat]);
+
   // Disable auto scroll when we're in the middle of streaming and the user scrolls
   // up to read previous content.
   const handleScroll = useCallback(() => {
@@ -272,87 +276,90 @@ function ChatBase({ chat }: ChatBaseProps) {
   }
 
   return (
-    <Grid
-      w="100%"
-      h="100%"
-      gridTemplateRows="min-content 1fr min-content"
-      gridTemplateColumns={{
-        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
-      }}
-      bgGradient="linear(to-b, white, gray.100)"
-      _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
-    >
-      <GridItem colSpan={2}>
-        <Header
-          chatId={chat.id}
-          inputPromptRef={inputPromptRef}
-          onToggleSidebar={handleToggleSidebarVisible}
-        />
-      </GridItem>
-
-      <GridItem rowSpan={3} overflowY="auto">
-        <Sidebar selectedChat={chat} />
-      </GridItem>
-
-      <GridItem overflowY="auto" ref={messageListRef} pos="relative">
-        <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
-          {
-            /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
-            !!scrollProgress && !shouldAutoScroll && (
-              <Flex
-                w="100%"
-                maxW="900px"
-                mx="auto"
-                justify="center"
-                position="fixed"
-                top="5em"
-                zIndex="500"
-              >
-                <Button onClick={() => handleFollowChatClick()}>
-                  <CgArrowDownO />
-                  <Text ml={2}>Follow Chat</Text>
-                </Button>
-              </Flex>
-            )
-          }
-
-          <ChatHeader chat={chat} />
-
-          <ScrollRestoration />
-
-          <MessagesView
-            chat={chat}
-            newMessage={streamingMessage}
-            isLoading={loading}
-            onRemoveMessage={(message) => chat.removeMessage(message.id)}
-            isPaused={paused}
-            onTogglePause={togglePause}
-            onCancel={cancel}
-            onPrompt={onPrompt}
+    <>
+      <p id="topAnchor"></p>
+      <Grid
+        w="100%"
+        h="100%"
+        gridTemplateRows="min-content 1fr min-content"
+        gridTemplateColumns={{
+          base: isSidebarVisible ? "300px 1fr" : "0 1fr",
+          sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
+          md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
+        }}
+        bgGradient="linear(to-b, white, gray.100)"
+        _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
+      >
+        <GridItem colSpan={2}>
+          <Header
+            chatId={chat.id}
+            inputPromptRef={inputPromptRef}
+            onToggleSidebar={handleToggleSidebarVisible}
           />
-        </Flex>
-      </GridItem>
+        </GridItem>
 
-      <GridItem>
-        <Box maxW="900px" mx="auto" h="100%">
-          {chat.readonly ? (
-            <Flex w="100%" h="45px" justify="end" align="center" p={2}>
-              <NewButton forkUrl={`./fork`} variant="solid" />
-            </Flex>
-          ) : (
-            <PromptForm
-              forkUrl={`./fork`}
-              onSendClick={onPrompt}
+        <GridItem rowSpan={3} overflowY="auto">
+          <Sidebar selectedChat={chat} />
+        </GridItem>
+
+        <GridItem overflowY="auto" ref={messageListRef} pos="relative">
+          <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
+            {
+              /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
+              !!scrollProgress && !shouldAutoScroll && (
+                <Flex
+                  w="100%"
+                  maxW="900px"
+                  mx="auto"
+                  justify="center"
+                  position="fixed"
+                  top="5em"
+                  zIndex="500"
+                >
+                  <Button onClick={() => handleFollowChatClick()}>
+                    <CgArrowDownO />
+                    <Text ml={2}>Follow Chat</Text>
+                  </Button>
+                </Flex>
+              )
+            }
+
+            <ChatHeader chat={chat} />
+
+            <ScrollRestoration />
+
+            <MessagesView
+              chat={chat}
+              newMessage={streamingMessage}
               isLoading={loading}
-              previousMessage={chat.messages().at(-1)?.text}
-              inputPromptRef={inputPromptRef}
+              onRemoveMessage={(message) => chat.removeMessage(message.id)}
+              isPaused={paused}
+              onTogglePause={togglePause}
+              onCancel={cancel}
+              onPrompt={onPrompt}
             />
-          )}
-        </Box>
-      </GridItem>
-    </Grid>
+          </Flex>
+        </GridItem>
+
+        <GridItem>
+          <Box maxW="900px" mx="auto" h="100%">
+            {chat.readonly ? (
+              <Flex w="100%" h="45px" justify="end" align="center" p={2}>
+                <NewButton forkUrl={`./fork`} variant="solid" />
+              </Flex>
+            ) : (
+              <PromptForm
+                forkUrl={`./fork`}
+                onSendClick={onPrompt}
+                isLoading={loading}
+                previousMessage={chat.messages().at(-1)?.text}
+                inputPromptRef={inputPromptRef}
+              />
+            )}
+          </Box>
+        </GridItem>
+      </Grid>
+    </>
   );
 }
 

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -272,89 +272,87 @@ function ChatBase({ chat }: ChatBaseProps) {
   }
 
   return (
-    <>
-      <Grid
-        w="100%"
-        h="100%"
-        gridTemplateRows="min-content 1fr min-content"
-        gridTemplateColumns={{
-          base: isSidebarVisible ? "300px 1fr" : "0 1fr",
-          sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-          md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
-        }}
-        bgGradient="linear(to-b, white, gray.100)"
-        _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
-      >
-        <GridItem colSpan={2}>
-          <Header
-            chatId={chat.id}
-            inputPromptRef={inputPromptRef}
-            onToggleSidebar={handleToggleSidebarVisible}
-          />
-        </GridItem>
+    <Grid
+      w="100%"
+      h="100%"
+      gridTemplateRows="min-content 1fr min-content"
+      gridTemplateColumns={{
+        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
+        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
+        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
+      }}
+      bgGradient="linear(to-b, white, gray.100)"
+      _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
+    >
+      <GridItem colSpan={2}>
+        <Header
+          chatId={chat.id}
+          inputPromptRef={inputPromptRef}
+          onToggleSidebar={handleToggleSidebarVisible}
+        />
+      </GridItem>
 
-        <GridItem rowSpan={2} overflowY="auto">
-          <Sidebar selectedChat={chat} />
-        </GridItem>
+      <GridItem rowSpan={2} overflowY="auto">
+        <Sidebar selectedChat={chat} />
+      </GridItem>
 
-        <GridItem overflowY="auto" ref={messageListRef} pos="relative">
-          <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
-            {
-              /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
-              !!scrollProgress && !shouldAutoScroll && (
-                <Flex
-                  w="100%"
-                  maxW="900px"
-                  mx="auto"
-                  justify="center"
-                  position="fixed"
-                  top="5em"
-                  zIndex="500"
-                >
-                  <Button onClick={() => handleFollowChatClick()}>
-                    <CgArrowDownO />
-                    <Text ml={2}>Follow Chat</Text>
-                  </Button>
-                </Flex>
-              )
-            }
-
-            <ChatHeader chat={chat} />
-
-            <ScrollRestoration />
-
-            <MessagesView
-              chat={chat}
-              newMessage={streamingMessage}
-              isLoading={loading}
-              onRemoveMessage={(message) => chat.removeMessage(message.id)}
-              isPaused={paused}
-              onTogglePause={togglePause}
-              onCancel={cancel}
-              onPrompt={onPrompt}
-            />
-          </Flex>
-        </GridItem>
-
-        <GridItem>
-          <Box maxW="900px" mx="auto" h="100%">
-            {chat.readonly ? (
-              <Flex w="100%" h="45px" justify="end" align="center" p={2}>
-                <NewButton forkUrl={`./fork`} variant="solid" />
+      <GridItem overflowY="auto" ref={messageListRef} pos="relative">
+        <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
+          {
+            /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
+            !!scrollProgress && !shouldAutoScroll && (
+              <Flex
+                w="100%"
+                maxW="900px"
+                mx="auto"
+                justify="center"
+                position="fixed"
+                top="5em"
+                zIndex="500"
+              >
+                <Button onClick={() => handleFollowChatClick()}>
+                  <CgArrowDownO />
+                  <Text ml={2}>Follow Chat</Text>
+                </Button>
               </Flex>
-            ) : (
-              <PromptForm
-                forkUrl={`./fork`}
-                onSendClick={onPrompt}
-                isLoading={loading}
-                previousMessage={chat.messages().at(-1)?.text}
-                inputPromptRef={inputPromptRef}
-              />
-            )}
-          </Box>
-        </GridItem>
-      </Grid>
-    </>
+            )
+          }
+
+          <ChatHeader chat={chat} />
+
+          <ScrollRestoration />
+
+          <MessagesView
+            chat={chat}
+            newMessage={streamingMessage}
+            isLoading={loading}
+            onRemoveMessage={(message) => chat.removeMessage(message.id)}
+            isPaused={paused}
+            onTogglePause={togglePause}
+            onCancel={cancel}
+            onPrompt={onPrompt}
+          />
+        </Flex>
+      </GridItem>
+
+      <GridItem>
+        <Box maxW="900px" mx="auto" h="100%">
+          {chat.readonly ? (
+            <Flex w="100%" h="45px" justify="end" align="center" p={2}>
+              <NewButton forkUrl={`./fork`} variant="solid" />
+            </Flex>
+          ) : (
+            <PromptForm
+              forkUrl={`./fork`}
+              onSendClick={onPrompt}
+              isLoading={loading}
+              previousMessage={chat.messages().at(-1)?.text}
+              inputPromptRef={inputPromptRef}
+            />
+          )}
+        </Box>
+      </GridItem>
+    </Grid>
   );
 }
 

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -88,10 +88,6 @@ function ChatBase({ chat }: ChatBaseProps) {
     forceScroll();
   }, [forceScroll, scrollProgress, shouldAutoScroll, chat.date]);
 
-  useEffect(() => {
-    document.getElementById("topAnchor")?.scrollIntoView();
-  }, [chat]);
-
   // Disable auto scroll when we're in the middle of streaming and the user scrolls
   // up to read previous content.
   const handleScroll = useCallback(() => {
@@ -277,7 +273,6 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   return (
     <>
-      <p id="topAnchor"></p>
       <Grid
         w="100%"
         h="100%"
@@ -298,7 +293,7 @@ function ChatBase({ chat }: ChatBaseProps) {
           />
         </GridItem>
 
-        <GridItem rowSpan={3} overflowY="auto">
+        <GridItem rowSpan={2} overflowY="auto">
           <Sidebar selectedChat={chat} />
         </GridItem>
 

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -42,7 +42,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList height={400} overflowY={"auto"}>
+        <MenuList maxHeight={400} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}
@@ -71,7 +71,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList height={400} overflowY={"auto"}>
+        <MenuList maxHeight={400} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -23,7 +23,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
 
   return (
     <ButtonGroup variant="outline" isAttached>
-      <Menu>
+      <Menu placement="top" strategy="fixed">
         <IconButton
           type="submit"
           size="lg"
@@ -42,7 +42,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList>
+        <MenuList height={400} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -63,7 +63,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      <Menu>
+      <Menu placement="top" strategy="fixed">
         <MenuButton
           as={IconButton}
           size="sm"
@@ -71,7 +71,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList>
+        <MenuList height={400} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -42,7 +42,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList maxHeight={400} overflowY={"auto"}>
+        <MenuList maxHeight={"70vh"} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}
@@ -71,7 +71,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList maxHeight={400} overflowY={"auto"}>
+        <MenuList maxHeight={"70vh"} overflowY={"auto"}>
           {models.map((model) => (
             <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
               {model.prettyModel}


### PR DESCRIPTION
The `main` element of the application has a lot of extra height (about 2.5 times) that of the main grid in `ChatBase` component. The additional scrollbar is hidden from the user because of the use of `overflow: hidden` style. 

Now whenever a sidebar link is clicked, the view loads the correct chat but scrolls to the link that was clicked. However, the user is not able to scroll back up as there is no scrollbar for the actual page due to overflow: hidden` hack.
This creates an impression that the router is messing things up by shifting the viewport.

I've added a fix for this issue, where on each render of this page the document is scrolled to top, preventing the UI from messing up.

This closes #263 

**Note:** I might be wrong, but I believe the layout could have some fundamental flaws as 2 scrollbars side by side is a bad design and a red flag.