### PR TITLE
logging intercept and more careful eval of es6

### DIFF
--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -84,8 +84,7 @@ function CodeHeader({
       ret = result;
     } catch (error: any) {
       ret = formatAsCodeBlock(
-        error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : `${error}`,
-        "js"
+        error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : `${error}`
       );
     }
     if (ret !== undefined) {

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -59,9 +59,27 @@ function CodeHeader({
 
     let ret = undefined;
     try {
-      let result = await runCode(code, language);
-      if (result !== undefined && typeof result !== "string") {
-        result = formatAsCodeBlock(JSON.stringify(result), "json");
+      let resultWithLogs = await runCode(code, language);
+      let result = resultWithLogs.ret;
+      if (typeof result === "string") {
+        // catch corner cases with strings
+        if (!result.length || result[0] === "/") {
+          result = formatAsCodeBlock(JSON.stringify(result), "js");
+        } else {
+          // result is good to include inline, might have formatting, etc
+        }
+      } else {
+        let maybeJSON = JSON.stringify(result);
+        // catch corner case where JSON.stringify returns undefined but underlying object is truthy, eg a function
+        if (!maybeJSON && result && typeof result.toString === "function") {
+          result = formatAsCodeBlock(result.toString(), "js");
+        } else {
+          result = formatAsCodeBlock(maybeJSON, "json");
+        }
+      }
+      if (resultWithLogs.logs) {
+        resultWithLogs.logs = formatAsCodeBlock(resultWithLogs.logs, "logs");
+        result = resultWithLogs.logs + "\n\n" + result;
       }
       // let js decide how to render the result
       ret = result;

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -59,7 +59,7 @@ function CodeHeader({
 
     let ret = undefined;
     try {
-      let resultWithLogs = await runCode(code, language);
+      const resultWithLogs = await runCode(code, language);
       let result = resultWithLogs.ret;
       if (typeof result === "string") {
         // catch corner cases with strings
@@ -69,7 +69,7 @@ function CodeHeader({
           // result is good to include inline, might have formatting, etc
         }
       } else {
-        let maybeJSON = JSON.stringify(result);
+        const maybeJSON = JSON.stringify(result);
         // catch corner case where JSON.stringify returns undefined but underlying object is truthy, eg a function
         if (!maybeJSON && result && typeof result.toString === "function") {
           result = formatAsCodeBlock(result.toString(), "js");
@@ -81,11 +81,11 @@ function CodeHeader({
         resultWithLogs.logs = formatAsCodeBlock(resultWithLogs.logs, "logs");
         result = resultWithLogs.logs + "\n\n" + result;
       }
-      // let js decide how to render the result
       ret = result;
     } catch (error: any) {
       ret = formatAsCodeBlock(
-        error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : `${error}`
+        error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : `${error}`,
+        "js"
       );
     }
     if (ret !== undefined) {

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -25,35 +25,83 @@ export function isRunnable(language: string) {
   return supportedLanguages.includes(language);
 }
 
+async function captureConsole<T>(
+  callback: () => Promise<T>
+): Promise<{ logs: string | undefined; ret: T }> {
+  // Save the original console methods
+  const originalConsole = {
+    log: console.log,
+    info: console.info,
+    warn: console.warn,
+    error: console.error,
+  };
+
+  // Prepare a string to store the captured messages
+  let capturedMessages: string = "";
+
+  // Function to create an overridden console method
+  const createOverriddenMethod = (method: keyof Console) => {
+    return (...args: any[]) => {
+      capturedMessages += `[${method}] ` + args.map((arg) => String(arg)).join(" ") + "\n";
+      // If you want to still print the messages, uncomment the next line
+      (originalConsole as any)[method].apply(console, args);
+    };
+  };
+
+  // Override console methods
+  console.log = createOverriddenMethod("log");
+  console.info = createOverriddenMethod("info");
+  console.warn = createOverriddenMethod("warn");
+  console.error = createOverriddenMethod("error");
+
+  let returnValue: T;
+  try {
+    // Call the async callback function and capture the return value
+    returnValue = await callback();
+  } finally {
+    // Restore the original console methods
+    console.log = originalConsole.log;
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+  }
+
+  // Return the captured messages as a single string, or undefined if nothing was captured, along with the return value
+  return {
+    logs: capturedMessages.trim() || undefined,
+    ret: returnValue,
+  };
+}
+
 /**
  * Run JavaScript code in eval() context, to support returning values from simple expressions `1+1`
  * and also support `import * as esbuild from 'https://cdn.skypack.dev/esbuild-wasm@0.19.2'` via ES6 modules fallback
  */
 async function runJavaScript(code: string) {
   try {
-    const fn = new Function(`return eval(${JSON.stringify(code)});`);
-    return fn();
+    const generated = `return eval(${JSON.stringify(code)});`;
+    const fn = new Function(generated);
+    return await captureConsole(() => fn());
   } catch (error: any) {
-    const msgLower = error.message.toLowerCase();
-    const maybeES6Module =
-      error instanceof SyntaxError &&
+    let maybeES6Module = false;
+    if (error instanceof SyntaxError) {
+      const msg = error.message;
       // Cannot use import statement outside a module
       // import declarations may only appear at top level of a module
-      msgLower.includes("module") &&
-      msgLower.includes("import");
-    if (maybeES6Module) {
-      // check if code has export.*default regexp
-      if (!/export\s+default\s+/.test(code)) {
-        console.warn(
-          "ChatCraft: Eval'ing code in a module context, must `export default <your val>` at end to return a value"
-        );
-      }
-      const blob = new Blob([code], { type: "text/javascript" });
-      const module = await import(URL.createObjectURL(blob) /* @vite-ignore */);
-      return module.default;
-    } else {
-      throw error;
+      maybeES6Module = msg.includes("module") || msg.includes("import") || msg.includes("export");
     }
+    if (maybeES6Module) {
+      const blob = new Blob([code], { type: "text/javascript" });
+      const execution = await captureConsole(
+        async () => await import(URL.createObjectURL(blob) /* @vite-ignore */)
+      );
+      const module = execution.ret;
+      if (!("default" in module)) {
+        throw new Error("No default export in ES6 module");
+      }
+      return { ...execution, ret: module.default };
+    }
+    throw error;
   }
 }
 


### PR DESCRIPTION
this fixes one of the problems i had in #294.

- better fallback to ES6
- better code for checking missing export default
- handles weird edge case of objects that are not serializable into JSON, yet toString()able like functions
- lack of log intercept bothered me a lot now:

<img width="612" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/857083/5b3a545b-1e5e-456f-b671-c3c94bd72537">
