### PR TITLE
Add - Support visual input for the gpt-4-vision-preview

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -141,7 +141,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   // Handle prompt form submission
   const onPrompt = useCallback(
-    async (prompt?: string, image_url?: string[]) => {
+    async (prompt?: string, image?: string[]) => {
       setLoading(true);
 
       // Special-case for "help", to invoke /help command
@@ -184,7 +184,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         // If the prompt text exist, package it up as a human message and add to the chat
         if (prompt) {
           // Add this prompt message to the chat
-          promptMessage = new ChatCraftHumanMessage({ text: prompt, image_url, user });
+          promptMessage = new ChatCraftHumanMessage({ text: prompt, image, user });
           await chat.addMessage(promptMessage);
         } else {
           // If there isn't any prompt text, see if the final message in the chat was a human
@@ -220,7 +220,6 @@ function ChatBase({ chat }: ChatBaseProps) {
 
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
         const messages = chat.messages({ includeAppMessages: false });
-        console.log(messages);
         const response = await callChatApi(messages, {
           functions,
           functionToCall,

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -141,7 +141,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   // Handle prompt form submission
   const onPrompt = useCallback(
-    async (prompt?: string) => {
+    async (prompt?: string, image_url?: string[]) => {
       setLoading(true);
 
       // Special-case for "help", to invoke /help command
@@ -184,7 +184,7 @@ function ChatBase({ chat }: ChatBaseProps) {
         // If the prompt text exist, package it up as a human message and add to the chat
         if (prompt) {
           // Add this prompt message to the chat
-          promptMessage = new ChatCraftHumanMessage({ text: prompt, user });
+          promptMessage = new ChatCraftHumanMessage({ text: prompt, image_url, user });
           await chat.addMessage(promptMessage);
         } else {
           // If there isn't any prompt text, see if the final message in the chat was a human
@@ -220,6 +220,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
         const messages = chat.messages({ includeAppMessages: false });
+        console.log(messages);
         const response = await callChatApi(messages, {
           functions,
           functionToCall,

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -65,6 +65,7 @@ function DesktopPromptForm({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const inputType = isRecording || isTranscribing ? "audio" : "text";
+  // Base64 images
   const [inputImages, setInputImages] = useState<string[]>([]);
   const location = useLocation();
 
@@ -168,13 +169,25 @@ function DesktopPromptForm({
     setIsTranscribing(false);
   };
 
+  const getBase64FromFile = (file: File): Promise<string> => {
+    return new Promise((resolve) => {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        const base64data = reader.result as string;
+        resolve(base64data);
+      };
+    });
+  };
+
   const handleDropImage = (e: React.DragEvent) => {
     e.preventDefault();
     const files = Array.from(e.dataTransfer.files);
-    const newImages = files
-      .filter((file) => file.type.startsWith("image/"))
-      .map((file) => URL.createObjectURL(file));
-    setInputImages((prevImages) => [...prevImages, ...newImages]);
+    Promise.all(
+      files.filter((file) => file.type.startsWith("image/")).map((file) => getBase64FromFile(file))
+    ).then((base64Strings) => {
+      setInputImages((prevImages) => [...prevImages, ...base64Strings]);
+    });
   };
 
   const handleDeleteImage = (index: number) => {

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -44,7 +44,7 @@ function KeyboardHint({ isVisible }: KeyboardHintProps) {
 
 type DesktopPromptFormProps = {
   forkUrl: string;
-  onSendClick: (prompt: string, image_url: string[]) => void;
+  onSendClick: (prompt: string, image: string[]) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
   isLoading: boolean;
   previousMessage?: string;

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -44,7 +44,7 @@ function KeyboardHint({ isVisible }: KeyboardHintProps) {
 
 type DesktopPromptFormProps = {
   forkUrl: string;
-  onSendClick: (prompt: string) => void;
+  onSendClick: (prompt: string, image_url: string[]) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
   isLoading: boolean;
   previousMessage?: string;
@@ -65,7 +65,7 @@ function DesktopPromptForm({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const inputType = isRecording || isTranscribing ? "audio" : "text";
-  const [draggedImages, setDraggedImages] = useState<string[]>([]);
+  const [inputImages, setInputImages] = useState<string[]>([]);
   const location = useLocation();
 
   // If the user clears the prompt, allow up-arrow again
@@ -109,9 +109,10 @@ function DesktopPromptForm({
   // Handle prompt form submission
   const handlePromptSubmit = (e: FormEvent) => {
     e.preventDefault();
-    const value = prompt.trim();
+    const textValue = prompt.trim();
     setPrompt("");
-    onSendClick(value);
+    setInputImages([]);
+    onSendClick(textValue, inputImages);
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -162,7 +163,7 @@ function DesktopPromptForm({
 
   const handleTranscriptionAvailable = (transcription: string) => {
     // Use this transcript as our prompt
-    onSendClick(transcription);
+    onSendClick(transcription, inputImages);
     setIsRecording(false);
     setIsTranscribing(false);
   };
@@ -173,13 +174,13 @@ function DesktopPromptForm({
     const newImages = files
       .filter((file) => file.type.startsWith("image/"))
       .map((file) => URL.createObjectURL(file));
-    setDraggedImages((prevImages) => [...prevImages, ...newImages]);
+    setInputImages((prevImages) => [...prevImages, ...newImages]);
   };
 
   const handleDeleteImage = (index: number) => {
-    const updatedImages = [...draggedImages];
+    const updatedImages = [...inputImages];
     updatedImages.splice(index, 1);
-    setDraggedImages(updatedImages);
+    setInputImages(updatedImages);
   };
 
   return (
@@ -197,7 +198,7 @@ function DesktopPromptForm({
               >
                 <Flex w="100%" h="100%" direction="column">
                   <Flex flexWrap="wrap">
-                    {draggedImages.map((image, index) => (
+                    {inputImages.map((image, index) => (
                       <Box key={index}>
                         <Flex direction="column">
                           <img

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -4,6 +4,7 @@ import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
 import { isMac, isWindows } from "../../lib/utils";
+import { TiDeleteOutline } from "react-icons/ti";
 import NewButton from "../NewButton";
 import MicIcon from "./MicIcon";
 import { isTranscriptionSupported } from "../../lib/speech-recognition";
@@ -64,6 +65,7 @@ function DesktopPromptForm({
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [recordingSeconds, setRecordingSeconds] = useState(0);
   const inputType = isRecording || isTranscribing ? "audio" : "text";
+  const [draggedImages, setDraggedImages] = useState<string[]>([]);
   const location = useLocation();
 
   // If the user clears the prompt, allow up-arrow again
@@ -165,51 +167,95 @@ function DesktopPromptForm({
     setIsTranscribing(false);
   };
 
+  const handleDropImage = (e: React.DragEvent) => {
+    e.preventDefault();
+    const files = Array.from(e.dataTransfer.files);
+    const newImages = files
+      .filter((file) => file.type.startsWith("image/"))
+      .map((file) => URL.createObjectURL(file));
+    setDraggedImages((prevImages) => [...prevImages, ...newImages]);
+  };
+
+  const handleDeleteImage = (index: number) => {
+    const updatedImages = [...draggedImages];
+    updatedImages.splice(index, 1);
+    setDraggedImages(updatedImages);
+  };
+
   return (
     <Flex dir="column" w="100%" h="100%">
       <Card flex={1} my={4} mx={1}>
         <chakra.form onSubmit={handlePromptSubmit} h="100%">
           <CardBody h="100%" p={6}>
             <VStack w="100%" h="100%" gap={3}>
-              <InputGroup h="100%" bg="white" _dark={{ bg: "gray.700" }}>
-                <Flex w="100%" h="100%">
-                  {inputType === "audio" ? (
-                    <Box py={2} px={1} flex={1}>
-                      <AudioStatus
-                        isRecording={isRecording}
-                        isTranscribing={isTranscribing}
-                        recordingSeconds={recordingSeconds}
+              <InputGroup
+                h="100%"
+                bg="white"
+                _dark={{ bg: "gray.700" }}
+                onDragOver={(e) => e.preventDefault()}
+                onDrop={handleDropImage}
+              >
+                <Flex w="100%" h="100%" direction="column">
+                  <Flex flexWrap="wrap">
+                    {draggedImages.map((image, index) => (
+                      <Box key={index}>
+                        <Flex direction="column">
+                          <img
+                            src={image}
+                            alt={`Dragged ${index}`}
+                            style={{ width: "100px", height: "100px", objectFit: "cover" }}
+                          />
+                          <Flex justify="flex-end">
+                            <TiDeleteOutline
+                              onClick={() => handleDeleteImage(index)}
+                              style={{ cursor: "pointer" }}
+                            >
+                              Delete
+                            </TiDeleteOutline>
+                          </Flex>
+                        </Flex>
+                      </Box>
+                    ))}
+                  </Flex>
+                  <Flex flexWrap="wrap">
+                    {inputType === "audio" ? (
+                      <Box py={2} px={1} flex={1}>
+                        <AudioStatus
+                          isRecording={isRecording}
+                          isTranscribing={isTranscribing}
+                          recordingSeconds={recordingSeconds}
+                        />
+                      </Box>
+                    ) : (
+                      <AutoResizingTextarea
+                        ref={inputPromptRef}
+                        variant="unstyled"
+                        onKeyDown={handleKeyDown}
+                        isDisabled={isLoading}
+                        autoFocus={true}
+                        value={prompt}
+                        onChange={(e) => setPrompt(e.target.value)}
+                        bg="white"
+                        _dark={{ bg: "gray.700" }}
+                        placeholder={
+                          !isLoading && !isRecording && !isTranscribing
+                            ? "Ask a question or use /help to learn more"
+                            : undefined
+                        }
+                        overflowY="auto"
+                        flex={1}
                       />
-                    </Box>
-                  ) : (
-                    <AutoResizingTextarea
-                      ref={inputPromptRef}
-                      variant="unstyled"
-                      onKeyDown={handleKeyDown}
-                      isDisabled={isLoading}
-                      autoFocus={true}
-                      value={prompt}
-                      onChange={(e) => setPrompt(e.target.value)}
-                      bg="white"
-                      _dark={{ bg: "gray.700" }}
-                      placeholder={
-                        !isLoading && !isRecording && !isTranscribing
-                          ? "Ask a question or use /help to learn more"
-                          : undefined
-                      }
-                      overflowY="auto"
-                      flex={1}
-                    />
-                  )}
-                  {isTranscriptionSupported() && (
-                    <MicIcon
-                      isDisabled={isLoading}
-                      onRecording={handleRecording}
-                      onTranscribing={handleTranscribing}
-                      onTranscriptionAvailable={handleTranscriptionAvailable}
-                      onCancel={handleRecordingCancel}
-                    />
-                  )}
+                    )}
+                    {isTranscriptionSupported() && (
+                      <MicIcon
+                        isDisabled={isLoading}
+                        onRecording={handleRecording}
+                        onTranscribing={handleTranscribing}
+                        onTranscriptionAvailable={handleTranscriptionAvailable}
+                        onCancel={handleRecordingCancel}
+                      />
+                    )}
+                  </Flex>
                 </Flex>
               </InputGroup>
 

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -312,29 +312,34 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
 
 export class ChatCraftHumanMessage extends ChatCraftMessage {
   user?: User;
+  image_url?: string[];
 
   constructor({
     id,
     date,
     user,
     text,
+    image_url,
     readonly,
   }: {
     id?: string;
     date?: Date;
     user?: User;
     text: string;
+    image_url?: string[];
     readonly?: boolean;
   }) {
     super({ id, date, type: "human", text, readonly });
 
     this.user = user;
+    this.image_url = image_url;
   }
 
   clone() {
     return new ChatCraftHumanMessage({
       user: this.user,
       text: this.text,
+      image_url: this.image_url,
     });
   }
 

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -99,14 +99,14 @@ export class ChatCraftMessage {
     };
   }
 
-  toOpenAiMessage(): OpenAI.Chat.Completions.CreateChatCompletionRequestMessage {
+  toOpenAiMessage(): OpenAI.Chat.Completions.ChatCompletionMessageParam {
     const text = this.text;
 
-    const content = [];
-    content.push({ type: "text", text: this.text });
+    const textAndImage = [];
+    textAndImage.push({ type: "text", text: this.text });
     if (this.image && this.image.length > 0) {
       this.image.forEach((image) => {
-        content.push({
+        textAndImage.push({
           type: "image_url",
           image_url: { url: image },
         });
@@ -117,7 +117,7 @@ export class ChatCraftMessage {
       case "ai":
         return { role: "assistant", content: text };
       case "human":
-        return { role: "user", content };
+        return { role: "user", content: textAndImage };
       case "system":
         return { role: "system", content: text };
       case "function":

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -46,6 +46,7 @@ export class ChatCraftMessage {
   date: Date;
   type: MessageType;
   text: string;
+  image: string[];
   readonly: boolean;
 
   constructor({
@@ -53,18 +54,21 @@ export class ChatCraftMessage {
     date,
     type,
     text,
+    image,
     readonly,
   }: {
     id?: string;
     date?: Date;
     type: MessageType;
     text: string;
+    image?: string[];
     readonly?: boolean;
   }) {
     this.id = id ?? nanoid();
     this.date = date ?? new Date();
     this.type = type;
     this.text = text;
+    this.image = image ?? [];
 
     // When we load a message outside the db (e.g., from shared chat via JSON) it is readonly
     this.readonly = readonly === true;
@@ -82,6 +86,7 @@ export class ChatCraftMessage {
     return new ChatCraftMessage({
       type: this.type,
       text: this.text,
+      image: this.image,
     });
   }
 
@@ -96,11 +101,23 @@ export class ChatCraftMessage {
 
   toOpenAiMessage(): OpenAI.Chat.Completions.CreateChatCompletionRequestMessage {
     const text = this.text;
+
+    const content = [];
+    content.push({ type: "text", text: this.text });
+    if (this.image && this.image.length > 0) {
+      this.image.forEach((image) => {
+        content.push({
+          type: "image_url",
+          image_url: { url: image },
+        });
+      });
+    }
+
     switch (this.type) {
       case "ai":
         return { role: "assistant", content: text };
       case "human":
-        return { role: "user", content: text };
+        return { role: "user", content };
       case "system":
         return { role: "system", content: text };
       case "function":
@@ -312,34 +329,32 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
 
 export class ChatCraftHumanMessage extends ChatCraftMessage {
   user?: User;
-  image_url?: string[];
 
   constructor({
     id,
     date,
     user,
     text,
-    image_url,
+    image,
     readonly,
   }: {
     id?: string;
     date?: Date;
     user?: User;
     text: string;
-    image_url?: string[];
+    image?: string[];
     readonly?: boolean;
   }) {
-    super({ id, date, type: "human", text, readonly });
+    super({ id, date, type: "human", text, image, readonly });
 
     this.user = user;
-    this.image_url = image_url;
   }
 
   clone() {
     return new ChatCraftHumanMessage({
       user: this.user,
       text: this.text,
-      image_url: this.image_url,
+      image: this.image,
     });
   }
 


### PR DESCRIPTION
Hi, as #279 discuses, the `gpt-4-vision-preview` now allow us to ask questions related images.  I would like to help to update the code support visual Input. Because it related to many components, I was trying to make minimum possible updates to show the workable and share my process now. Hope my approach is on the right way.

## Tasks

- [ ] Fix response cutoff bug
- [ ] Update the model based on file type
- [ ] Attach file instead of drag file
- [ ] Better preview if attach file is image

## Status
Now user can drag the image to text area and ask questions, like below:
<details>

Before submit:
![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/6258474c-370b-4ef6-8510-3ec395139266)

After submit:
<img width="837" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/5d262d69-f140-49e0-8be7-d856ada486b3">
</details>

## Known issues 
### response cutoff bug
![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/addf178f-7ad6-4173-a0ba-b3f7f73275e6)

### type mismatch
New payload format not meet the interface type, trying to fix
<img width="885" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/8f3d328c-b8d9-4e53-b2d4-0fe5e1c47e7e">

Feel free to share your feedback! Thanks!