### PR TITLE
Added validation for OpenRouter API key

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -14,7 +14,7 @@ import MessageBase, { type MessageBaseProps } from "../MessageBase";
 import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
 import RevealablePasswordInput from "../../RevealablePasswordInput";
 import { useSettings } from "../../../hooks/use-settings";
-import { openRouterPkceRedirect, validateOpenAiApiKey } from "../../../lib/ai";
+import { openRouterPkceRedirect, validateApiKey } from "../../../lib/ai";
 import { OPENAI_API_URL, OPENROUTER_API_URL } from "../../../lib/settings";
 
 const ApiKeyInstructionsText = `## Getting Started with ChatCraft
@@ -68,7 +68,7 @@ function Instructions(props: MessageBaseProps) {
 
     // See if this API Key is valid
     setIsValidating(true);
-    validateOpenAiApiKey(apiKey)
+    validateApiKey(apiKey)
       .then((valid) => {
         if (valid) {
           setIsInvalid(false);

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -37,7 +37,7 @@ import db from "../lib/db";
 import { useModels } from "../hooks/use-models";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { OPENAI_API_URL, OPENROUTER_API_URL } from "../lib/settings";
-import { openRouterPkceRedirect, validateOpenAiApiKey } from "../lib/ai";
+import { openRouterPkceRedirect, validateApiKey } from "../lib/ai";
 import { useAlert } from "../hooks/use-alert";
 
 // https://dexie.org/docs/StorageManager
@@ -73,7 +73,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
       if (!apiKey) {
         setIsApiKeyInvalid(true);
       } else {
-        validateOpenAiApiKey(apiKey)
+        validateApiKey(apiKey)
           .then((result: boolean) => setIsApiKeyInvalid(!result))
           .catch((err) => {
             console.warn("Error validating API key", err);
@@ -164,7 +164,9 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               <FormLabel>API URL</FormLabel>
               <Select
                 value={settings.apiUrl}
-                onChange={(e) => setSettings({ ...settings, apiUrl: e.target.value })}
+                onChange={(e) =>
+                  setSettings({ ...settings, apiUrl: e.target.value, apiKey: undefined })
+                }
               >
                 <option value={OPENAI_API_URL}>OpenAI ({OPENAI_API_URL})</option>
                 <option value={OPENROUTER_API_URL}>OpenRouter.ai ({OPENROUTER_API_URL})</option>

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -387,20 +387,20 @@ export async function validateOpenRouterApiKey(apiKey: string) {
     throw new Error(`${res.status} ${await res.text()}`);
   }
 
-  return res;
+  return true;
 }
 
 export async function validateApiKey(apiKey: string) {
-  const usingOpenAI = usingOfficialOpenAI();
-  const usingOpenRouter = usingOfficialOpenRouter();
-
-  if (usingOpenAI) {
+  if (usingOfficialOpenAI()) {
     return validateOpenAiApiKey(apiKey);
-  } else if (usingOpenRouter) {
-    return !!(await validateOpenRouterApiKey(apiKey));
-  } else {
-    return false;
   }
+
+  if (usingOfficialOpenRouter()) {
+    return validateOpenRouterApiKey(apiKey);
+  }
+
+  // If not either of those providers, something is wrong
+  throw new Error("unexpected provider, not able to validate api key");
 }
 
 // Cache this instance on first use

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -357,8 +357,23 @@ export async function queryModels(apiKey: string) {
 
   try {
     const models = [];
-    for await (const page of openai.models.list()) {
-      models.push(page);
+
+    if (usingOpenAI) {
+      for await (const page of openai.models.list()) {
+        models.push(page);
+      }
+    } else {
+      // Use response from https://openrouter.ai/docs#limits to check if API key is valid
+      const res = await fetch(`https://openrouter.ai/api/v1/auth/key`, {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+        },
+      });
+
+      if (!res.ok) {
+        throw new Error(`${res.status} ${await res.text()}`);
+      }
     }
 
     return models


### PR DESCRIPTION
Closes #230 

Added validation for OpenRouter API key

**Current code (before PR):**
- No validation for OpenRouter API key

**PR Code changes:**
- In `src/lib/ai.ts`, created new function `validateApiKey()` which validates both OpenAI and OpenRouter keys, by calling `validateOpenAiApiKey()` or `validateOpenRouterApiKey()`
- In `src/lib/ai.ts`, create new function `validateOpenRouterApiKey()`, which uses response from https://openrouter.ai/docs#limits to check if OpenRouter API key is valid
- In `src/components/Message/AppMessage/Instructions.tsx`, replaced call of `validateOpenAiApiKey()` with `validateApiKey()`
- In `src/components/PreferencesModal.tsx`, replaced call of `validateOpenAiApiKey()` with `validateApiKey()`

**Testing:**

Invalid OpenRouter API key:

![invalidOpenRouter1](https://github.com/tarasglek/chatcraft.org/assets/98062538/07205159-5865-41e7-846d-8b9991cb54a6)

![invalidOpenRouter2](https://github.com/tarasglek/chatcraft.org/assets/98062538/ba2102de-9353-40ca-8af3-92ca65fe0c4a)

![invalidOpenRouter3](https://github.com/tarasglek/chatcraft.org/assets/98062538/0bd3f8dc-06fd-40dc-bb88-d8b2472503f0)

Valid OpenRouter API key:

![validOpenRouter](https://github.com/tarasglek/chatcraft.org/assets/98062538/a020557a-641f-4387-a441-a990ca5ca9dc)

**Regression Testing:**

Invalid OpenAI API key:

![invalidOpenAI1](https://github.com/tarasglek/chatcraft.org/assets/98062538/54fbbe53-53b6-4bed-979d-280d8b5dcfc5)

![invalidOpenAI2](https://github.com/tarasglek/chatcraft.org/assets/98062538/c83f6dd3-f3e8-41d8-a32b-1b3c74c00a54)

![invalidOpenAI3](https://github.com/tarasglek/chatcraft.org/assets/98062538/a60a0841-f69f-4426-8549-ffd97b44ea68)

Valid OpenAI API key:

![validOpenAI](https://github.com/tarasglek/chatcraft.org/assets/98062538/61a6dddd-04ea-4c3c-8680-960b5468c7a7)