### PR TITLE
Clear stored api key when changing providers in user settings

### DIFF
--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -164,7 +164,9 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               <FormLabel>API URL</FormLabel>
               <Select
                 value={settings.apiUrl}
-                onChange={(e) => setSettings({ ...settings, apiUrl: e.target.value })}
+                onChange={(e) =>
+                  setSettings({ ...settings, apiUrl: e.target.value, apiKey: undefined })
+                }
               >
                 <option value={OPENAI_API_URL}>OpenAI ({OPENAI_API_URL})</option>
                 <option value={OPENROUTER_API_URL}>OpenRouter.ai ({OPENROUTER_API_URL})</option>


### PR DESCRIPTION
Closes #307

User Settings -> Change provider using API URL dropdown -> Clears the stored API key

**Current code (before PR):**
- In `src/components/PreferencesModal.tsx`, change event handler for the API URL dropdown does not clear the stored API key, thereby sending the old stored key to the newly selected provider

**PR Code changes:**
- In `src/components/PreferencesModal.tsx`, change event handler for the API URL dropdown clears the stored API key (just like the Remove button does)
- The resulting behaviour is the same as the Remove Button (the only difference is the provider is changed to the one we selected)

**Testing:**

Changing from OpenRouter -> OpenAI

![test1](https://github.com/tarasglek/chatcraft.org/assets/98062538/25f84801-55d8-439b-b22d-e74176ac992f)
![test2](https://github.com/tarasglek/chatcraft.org/assets/98062538/08902cc0-6198-4a77-a580-1c0cb04d2c0c)
![test3](https://github.com/tarasglek/chatcraft.org/assets/98062538/149bb84f-ea92-44a8-be62-3e9d4c26d60c)

Changing from OpenAI -> OpenRouter

![test3](https://github.com/tarasglek/chatcraft.org/assets/98062538/8e04d73d-54c6-49db-b9f3-f435c06a6bdc)
![test4](https://github.com/tarasglek/chatcraft.org/assets/98062538/0ccc6710-6521-46e9-a870-fa45e74b1774)