### PR TITLE
Update README.sops.md with user instructions for encrypted key

### DIFF
--- a/README.sops.md
+++ b/README.sops.md
@@ -52,6 +52,14 @@ export SOPS_AGE_KEY=scripts/sops_age_key.sh
 sops -d sops/keys.enc.yaml
 ```
 
+If you are using an encrypted key, you will have to first export the password in `SSH_TO_AGE_PASSPHRASE` and then export the AGE key in `SOPS_AGE_KEY`:
+```bash
+read -s SSH_TO_AGE_PASSPHRASE; export SSH_TO_AGE_PASSPHRASE
+# Type passphrase then press [Enter]
+export SOPS_AGE_KEY=$(ssh-to-age -private-key < ~/.ssh/id_ed25519)
+sops -d sops/keys.enc.yaml
+```
+
 ### Holes
 
 To paraphrase sops docs: note that, while sops user list is in cleartext, unencrypted content is still added to the checksum of the file, and thus cannot be modified outside of SOPS without breaking the file integrity check.


### PR DESCRIPTION
Summary
---
Based on discussion in https://github.com/tarasglek/chatcraft.org/pull/329#issuecomment-1890483618 , added instructions in README.sops.md for users decrypting secrets using an encrypted key.