### PR TITLE
Allow storage of multiple providers info

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -12,6 +12,7 @@ import {
 
 import MessageBase, { type MessageBaseProps } from "../MessageBase";
 import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
+import { ChatCraftProvider } from "../../../lib/ChatCraftProvider";
 import RevealablePasswordInput from "../../RevealablePasswordInput";
 import { useSettings } from "../../../hooks/use-settings";
 import { openRouterPkceRedirect, validateApiKey } from "../../../lib/ai";
@@ -72,7 +73,16 @@ function Instructions(props: MessageBaseProps) {
       .then((valid) => {
         if (valid) {
           setIsInvalid(false);
-          setSettings({ ...settings, apiKey: apiKey.trim() });
+
+          const newProvider = ChatCraftProvider.fromUrl(settings.apiUrl, apiKey.trim());
+
+          setSettings({
+            ...settings,
+            apiKey: apiKey.trim(),
+            providers: {
+              [newProvider.name]: newProvider,
+            },
+          });
         } else {
           setIsInvalid(true);
         }

--- a/src/lib/ChatCraftProvider.ts
+++ b/src/lib/ChatCraftProvider.ts
@@ -1,0 +1,45 @@
+import { nanoid } from "nanoid";
+
+type ProviderName = "OpenAI" | "OpenRouter.ai";
+
+export const OPENAI_API_URL = "https://api.openai.com/v1";
+export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
+
+const urlToNameMap: { [key: string]: ProviderName } = {
+  [OPENAI_API_URL]: "OpenAI",
+  [OPENROUTER_API_URL]: "OpenRouter.ai",
+};
+
+export type SerializedChatCraftProvider = {
+  id: string;
+  name: ProviderName;
+  apiUrl: string;
+  apiKey?: string;
+};
+
+export class ChatCraftProvider {
+  id: string;
+  name: ProviderName;
+  apiUrl: string;
+  apiKey?: string;
+
+  constructor(url: string, key?: string) {
+    this.id = nanoid();
+    this.name = urlToNameMap[url];
+    this.apiUrl = url;
+    this.apiKey = key;
+  }
+
+  // Parses url into instance of ChatCraftProvider
+  static fromUrl(url: string, key?: string) {
+    return new ChatCraftProvider(url, key);
+  }
+
+  // Parse from serialized JSON
+  static fromJSON({ id, name, apiUrl, apiKey }: SerializedChatCraftProvider): ChatCraftProvider {
+    const provider = new ChatCraftProvider(apiUrl, apiKey);
+    provider.id = id;
+    provider.name = name;
+    return provider;
+  }
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,12 +6,17 @@
  * when you only need to read something.
  */
 import { ChatCraftModel } from "../lib/ChatCraftModel";
+import { ChatCraftProvider } from "../lib/ChatCraftProvider";
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
  */
 export const OPENAI_API_URL = "https://api.openai.com/v1";
 export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
+
+interface ProviderData {
+  [key: string]: ChatCraftProvider;
+}
 
 export type Settings = {
   apiKey?: string;
@@ -24,6 +29,7 @@ export type Settings = {
   alwaysSendFunctionResult: boolean;
   customSystemPrompt?: string;
   announceMessages?: boolean;
+  providers: ProviderData;
 };
 
 export const defaults: Settings = {
@@ -37,6 +43,7 @@ export const defaults: Settings = {
   // Disabled by default, so we don't waste tokens
   alwaysSendFunctionResult: false,
   announceMessages: false,
+  providers: {},
 };
 
 export const key = "settings";


### PR DESCRIPTION
Closes #383 

Save all newly inputted provider info to associative array settings.providers (stored in localStorage in providers)

Existing functionality is unchanged. We are only storing to settings.providers, not reading from settings.providers yet.

**Code changes:**

- `src/lib/ChatCraftProvider.ts` — new class which stores information for a provider such as provider name, url, key.
- `src/lib/settings.ts` — added the variable `providers` to Settings, which is an associative array of `ChatCraftProvider` objects
- `src/components/Message/AppMessage/Instructions.tsx` — added code so when new ChatCraft users enters a key and clicks the Save button, the provider info is stored to `settings.providers`
- `src/components/PreferencesModal.tsx` — added code to the event handlers of the API URL field, API Key field, Remove button, so that in addition to performing their usual behaviour, they also store/remove data from settings.providers

**Behaviour of the new code:**

1) New users to ChatCraft — the moment they input their api key, the provider information will be stored in settings.providers. You can test this by checking localStorage.

2) Existing users to ChatCraft — their current api key will not yet be stored in settings.providers. Will be addressed in release 1.2.

3) When a user changes their provider url in Settings — the moment they toggle to another API url, settings.providers is cleared, to match the current behaviour. This behaviour will change in release 1.2 (In 1.2 we will not clear the providers and instead keep them stored in settings.providers to be read from at a later date)

4) When a user enters a new/different provider key in Settings — the moment they enter a key, the key stored in settings.providers is stored or overwritten. There will never be more than one key stored for openai, for example.

5) When a user clicks the Remove button in Settings — if the current provider is stored in settings.providers it is removed from settings.providers.

![image1](https://github.com/tarasglek/chatcraft.org/assets/98062538/867b828a-fa2b-4caa-94ab-9d97d035b7e7)

**How to check localStorage in Chrome DevTools:**

Right click + Inspect (or F12)
![image2](https://github.com/tarasglek/chatcraft.org/assets/98062538/bc072cbf-967e-41cb-9f38-f53c4e0f17c9)

