### PR TITLE
Fix and add back the first sops decryption method

### DIFF
--- a/sops/README.sops.md
+++ b/sops/README.sops.md
@@ -9,7 +9,7 @@ export SOPS_AGE_KEY=$(bash ./scripts/sops_age_key.sh)
 sops -d sops/keys.enc.yaml
 ```
 
-**Note:** Instead of storing the private age key in the environment variable, it is recommended to store the secrets in a `keys.txt` file as documented at
+**Note:** Alternatively, to not mess with the environment variables, you can also store the secrets in a `keys.txt` file as documented at
 https://github.com/getsops/sops/blob/0bceaf42b834f254cf2c6a6f61e7121de8eb9c52/README.rst#L205C1-L212C22
 
 **2.** Using [ssh-to-age](https://github.com/Mic92/ssh-to-age) tool

--- a/sops/README.sops.md
+++ b/sops/README.sops.md
@@ -1,10 +1,18 @@
 ### Decryption
 
+There are 2 ways this can be done.
+
+**1.** Using the [Project Script](../scripts/sops_age_key.sh)
+
 ```bash
 export SOPS_AGE_KEY=$(bash ./scripts/sops_age_key.sh)
-
 sops -d sops/keys.enc.yaml
 ```
+
+**Note:** Instead of storing the private age key in the environment variable, it is recommended to store the secrets in a `keys.txt` file as documented at
+https://github.com/getsops/sops/blob/0bceaf42b834f254cf2c6a6f61e7121de8eb9c52/README.rst#L205C1-L212C22
+
+**2.** Using [ssh-to-age](https://github.com/Mic92/ssh-to-age) tool
 
 ```bash
 export SOPS_AGE_KEY=$(ssh-to-age -private-key < ~/.ssh/id_ed25519)

--- a/sops/README.sops.md
+++ b/sops/README.sops.md
@@ -1,6 +1,12 @@
 ### Decryption
 
 ```bash
+export SOPS_AGE_KEY=$(bash ./scripts/sops_age_key.sh)
+
+sops -d sops/keys.enc.yaml
+```
+
+```bash
 export SOPS_AGE_KEY=$(ssh-to-age -private-key < ~/.ssh/id_ed25519)
 sops -i keys.enc.yaml
 ```


### PR DESCRIPTION
This PR adds the fix for the first decryption method that was removed from [README.sops.md](https://github.com/tarasglek/chatcraft.org/blob/main/sops/README.sops.md) file.

We now make sure that the script is executed, and its **result** is stored in the `SOPS_AGE_KEY` environment variable.

```bash
export SOPS_AGE_KEY=$(bash ./scripts/sops_age_key.sh)
```

Instead of

```bash
export SOPS_AGE_KEY=./scripts/sops_age_key.sh
```
This fixes #350 

