### PR TITLE
Fix math render conflict with coding 

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -61,7 +61,7 @@ function Markdown({ previewCode, isLoading, onPrompt, children }: MarkdownProps)
     <ReactMarkdown
       className="message-text"
       children={children}
-      remarkPlugins={[remarkGfm, remarkMath]}
+      remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],


### PR DESCRIPTION
Fix https://github.com/tarasglek/chatcraft.org/pull/349#issuecomment-1901090635

Now we can use $ as normal:
![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/bfea0458-f6a6-4c89-922d-b75147bcaec8)

[link](https://mingming-equation-strict.console-overthinker-dev.pages.dev/c/chatcraft_dev/2GkxXdOTBG0Soha-IYGsr)