### PR TITLE
nuke "Just show me the code"

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -31,7 +31,6 @@ We think ChatCraft is the best platform for learning, experimenting, and getting
 | Edit Generated AI Replies             | ✅        | ❌      | ✅      |
 | Use Custom System Prompts             | ✅        | ✅      | ❌      |
 | Easy to retry with different AI models| ✅        | ❌      | ❌      |
-| Just Show Me The Code                 | ✅        | ❌      | ✅      |
 | Edit/Run Generated Code and Custom Functions | ✅        | ❌      | ✅      |
 | Open Source                           | ✅        | ❌      | ❌      |
 

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -345,19 +345,6 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                 Track and Display Token Count and Cost
               </Checkbox>
             </FormControl>
-
-            <FormControl>
-              <Checkbox
-                isChecked={settings.justShowMeTheCode}
-                onChange={(e) => setSettings({ ...settings, justShowMeTheCode: e.target.checked })}
-              >
-                Just show me the code, don&apos;t explain anything
-              </Checkbox>
-              <FormHelperText>
-                NOTE: this change will alter the default system prompt and be used for new chats you
-                create (i.e., it won&apos;t affect the current chat)
-              </FormHelperText>
-            </FormControl>
           </VStack>
         </ModalBody>
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -19,7 +19,6 @@ export type Settings = {
   apiUrl: string;
   temperature: number;
   enterBehaviour: EnterBehaviour;
-  justShowMeTheCode: boolean;
   countTokens: boolean;
   sidebarVisible: boolean;
   alwaysSendFunctionResult: boolean;
@@ -33,7 +32,6 @@ export const defaults: Settings = {
   enterBehaviour: "send",
   // Disabled by default, since token parsing requires downloading larger deps
   countTokens: false,
-  justShowMeTheCode: false,
   sidebarVisible: false,
   // Disabled by default, so we don't waste tokens
   alwaysSendFunctionResult: false,

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -12,16 +12,10 @@ I follow these rules when responding:
 - If using functions, only use the specific functions I have been provided with
 `;
 
-const justShowMeTheCodeText =
-  "- When responding with code, ONLY return the code and NOTHING else (i.e., don't explain ANYTHING)";
-
 export const defaultSystemPrompt = () => {
-  const { justShowMeTheCode, customSystemPrompt } = getSettings();
+  const { customSystemPrompt } = getSettings();
 
-  let systemPrompt = customSystemPrompt ?? defaultSystemPromptText;
-  if (justShowMeTheCode) {
-    systemPrompt += justShowMeTheCodeText;
-  }
+  const systemPrompt = customSystemPrompt ?? defaultSystemPromptText;
   return systemPrompt;
 };
 


### PR DESCRIPTION
Proper way to do this is to edit prompt. We didn't have that before.

This feature resulted in me having 100s of saved prompts with multiple copies of just show me the code