### PR TITLE
Improve Mic UX

### DIFF
--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -103,7 +103,29 @@ export default function MicIcon({
     onCancel();
   };
 
-  return (
+  const handleMobileMicToggle = () => {
+    if (isRecording) {
+      onRecordingStop();
+    } else {
+      onRecordingStart();
+    }
+  };
+
+  return isMobile ? (
+    <IconButton
+      isRound
+      isDisabled={isDisabled}
+      colorScheme={colorScheme}
+      icon={<TbMicrophone />}
+      variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
+      aria-label="Record speech"
+      size={isMobile ? "lg" : "md"}
+      fontSize="18px"
+      ref={micIconRef}
+      onClick={handleMobileMicToggle}
+      onBlur={() => onRecordingCancel()}
+    />
+  ) : (
     <motion.div
       drag="x"
       dragConstraints={{ left: 0, right: 0 }}
@@ -114,6 +136,11 @@ export default function MicIcon({
           setColorScheme("red");
         } else {
           setColorScheme("blue");
+        }
+
+        // If dragging to the right, set x to the maximum allowed value
+        if (info.offset.x > 0) {
+          x.set(0);
         }
       }}
       onDragEnd={(_event, info) => {

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -1,11 +1,10 @@
-import { useState, useRef } from "react";
 import { IconButton } from "@chakra-ui/react";
+import { useRef, useState } from "react";
 import { TbMicrophone } from "react-icons/tb";
-import { motion, useMotionValue } from "framer-motion";
 
-import { SpeechRecognition } from "../../lib/speech-recognition";
 import { useAlert } from "../../hooks/use-alert";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
+import { SpeechRecognition } from "../../lib/speech-recognition";
 
 type MicIconProps = {
   onRecording: () => void;
@@ -23,13 +22,10 @@ export default function MicIcon({
   isDisabled = false,
 }: MicIconProps) {
   const isMobile = useMobileBreakpoint();
-  const [colorScheme, setColorScheme] = useState<"blue" | "red">("blue");
   const [isRecording, setIsRecording] = useState(false);
   const micIconRef = useRef<HTMLButtonElement | null>(null);
   const speechRecognitionRef = useRef<SpeechRecognition | null>(null);
   const { error } = useAlert();
-  const x = useMotionValue(0);
-  const xCancelOffset = isMobile ? -50 : -100;
 
   const onRecordingStart = async () => {
     speechRecognitionRef.current = new SpeechRecognition();
@@ -103,7 +99,7 @@ export default function MicIcon({
     onCancel();
   };
 
-  const handleMobileMicToggle = () => {
+  const handleMicToggle = () => {
     if (isRecording) {
       onRecordingStop();
     } else {
@@ -111,61 +107,18 @@ export default function MicIcon({
     }
   };
 
-  return isMobile ? (
+  return (
     <IconButton
       isRound
       isDisabled={isDisabled}
-      colorScheme={colorScheme}
       icon={<TbMicrophone />}
       variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
       aria-label="Record speech"
       size={isMobile ? "lg" : "md"}
       fontSize="18px"
       ref={micIconRef}
-      onClick={handleMobileMicToggle}
+      onClick={handleMicToggle}
       onBlur={() => onRecordingCancel()}
     />
-  ) : (
-    <motion.div
-      drag="x"
-      dragConstraints={{ left: 0, right: 0 }}
-      dragTransition={{ bounceStiffness: 500, bounceDamping: 20 }}
-      dragElastic={1}
-      onDrag={(_event, info) => {
-        if (info.offset.x < xCancelOffset) {
-          setColorScheme("red");
-        } else {
-          setColorScheme("blue");
-        }
-
-        // If dragging to the right, set x to the maximum allowed value
-        if (info.offset.x > 0) {
-          x.set(0);
-        }
-      }}
-      onDragEnd={(_event, info) => {
-        if (info.offset.x < xCancelOffset) {
-          onRecordingCancel();
-        }
-        setColorScheme("blue");
-        x.set(0);
-      }}
-      style={{ x }}
-    >
-      <IconButton
-        isRound
-        isDisabled={isDisabled}
-        colorScheme={colorScheme}
-        icon={<TbMicrophone />}
-        variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
-        aria-label="Record speech"
-        size={isMobile ? "lg" : "md"}
-        fontSize="18px"
-        ref={micIconRef}
-        onPointerDown={() => onRecordingStart()}
-        onPointerUp={() => onRecordingStop()}
-        onBlur={() => onRecordingCancel()}
-      />
-    </motion.div>
   );
 }


### PR DESCRIPTION
I spent a few hours last night fixing the **Mic Drag UX** on mobile based on discussions in #357, and was able make it better to some point but its quite tedious to get around all the edge cases.
This branch has all the work for that.
https://github.com/tarasglek/chatcraft.org/tree/amnish04/mic-mobile

@tarasglek has been suggesting a "press to start, press to stop" audio UX instead, which is much easier to implement for mobile browsers.

Based on the suggestions, I have made the following changes to fix #368 

1. The **Mic Button** on **mobile** now uses "press to start, press to stop".
2. I did not change the drag behaviour for **Desktop** as it seems to work seamlessly on computers. I also noticed there was a lot of work put into it, so wanted to preserve it if possible.
3. Previously, the mic icon could be dragged to both right and left. Dragging and leaving to **left** side **cancelled** the recording, but I couldn't find a reason to allow dragging to **right**, which is why I have disabled that behaviour.

I am not sure if we want it to behave in this way, but we can make more changes as needed.