### PR TITLE
Opening sidebar should not displace main content

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -359,7 +359,7 @@ function ChatBase({ chat }: ChatBaseProps) {
           transformOrigin={"left"}
           animation={`${
             isSidebarVisible ? sidebarOpenAnimation : sidebarClosedAnimation
-          } 200ms ease-in-out forwards`}
+          } 150ms ease-out forwards`}
         >
           <Sidebar selectedChat={chat} />
         </Box>

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -33,6 +33,7 @@ import { useAutoScroll } from "../hooks/use-autoscroll";
 import { useAlert } from "../hooks/use-alert";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import { ChatCraftCommand } from "../lib/ChatCraftCommand";
+import theme from "../theme";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -353,7 +354,7 @@ function ChatBase({ chat }: ChatBaseProps) {
           width={"20vw"}
           bgGradient="linear(to-b, white, gray.100)"
           _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
-          zIndex={99999}
+          zIndex={theme.zIndices.modal}
           overflowY="auto"
           height={"100%"}
           maxHeight={"100%"}
@@ -364,11 +365,11 @@ function ChatBase({ chat }: ChatBaseProps) {
             isSidebarVisible // If visible, trigger open animation
               ? sidebarOpenAnimation
               : // Only trigger closed animation when closed manually.
-              // This is because the sidebar open/close state is persisted across refreshes
-              // and may cause unnecessary animations if not handled
-              sidebarTouched
-              ? sidebarClosedAnimation
-              : "none"
+                // This is because the sidebar open/close state is persisted across refreshes
+                // and may cause unnecessary animations if not handled
+                sidebarTouched
+                ? sidebarClosedAnimation
+                : "none"
           } 150ms ease-out forwards`}
         >
           <Sidebar selectedChat={chat} />

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -1,5 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box, Button, Flex, Text, useDisclosure, Grid, GridItem } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Flex,
+  Text,
+  useDisclosure,
+  Grid,
+  GridItem,
+  keyframes,
+} from "@chakra-ui/react";
 import { ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
 
@@ -294,16 +303,34 @@ function ChatBase({ chat }: ChatBaseProps) {
     resume();
   }
 
+  // Sidebar Animations
+  const sidebarOpenAnimation = keyframes`
+  0% {
+    transform: scaleX(0);
+  }
+  50% {
+    transform: scaleX(1.075);
+  }
+  100% {
+    transform: scaleX(1);
+  }
+`;
+
+  const sidebarClosedAnimation = keyframes`
+  from {
+    transform: scaleX(1);
+  }
+  to {
+    transform: scaleX(0);
+  }
+  `;
+
   return (
     <Grid
       w="100%"
       h="100%"
       gridTemplateRows="min-content 1fr min-content"
-      gridTemplateColumns={{
-        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
-      }}
+      gridTemplateColumns={"0 1fr"}
       bgGradient="linear(to-b, white, gray.100)"
       _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
     >
@@ -315,8 +342,27 @@ function ChatBase({ chat }: ChatBaseProps) {
         />
       </GridItem>
 
-      <GridItem rowSpan={2} overflowY="auto">
-        <Sidebar selectedChat={chat} />
+      <GridItem rowSpan={2} colSpan={1}>
+        <Box
+          position="relative"
+          width={{
+            base: "300px",
+            lg: "20vw",
+          }}
+          bgGradient="linear(to-b, white, gray.100)"
+          _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
+          zIndex={99999}
+          overflowY="auto"
+          height={"100%"}
+          maxHeight={"100%"}
+          boxShadow={"base"}
+          transformOrigin={"left"}
+          animation={`${
+            isSidebarVisible ? sidebarOpenAnimation : sidebarClosedAnimation
+          } 200ms ease-in-out forwards`}
+        >
+          <Sidebar selectedChat={chat} />
+        </Box>
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -70,6 +70,8 @@ function ChatBase({ chat }: ChatBaseProps) {
     const newValue = !isSidebarVisible;
     toggleSidebarVisible();
     setSettings({ ...settings, sidebarVisible: newValue });
+
+    setSidebarTouched(true);
   }, [isSidebarVisible, settings, setSettings, toggleSidebarVisible]);
 
   // Scroll chat to bottom (or to bottom of element specified by scrollBottomRef),
@@ -325,6 +327,8 @@ function ChatBase({ chat }: ChatBaseProps) {
   }
   `;
 
+  const [sidebarTouched, setSidebarTouched] = useState<boolean>(false);
+
   return (
     <Grid
       w="100%"
@@ -345,10 +349,8 @@ function ChatBase({ chat }: ChatBaseProps) {
       <GridItem rowSpan={2} colSpan={1}>
         <Box
           position="relative"
-          width={{
-            base: "300px",
-            lg: "20vw",
-          }}
+          minWidth={"300px"}
+          width={"20vw"}
           bgGradient="linear(to-b, white, gray.100)"
           _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
           zIndex={99999}
@@ -357,8 +359,16 @@ function ChatBase({ chat }: ChatBaseProps) {
           maxHeight={"100%"}
           boxShadow={"base"}
           transformOrigin={"left"}
+          transform={`translateX(${isSidebarVisible ? 0 : "-100%"})`}
           animation={`${
-            isSidebarVisible ? sidebarOpenAnimation : sidebarClosedAnimation
+            isSidebarVisible // If visible, trigger open animation
+              ? sidebarOpenAnimation
+              : // Only trigger closed animation when closed manually.
+              // This is because the sidebar open/close state is persisted across refreshes
+              // and may cause unnecessary animations if not handled
+              sidebarTouched
+              ? sidebarClosedAnimation
+              : "none"
           } 150ms ease-out forwards`}
         >
           <Sidebar selectedChat={chat} />

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -34,6 +34,7 @@ import { useAlert } from "../hooks/use-alert";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import { ChatCraftCommand } from "../lib/ChatCraftCommand";
 import theme from "../theme";
+import useDesktopBreakpoint from "../hooks/use-desktop-breakpoint";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -330,6 +331,8 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   const [sidebarTouched, setSidebarTouched] = useState<boolean>(false);
 
+  const isDesktop = useDesktopBreakpoint();
+
   return (
     <Grid
       w="100%"
@@ -362,7 +365,7 @@ function ChatBase({ chat }: ChatBaseProps) {
           transformOrigin={"left"}
           transform={`translateX(${isSidebarVisible ? 0 : "-100%"})`}
           animation={`${
-            isSidebarVisible // If visible, trigger open animation
+            isSidebarVisible || (settings.sidebarPinned && isDesktop) // If visible or pinned, open the sidebar
               ? sidebarOpenAnimation
               : // Only trigger closed animation when closed manually.
                 // This is because the sidebar open/close state is persisted across refreshes

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   ButtonGroup,
   Flex,
+  Icon,
   IconButton,
   Input,
   InputGroup,
@@ -26,6 +27,9 @@ import { Form } from "react-router-dom";
 import PreferencesModal from "./PreferencesModal";
 import DefaultSystemPromptModal from "./DefaultSystemPromptModal";
 import { useUser } from "../hooks/use-user";
+import { useSettings } from "../hooks/use-settings";
+import { MdOutlinePinDrop, MdPinDrop } from "react-icons/md";
+import useDesktopBreakpoint from "../hooks/use-desktop-breakpoint";
 
 type HeaderProps = {
   chatId?: string;
@@ -56,6 +60,17 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
     }
   }, [chatId, user, login, logout]);
 
+  const { settings, setSettings } = useSettings();
+
+  const togglePinnedSidebar = () => {
+    setSettings({
+      ...settings,
+      sidebarPinned: !settings.sidebarPinned,
+    });
+  };
+
+  const isDesktop = useDesktopBreakpoint();
+
   return (
     <Flex
       w="100%"
@@ -67,15 +82,21 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       borderColor={useColorModeValue("gray.50", "gray.600")}
     >
       <Flex pl={1} align="center" gap={2}>
-        <IconButton
-          icon={<BiMenu />}
-          variant="ghost"
-          aria-label="Toggle Sidebar Menu"
-          title="Toggle Sidebar Menu"
-          onClick={onToggleSidebar}
-        />
+        {(!settings.sidebarPinned || !isDesktop) && (
+          <IconButton
+            icon={<BiMenu />}
+            variant="ghost"
+            aria-label="Toggle Sidebar Menu"
+            title="Toggle Sidebar Menu"
+            onClick={onToggleSidebar}
+          />
+        )}
 
-        <Text fontWeight="bold" color={useColorModeValue("blue.600", "blue.200")}>
+        <Text
+          fontWeight="bold"
+          color={useColorModeValue("blue.600", "blue.200")}
+          marginInlineStart={settings.sidebarPinned && isDesktop ? 2 : 0}
+        >
           <Link
             href="/"
             _hover={{ textDecoration: "none", color: useColorModeValue("blue.400", "blue.100") }}
@@ -95,6 +116,22 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       </Box>
 
       <ButtonGroup isAttached pr={2} alignItems="center">
+        {isDesktop && (
+          <IconButton
+            aria-label={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
+            title={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
+            icon={
+              settings.sidebarPinned ? (
+                <Icon boxSize={5} as={MdPinDrop} />
+              ) : (
+                <Icon boxSize={5} as={MdOutlinePinDrop} />
+              )
+            }
+            variant={"ghost"}
+            onClick={togglePinnedSidebar}
+          />
+        )}
+
         <IconButton
           aria-label={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           title={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,11 @@ import {
   useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
-import { BiSun, BiMoon, BiMenu } from "react-icons/bi";
+import { BiSun, BiMoon } from "react-icons/bi";
+import {
+  TbLayoutSidebarRightCollapseFilled,
+  TbLayoutSidebarRightExpandFilled,
+} from "react-icons/tb";
 import { BsGithub } from "react-icons/bs";
 import { TbSearch } from "react-icons/tb";
 import { Form } from "react-router-dom";
@@ -28,7 +32,6 @@ import PreferencesModal from "./PreferencesModal";
 import DefaultSystemPromptModal from "./DefaultSystemPromptModal";
 import { useUser } from "../hooks/use-user";
 import { useSettings } from "../hooks/use-settings";
-import { MdOutlinePinDrop, MdPinDrop } from "react-icons/md";
 import useDesktopBreakpoint from "../hooks/use-desktop-breakpoint";
 
 type HeaderProps = {
@@ -60,14 +63,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
     }
   }, [chatId, user, login, logout]);
 
-  const { settings, setSettings } = useSettings();
-
-  const togglePinnedSidebar = () => {
-    setSettings({
-      ...settings,
-      sidebarPinned: !settings.sidebarPinned,
-    });
-  };
+  const { settings } = useSettings();
 
   const isDesktop = useDesktopBreakpoint();
 
@@ -84,7 +80,13 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       <Flex pl={1} align="center" gap={2}>
         {(!settings.sidebarPinned || !isDesktop) && (
           <IconButton
-            icon={<BiMenu />}
+            icon={
+              settings.sidebarVisible ? (
+                <Icon boxSize={6} as={TbLayoutSidebarRightExpandFilled} />
+              ) : (
+                <Icon boxSize={6} as={TbLayoutSidebarRightCollapseFilled} />
+              )
+            }
             variant="ghost"
             aria-label="Toggle Sidebar Menu"
             title="Toggle Sidebar Menu"
@@ -116,22 +118,6 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       </Box>
 
       <ButtonGroup isAttached pr={2} alignItems="center">
-        {isDesktop && (
-          <IconButton
-            aria-label={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
-            title={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
-            icon={
-              settings.sidebarPinned ? (
-                <Icon boxSize={5} as={MdPinDrop} />
-              ) : (
-                <Icon boxSize={5} as={MdOutlinePinDrop} />
-              )
-            }
-            variant={"ghost"}
-            onClick={togglePinnedSidebar}
-          />
-        )}
-
         <IconButton
           aria-label={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           title={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,9 +17,11 @@ import {
   AccordionButton,
   AccordionIcon,
   AccordionPanel,
+  Icon,
+  Tooltip,
 } from "@chakra-ui/react";
 import { useLiveQuery } from "dexie-react-hooks";
-import { MdOutlineChatBubbleOutline } from "react-icons/md";
+import { MdOutlineChatBubbleOutline, MdOutlinePinDrop, MdPinDrop } from "react-icons/md";
 import { TbCheck, TbTrash } from "react-icons/tb";
 import { CgClose } from "react-icons/cg";
 import { AiOutlineEdit } from "react-icons/ai";
@@ -34,6 +36,8 @@ import { SharedChatCraftChat } from "../lib/SharedChatCraftChat";
 import { useUser } from "../hooks/use-user";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
 import { useAlert } from "../hooks/use-alert";
+import { useSettings } from "../hooks/use-settings";
+import useDesktopBreakpoint from "../hooks/use-desktop-breakpoint";
 
 /**
  * Chat Sidebar Items
@@ -357,9 +361,44 @@ function Sidebar({ selectedChat, selectedFunction }: SidebarProps) {
       .catch((err) => console.warn("Unable to delete shared chat", err));
   }
 
+  const { settings, setSettings } = useSettings();
+
+  const togglePinnedSidebar = () => {
+    setSettings({
+      ...settings,
+      sidebarPinned: !settings.sidebarPinned,
+    });
+  };
+
+  const isDesktop = useDesktopBreakpoint();
+
   return (
     <Flex direction="column" h="100%" p={2} gap={4}>
       <Accordion allowToggle>
+        <AccordionItem>
+          <Flex justifyContent={"flex-end"}>
+            {isDesktop && (
+              <Tooltip
+                label={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
+                fontSize="md"
+              >
+                <IconButton
+                  aria-label={settings.sidebarPinned ? "Unpin Sidebar" : "Pin Sidebar"}
+                  icon={
+                    settings.sidebarPinned ? (
+                      <Icon boxSize={5} as={MdPinDrop} />
+                    ) : (
+                      <Icon boxSize={5} as={MdOutlinePinDrop} />
+                    )
+                  }
+                  variant={"ghost"}
+                  onClick={togglePinnedSidebar}
+                />
+              </Tooltip>
+            )}
+          </Flex>
+        </AccordionItem>
+
         <AccordionItem>
           <AccordionButton p={0} minH={10}>
             <Heading as="h3" size="xs">

--- a/src/hooks/use-desktop-breakpoint.ts
+++ b/src/hooks/use-desktop-breakpoint.ts
@@ -1,6 +1,6 @@
 import { useMediaQuery } from "@chakra-ui/react";
 
-// Use 480 as our upper limit for the "mobile" experience.
+// Use 1496 as lower limit for the "desktop" experience.
 const desktopMediaQuery = "(min-width: 1496px)";
 
 export default function useDesktopBreakpoint() {

--- a/src/hooks/use-desktop-breakpoint.ts
+++ b/src/hooks/use-desktop-breakpoint.ts
@@ -1,0 +1,10 @@
+import { useMediaQuery } from "@chakra-ui/react";
+
+// Use 480 as our upper limit for the "mobile" experience.
+const desktopMediaQuery = "(min-width: 1496px)";
+
+export default function useDesktopBreakpoint() {
+  const [isDesktop] = useMediaQuery(desktopMediaQuery);
+
+  return isDesktop;
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -30,6 +30,7 @@ export type Settings = {
   customSystemPrompt?: string;
   announceMessages?: boolean;
   providers: ProviderData;
+  sidebarPinned: boolean;
 };
 
 export const defaults: Settings = {
@@ -44,6 +45,8 @@ export const defaults: Settings = {
   alwaysSendFunctionResult: false,
   announceMessages: false,
   providers: {},
+  // Do not pin by default
+  sidebarPinned: false,
 };
 
 export const key = "settings";


### PR DESCRIPTION
@humphd

I spent a while to figure out a solution that requires least amount of changes to the existing structure.

I have made the following changes:
1. Grid Columns do not change their width on **toggling** sidebar.
2. The sidebar is wrapped inside a **Box** element provided by **Chakra**, that opens **over** the main content instead of **pushing** it away, or **squishing it** in case of a mobile screen.
3. The width of sidebar is almost similar to how it was initially across various **screen widths**.
4. The sidebar now has a **custom animation** when opened and closed (enhancing user experience).
5. Nothing else was changed in the original layout.

Please let me know if any changes are required.

Fixes #299 
