### PR TITLE
Fix regression in ChatCraftMessage: Maximum call stack size exceeded

### DIFF
--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -400,6 +400,15 @@ export class ChatCraftSystemMessage extends ChatCraftMessage {
     super({ id, date, type: "system", text, readonly });
   }
 
+  static fromJSON(message: SerializedChatCraftMessage) {
+    return new ChatCraftSystemMessage({
+      id: message.id,
+      date: new Date(message.date),
+      text: message.text,
+      readonly: true,
+    });
+  }
+
   static fromDB(message: ChatCraftMessageTable) {
     return new ChatCraftSystemMessage({
       id: message.id,


### PR DESCRIPTION
Prod is crashing for me after we landed #290:

<img width="714" alt="Screenshot 2023-11-19 at 5 10 49 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/234a299e-bbda-445b-9a72-78e8dc1140cf">

This is due to the `ChatCraftSystemMessage` type no longer having a `fromJSON` override, so it calls back into the base `fromJSON` recursively forever until it exhausts the stack space.

This adds the override.

cc @kosty