### PR TITLE
Create new Blob URL for code

### DIFF
--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -101,6 +101,10 @@ function CodeHeader({
     }
     return toUrl(code);
   }, [isLoading, code]);
+  
+  const handlePreviewCode = useCallback(() => {
+    window.open(url, "_blank", "noopener,noreferrer");
+  }, [url]);
 
   return (
     <>

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -101,7 +101,7 @@ function CodeHeader({
     }
     return toUrl(code);
   }, [isLoading, code]);
-  
+
   const handlePreviewCode = useCallback(() => {
     window.open(url, "_blank", "noopener,noreferrer");
   }, [url]);

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -132,15 +132,13 @@ function CodeHeader({
           )}
           <IconButton
             size="sm"
-            as="a"
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
             aria-label="Open Code in New Window"
             title="Open Code in New Window"
             icon={<TbExternalLink />}
             color="gray.600"
             variant="ghost"
+            isDisabled={isLoading}
+            onClick={handlePreviewCode}
           />
           <IconButton
             size="sm"

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -100,7 +100,7 @@ function CodeHeader({
       return "about:blank";
     }
     return toUrl(code);
-  }, [children, isLoading]);
+  }, [isLoading, code]);
 
   return (
     <>

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, type ReactNode } from "react";
+import { memo, useCallback, useMemo, type ReactNode } from "react";
 import {
   Flex,
   ButtonGroup,
@@ -8,7 +8,7 @@ import {
   Text,
   Box,
 } from "@chakra-ui/react";
-import { TbCopy, TbDownload, TbRun } from "react-icons/tb";
+import { TbCopy, TbDownload, TbRun, TbExternalLink } from "react-icons/tb";
 
 import { download, formatAsCodeBlock } from "../lib/utils";
 import { useAlert } from "../hooks/use-alert";
@@ -92,6 +92,16 @@ function CodeHeader({
     }
   }, [onPrompt, code, language]);
 
+  const toUrl = (code: string) =>
+    URL.createObjectURL(new Blob([code], { type: "text/plain;charset=utf-8" }));
+
+  const url = useMemo(() => {
+    if (isLoading) {
+      return "about:blank";
+    }
+    return toUrl(code);
+  }, [children, isLoading]);
+
   return (
     <>
       <Flex
@@ -120,6 +130,18 @@ function CodeHeader({
               isDisabled={isLoading}
             />
           )}
+          <IconButton
+            size="sm"
+            as="a"
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="Open Code in New Window"
+            title="Open Code in New Window"
+            icon={<TbExternalLink />}
+            color="gray.600"
+            variant="ghost"
+          />
           <IconButton
             size="sm"
             aria-label="Download code"

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -140,6 +140,7 @@ function CodeHeader({
             title="Open Code in New Window"
             icon={<TbExternalLink />}
             color="gray.600"
+            _dark={{ color: "gray.300" }}
             variant="ghost"
             isDisabled={isLoading}
             onClick={handlePreviewCode}


### PR DESCRIPTION
generate a new Blob URL for the code and then open that in a new tab.

<img width="799" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/140febc1-a3b9-4787-8d24-56e2a1e538e4">
<img width="627" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/024ae18a-59cf-4a51-9d42-bfc8f8066d8d">


closes #158 