### PR TITLE
Add Text to Speech Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash-es": "^4.17.21",
     "mermaid": "^10.5.1",
     "nanoid": "^5.0.2",
-    "openai": "^4.12.4",
+    "openai": "^4.24.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^4.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ dependencies:
     specifier: ^5.0.2
     version: 5.0.2
   openai:
-    specifier: ^4.12.4
-    version: 4.12.4
+    specifier: ^4.24.7
+    version: 4.24.7
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -3735,7 +3735,7 @@ packages:
   /@types/node-fetch@2.6.7:
     resolution: {integrity: sha512-lX17GZVpJ/fuCjguZ5b3TjEbSENxmEk1B2z02yoXSK9WMEWRivhdSY73wWMn6bpcCDAOh6qAdktpKHIlkDk2lg==}
     dependencies:
-      '@types/node': 18.18.6
+      '@types/node': 20.8.7
       form-data: 4.0.0
     dev: false
 
@@ -3747,7 +3747,6 @@ packages:
     resolution: {integrity: sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==}
     dependencies:
       undici-types: 5.25.3
-    dev: true
 
   /@types/parse-json@4.0.1:
     resolution: {integrity: sha512-3YmXzzPAdOTVljVMkTMBdBEvlOLg2cDQaDhnnhT3nT9uDbnJzjWhKlzb+desT12Y7tGqaN6d+AbozcKzyL36Ng==}
@@ -8337,8 +8336,8 @@ packages:
       is-wsl: 2.2.0
     dev: true
 
-  /openai@4.12.4:
-    resolution: {integrity: sha512-oPNVJkpgxDUKF6WGGdHEZh5m/kjmYxS2Y1q7YVFCkvKUGthb8OGYRGCFBRPq5CQJezifzABTZRlVYnXLd6L4vQ==}
+  /openai@4.24.7:
+    resolution: {integrity: sha512-JUesECWPtsDHO0TlZGb6q73hnAmXUdzj9NrwgZeL4lqlRt/kR1sWrXoy8LocxN/6uOtitywvcJqe0O1PLkG45g==}
     hasBin: true
     dependencies:
       '@types/node': 18.18.6
@@ -9870,7 +9869,6 @@ packages:
 
   /undici-types@5.25.3:
     resolution: {integrity: sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA==}
