### PR TITLE
Feature/system prompts table kosty

### DIFF
--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -60,7 +60,7 @@ function SystemPromptVersionsMenu({
       ChatCraftStarredSystemPrompt.exists(promptMessage.text).catch((err) => {
         console.warn("Unable to query 'starred' table for PK", err);
         error({
-          title: "Error while checking for presense of Starred System Prompt in db",
+          title: "Error while checking for presence of starred System Prompt in db",
           message: err.message,
         });
         return false;

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -20,7 +20,7 @@ import MessageBase, { type MessageBaseProps } from "./MessageBase";
 import { createSystemPromptSummary, defaultSystemPrompt } from "../../lib/system-prompt";
 import db from "../../lib/db";
 import { ChatCraftSystemMessage } from "../../lib/ChatCraftMessage";
-import { ChatCraftStarredText } from "../../lib/ChatCraftStarredText";
+import { ChatCraftStarredSystemPrompt } from "../../lib/ChatCraftStarredSystemPrompt";
 import { useAlert } from "../../hooks/use-alert";
 
 function SystemPromptVersionsMenu({
@@ -55,17 +55,17 @@ function SystemPromptVersionsMenu({
     []
   );
 
-  const isStarredMessage = useLiveQuery<boolean>(async () => {
-    return ChatCraftStarredText.check(promptMessage.text);
+  const isStarredSystemPrompt = useLiveQuery<boolean>(async () => {
+    return ChatCraftStarredSystemPrompt.exists(promptMessage.text);
   }, [promptMessage]);
 
   const handleStarredChanged = () => {
-    const starredText = new ChatCraftStarredText({ text: promptMessage.text });
-    if (!isStarredMessage) {
+    const starredText = new ChatCraftStarredSystemPrompt({ text: promptMessage.text });
+    if (!isStarredSystemPrompt) {
       starredText.save().catch((err) => {
         console.warn("Unable to update system prompt", err);
         error({
-          title: `Error changing starred for System Prompt`,
+          title: `Error while saving Starred System Prompt to db`,
           message: err.message,
         });
       });
@@ -73,14 +73,14 @@ function SystemPromptVersionsMenu({
       starredText.remove().catch((err) => {
         console.warn("Unable to update system prompt", err);
         error({
-          title: `Error changing starred for System Prompt`,
+          title: `Error while removing Starred System Prompt from db`,
           message: err.message,
         });
       });
     }
   };
 
-  const title = isStarredMessage
+  const title = isStarredSystemPrompt
     ? "Unstar System Prompt to forget it"
     : "Star System Prompt to save for future use";
 
@@ -90,7 +90,7 @@ function SystemPromptVersionsMenu({
         size="sm"
         aria-label={title}
         title={title}
-        icon={isStarredMessage ? <TbStarFilled /> : <TbStar />}
+        icon={isStarredSystemPrompt ? <TbStarFilled /> : <TbStar />}
         variant="ghost"
         onClick={handleStarredChanged}
       />

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -46,34 +46,43 @@ function SystemPromptVersionsMenu({
           console.error("Failed to query the starred table:", error);
         });
       if (!records) {
-        return Promise.resolve([defaultSystemPrompt()]);
+        return [defaultSystemPrompt()];
       }
 
-      return Promise.resolve([defaultSystemPrompt(), ...records]);
+      return [defaultSystemPrompt(), ...records];
     },
     [],
     []
   );
 
-  const isStarredSystemPrompt = useLiveQuery<boolean>(async () => {
-    return ChatCraftStarredSystemPrompt.exists(promptMessage.text);
-  }, [promptMessage]);
+  const isStarredSystemPrompt = useLiveQuery<boolean>(
+    () =>
+      ChatCraftStarredSystemPrompt.exists(promptMessage.text).catch((err) => {
+        console.warn("Unable to query 'starred' table for PK", err);
+        error({
+          title: "Error while checking for presense of Starred System Prompt in db",
+          message: err.message,
+        });
+        return false;
+      }),
+    [promptMessage]
+  );
 
   const handleStarredChanged = () => {
     const starredText = new ChatCraftStarredSystemPrompt({ text: promptMessage.text });
     if (!isStarredSystemPrompt) {
       starredText.save().catch((err) => {
-        console.warn("Unable to update system prompt", err);
+        console.warn("Unable to save text to 'starred' table", err);
         error({
-          title: `Error while saving Starred System Prompt to db`,
+          title: "Error while saving Starred System Prompt to db",
           message: err.message,
         });
       });
     } else {
       starredText.remove().catch((err) => {
-        console.warn("Unable to update system prompt", err);
+        console.warn("Unable to remove text from 'starred' table", err);
         error({
-          title: `Error while removing Starred System Prompt from db`,
+          title: "Error while removing Starred System Prompt from db",
           message: err.message,
         });
       });

--- a/src/lib/ChatCraftStarredSystemPrompt.ts
+++ b/src/lib/ChatCraftStarredSystemPrompt.ts
@@ -1,13 +1,13 @@
 import { nanoid } from "nanoid";
-import db, { type ChatCraftStarredTextTable } from "./db";
+import db, { type ChatCraftStarredSystemPromptTable } from "./db";
 
-export type SerializedChatCraftStarredText = {
+export type SerializedChatCraftStarredSystemPrompt = {
   id: string;
   date: string;
   text: string;
 };
 
-export class ChatCraftStarredText {
+export class ChatCraftStarredSystemPrompt {
   id: string;
   date: Date;
   text: string;
@@ -19,7 +19,7 @@ export class ChatCraftStarredText {
   }
 
   clone() {
-    return new ChatCraftStarredText({
+    return new ChatCraftStarredSystemPrompt({
       text: this.text,
     });
   }
@@ -58,40 +58,21 @@ export class ChatCraftStarredText {
       });
   }
 
-  static async check(text: string): Promise<boolean> {
+  static async exists(text: string): Promise<boolean> {
     return db.starred
       .where("text")
       .equalsIgnoreCase(text)
       .count()
       .then((count) => {
-        if (count > 0) {
-          return Promise.resolve(true);
-        }
-        return Promise.resolve(false);
+        return count > 0;
       });
   }
 
-  // static fromJSON(message: SerializedChatCraftStarredText) {
-  //   return new ChatCraftSystemMessage({
-  //     id: message.id,
-  //     date: new Date(message.date),
-  //     text: message.text,
-  //   });
-  // }
-
-  toDB(): ChatCraftStarredTextTable {
+  toDB(): ChatCraftStarredSystemPromptTable {
     return {
       id: this.id,
       date: this.date,
       text: this.text,
     };
   }
-
-  // static fromDB(message: ChatCraftStarredTextTable) {
-  //   return new ChatCraftSystemMessage({
-  //     id: message.id,
-  //     date: message.date,
-  //     text: message.text,
-  //   });
-  // }
 }

--- a/src/lib/ChatCraftStarredText.ts
+++ b/src/lib/ChatCraftStarredText.ts
@@ -1,0 +1,97 @@
+import { nanoid } from "nanoid";
+import db, { type ChatCraftStarredTextTable } from "./db";
+
+export type SerializedChatCraftStarredText = {
+  id: string;
+  date: string;
+  text: string;
+};
+
+export class ChatCraftStarredText {
+  id: string;
+  date: Date;
+  text: string;
+
+  constructor({ id, date, text }: { id?: string; date?: Date; text: string }) {
+    this.id = id ?? nanoid();
+    this.date = date ?? new Date();
+    this.text = text;
+  }
+
+  clone() {
+    return new ChatCraftStarredText({
+      text: this.text,
+    });
+  }
+
+  async save() {
+    const promptText = this.text;
+    return db.starred
+      .where("text")
+      .equalsIgnoreCase(promptText)
+      .count()
+      .then((count) => {
+        if (count == 0) {
+          db.starred.put(this.toDB());
+        } else {
+          console.warn(`${promptText} was already found in DB. Ignoring`);
+        }
+      })
+      .catch((error) => {
+        console.error("Failed to query the systemPrompts table:", error);
+      });
+  }
+
+  async remove() {
+    const promptText = this.text;
+    return db.starred
+      .where("text")
+      .equalsIgnoreCase(promptText)
+      .toArray()
+      .then((entries) => {
+        entries.forEach((entry) => {
+          return db.starred.delete(entry.id);
+        });
+      })
+      .catch((error) => {
+        console.error("Failed to query the systemPrompts table:", error);
+      });
+  }
+
+  static async check(text: string): Promise<boolean> {
+    return db.starred
+      .where("text")
+      .equalsIgnoreCase(text)
+      .count()
+      .then((count) => {
+        if (count > 0) {
+          return Promise.resolve(true);
+        }
+        return Promise.resolve(false);
+      });
+  }
+
+  // static fromJSON(message: SerializedChatCraftStarredText) {
+  //   return new ChatCraftSystemMessage({
+  //     id: message.id,
+  //     date: new Date(message.date),
+  //     text: message.text,
+  //   });
+  // }
+
+  toDB(): ChatCraftStarredTextTable {
+    return {
+      id: this.id,
+      date: this.date,
+      text: this.text,
+    };
+  }
+
+  // static fromDB(message: ChatCraftStarredTextTable) {
+  //   return new ChatCraftSystemMessage({
+  //     id: message.id,
+  //     date: message.date,
+  //     text: message.text,
+  //   });
+  // }
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -41,9 +41,8 @@ export type ChatCraftFunctionTable = {
 };
 
 export type ChatCraftStarredSystemPromptTable = {
-  id: string;
-  date: Date;
   text: string;
+  date: Date;
 };
 
 class ChatCraftDatabase extends Dexie {
@@ -117,7 +116,7 @@ class ChatCraftDatabase extends Dexie {
     this.version(8)
       .stores({
         messages: "id, date, chatId, type, model, user, text, versions, starred",
-        starred: "id, date, text",
+        starred: "text, date",
       })
       .upgrade((tx) => {
         // Select entries from messages where starred is true and type is 'system'
@@ -129,8 +128,8 @@ class ChatCraftDatabase extends Dexie {
             // Prepare the entries for the systemPrompts table by removing the starred attribute
             const promptsEntries = entries
               .filter((entry) => entry.starred === true)
-              .map(({ id, date, text }) => {
-                return { id: id, date: date, text: text };
+              .map(({ text, date }) => {
+                return { text: text, date: date };
               });
             // Add the entries to the systemPrompts table
             return tx.table("starred").bulkAdd(promptsEntries, { allKeys: true });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -40,7 +40,7 @@ export type ChatCraftFunctionTable = {
   code: string;
 };
 
-export type ChatCraftStarredTextTable = {
+export type ChatCraftStarredSystemPromptTable = {
   id: string;
   date: Date;
   text: string;
@@ -51,7 +51,7 @@ class ChatCraftDatabase extends Dexie {
   messages: Table<ChatCraftMessageTable, string>;
   shared: Table<SharedChatCraftChatTable, string>;
   functions: Table<ChatCraftFunctionTable, string>;
-  starred: Table<ChatCraftStarredTextTable, string>;
+  starred: Table<ChatCraftStarredSystemPromptTable, string>;
 
   constructor() {
     super("ChatCraftDatabase");


### PR DESCRIPTION
Overall idea is to move starred system messages to a dedicated table, while keeping other "messages" as they are. Handling "starred" attribute seem difficult in this case. Likely it should become a dynamic check on specific wording being present in "starred" table.