### PR TITLE
Add .editorconfig and .gitattributes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,8 @@
 # top-most EditorConfig file
 root = true
 
-# For all TS under src directory
-[src/**.tsx]
+# For all the files
+[*]
 end_of_line = lf
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# For all TS under src directory
+[src/**.tsx]
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.yaml diff=sopsdiffer
+* text=auto eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -13,9 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "editorconfig.editorconfig",
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "streetsidesoftware.code-spell-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
+  "editor.detectIndentation": false,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  },
+  "files.eol": "\n",
+  "files.insertFinalNewline": true
+}


### PR DESCRIPTION
To ensure that all contributors to the project use a **consistent** line ending convention, I have added a [.editorconfig](https://editorconfig.org/#overview) file with the following options.

**1.** end_of_line = lf
**2.** trim_trailing_whitespace = true
**3.** insert_final_newline = true

A list of all options can be found at https://github.com/editorconfig/editorconfig/wiki/EditorConfig-Properties

I've also added [.gitattributes](https://git-scm.com/docs/gitattributes) file, so that git does not use **Windows Line Endings** (\r\n) when checking out files.

This fixes #341 