-    dev: true
 
   /undici@5.20.0:
     resolution: {integrity: sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -38,12 +38,16 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbSend />}
         />
         {isTtsSupported() && (
-          <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
+          <Tooltip
+            label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
+          >
             <IconButton
               type="button"
               size="lg"
               variant="solid"
-              aria-label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}
+              aria-label={
+                settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"
+              }
               icon={settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
               onClick={() =>
                 setSettings({ ...settings, announceMessages: !settings.announceMessages })
@@ -82,7 +86,9 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
         Ask {settings.model.prettyModel}
       </Button>
       {isTtsSupported() && (
-        <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
+        <Tooltip
+          label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
+        >
           <Button
             type="button"
             size="sm"

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -6,6 +6,7 @@ import {
   MenuButton,
   MenuList,
   MenuItem,
+  Tooltip,
 } from "@chakra-ui/react";
 import { TbChevronUp, TbSend } from "react-icons/tb";
 
@@ -13,6 +14,7 @@ import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
+import { AiFillSound, AiOutlineSound } from "react-icons/ai";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -64,6 +66,15 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
+      <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
+        <Button
+          type="button"
+          size="sm"
+          onClick={() => setSettings({ ...settings, announceMessages: !settings.announceMessages })}
+        >
+          {settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
+        </Button>
+      </Tooltip>
       <Menu placement="top" strategy="fixed">
         <MenuButton
           as={IconButton}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -15,6 +15,7 @@ import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { AiFillSound, AiOutlineSound } from "react-icons/ai";
+import { isTtsSupported } from "../../lib/ai";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -36,6 +37,20 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           isLoading={isLoading}
           icon={<TbSend />}
         />
+        {isTtsSupported() && (
+          <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
+            <IconButton
+              type="button"
+              size="lg"
+              variant="solid"
+              aria-label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}
+              icon={settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
+              onClick={() =>
+                setSettings({ ...settings, announceMessages: !settings.announceMessages })
+              }
+            />
+          </Tooltip>
+        )}
         <MenuButton
           as={IconButton}
           size="lg"
@@ -66,15 +81,19 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
-        <Button
-          type="button"
-          size="sm"
-          onClick={() => setSettings({ ...settings, announceMessages: !settings.announceMessages })}
-        >
-          {settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
-        </Button>
-      </Tooltip>
+      {isTtsSupported() && (
+        <Tooltip label={settings.announceMessages ? "TTS Enabled" : "TTS Disabled"}>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() =>
+              setSettings({ ...settings, announceMessages: !settings.announceMessages })
+            }
+          >
+            {settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
+          </Button>
+        </Tooltip>
+      )}
       <Menu placement="top" strategy="fixed">
         <MenuButton
           as={IconButton}

--- a/src/hooks/use-audio-player.ts
+++ b/src/hooks/use-audio-player.ts
@@ -1,6 +1,10 @@
 import { useState, useEffect } from "react";
 
 const useAudioPlayer = () => {
+  // We are managing promises of audio urls instead of directly storing strings
+  // because there is no guarantee when openai tts api finishes processing and resolves a specific url
+  // For more info, check this comment:
+  // https://github.com/tarasglek/chatcraft.org/pull/357#discussion_r1473470003
   const [queue, setQueue] = useState<Promise<string>[]>([]);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
 

--- a/src/hooks/use-audio-player.ts
+++ b/src/hooks/use-audio-player.ts
@@ -12,8 +12,10 @@ const useAudioPlayer = () => {
 
   const playAudio = async (audioClipUri: Promise<string>) => {
     setIsPlaying(true);
-    const audio = new Audio(await audioClipUri);
+    const audioUrl: string = await audioClipUri;
+    const audio = new Audio(audioUrl);
     audio.onended = () => {
+      URL.revokeObjectURL(audioUrl);
       setQueue((oldQueue) => oldQueue.slice(1));
       setIsPlaying(false);
     };

--- a/src/hooks/use-audio-player.ts
+++ b/src/hooks/use-audio-player.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from "react";
+
+const useAudioPlayer = () => {
+  const [queue, setQueue] = useState<Promise<string>[]>([]);
+  const [isPlaying, setIsPlaying] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!isPlaying && queue.length > 0) {
+      playAudio(queue[0]);
+    }
+  }, [queue, isPlaying]);
+
+  const playAudio = async (audioClipUri: Promise<string>) => {
+    setIsPlaying(true);
+    const audio = new Audio(await audioClipUri);
+    audio.onended = () => {
+      setQueue((oldQueue) => oldQueue.slice(1));
+      setIsPlaying(false);
+    };
+    audio.play();
+  };
+
+  const addToAudioQueue = (audioClipUri: Promise<string>) => {
+    setQueue((oldQueue) => [...oldQueue, audioClipUri]);
+  };
+
+  return { addToAudioQueue };
+};
+
+export default useAudioPlayer;

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -65,6 +65,8 @@ function useChatOpenAI() {
         },
         onData({ currentText }) {
           if (!pausedRef.current) {
+            // TODO: Hook tts code here
+
             setStreamingMessage(
               new ChatCraftAiMessage({
                 id: message.id,

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -82,7 +82,7 @@ function useChatOpenAI() {
         onResume() {
           setPaused(false);
         },
-        async onData({ currentText }) {
+        onData({ currentText }) {
           if (!pausedRef.current) {
             // Hook tts code here
             ttsWordsBuffer = currentText.slice(ttsCursor);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -442,7 +442,6 @@ export const openRouterPkceRedirect = () => {
   location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
 };
 
-// Audio Recording and Transcribing depends on a bunch of technologies
 export function isTtsSupported() {
   return usingOfficialOpenAI();
 }

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -442,6 +442,11 @@ export const openRouterPkceRedirect = () => {
   location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
 };
 
+// Audio Recording and Transcribing depends on a bunch of technologies
+export function isTtsSupported() {
+  return usingOfficialOpenAI();
+}
+
 /**
  *
  * @param message The text for which speech needs to be generated

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -442,7 +442,12 @@ export const openRouterPkceRedirect = () => {
   location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
 };
 
-export const textToSpeech = async (message: string) => {
+/**
+ *
+ * @param message The text for which speech needs to be generated
+ * @returns The URL of generated audio clip
+ */
+export const textToSpeech = async (message: string): Promise<string> => {
   const { apiKey, apiUrl } = getSettings();
   if (!apiKey) {
     throw new Error("Missing API Key");
@@ -455,10 +460,8 @@ export const textToSpeech = async (message: string) => {
     input: message,
   });
 
-  const blob = new Blob([await mp3.arrayBuffer()], { type: "audio/mpeg" });
+  const blob = new Blob([await mp3.arrayBuffer()], { type: "audio/mp3" });
   const objectUrl = URL.createObjectURL(blob);
 
-  // Testing for now
-  const audio = new Audio(objectUrl);
-  audio.play();
+  return objectUrl;
 };

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -441,3 +441,24 @@ export const openRouterPkceRedirect = () => {
   // Redirect the user to the OpenRouter authentication page in the same tab
   location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
 };
+
+export const textToSpeech = async (message: string) => {
+  const { apiKey, apiUrl } = getSettings();
+  if (!apiKey) {
+    throw new Error("Missing API Key");
+  }
+  const { openai } = createClient(apiKey, apiUrl);
+
+  const mp3 = await openai.audio.speech.create({
+    model: "tts-1",
+    voice: "onyx",
+    input: message,
+  });
+
+  const blob = new Blob([await mp3.arrayBuffer()], { type: "audio/mpeg" });
+  const objectUrl = URL.createObjectURL(blob);
+
+  // Testing for now
+  const audio = new Audio(objectUrl);
+  audio.play();
+};

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -23,6 +23,7 @@ export type Settings = {
   sidebarVisible: boolean;
   alwaysSendFunctionResult: boolean;
   customSystemPrompt?: string;
+  announceMessages?: boolean;
 };
 
 export const defaults: Settings = {
@@ -35,6 +36,7 @@ export const defaults: Settings = {
   sidebarVisible: false,
   // Disabled by default, so we don't waste tokens
   alwaysSendFunctionResult: false,
+  announceMessages: false,
 };
 
 export const key = "settings";


### PR DESCRIPTION
Regarding issue #354 

I think I was able to implement an initial version of TTS support.

I've added an additional button in the prompt menu that allows users to select if they want to enable this feature.
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/f02075b5-61cc-4c63-9f0b-c8f66de613be)

Whenever we ask a question, the response is read using the TTS api.

I am buffering the words received from LLM stream over time and once the `threshold` is reached, I pass it to the TTS method for audio generation.
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/575b59f5-a9dc-452d-9f7d-d856d58a91c5)

I've also added a `useAudioPlayer` hook that manages the playback of audio chunks by making sure they play in order.

I feel like its still very rough and lots of optimizations/changes need to be done (variable naming, code organization, performance, UI prefs) before I move on with other features like download.

One would be the ability to choose **different voices**, but I am not sure where to place that UI pref because there's hardly any real estate.