### PR TITLE
Chore: Don't show hints when editing on mobile

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -352,12 +352,14 @@ function MessageBase({
                     />
                     <Flex width="100%" alignItems="center" alignContent="end" gap={2}>
                       <Spacer />
-                      <Text fontSize="sm" color="gray">
-                        <span>
-                          <Kbd>{meta}</Kbd> + <Kbd>Enter</Kbd>
-                          <span> to save</span>
-                        </span>
-                      </Text>
+                      {!isNarrowScreen && (
+                        <Text fontSize="sm" color="gray">
+                          <span>
+                            <Kbd>{meta}</Kbd> + <Kbd>Enter</Kbd>
+                            <span> to save</span>
+                          </span>
+                        </Text>
+                      )}
                       <Button size="sm" variant="ghost" onClick={() => onEditingChange(false)}>
                         Cancel
                       </Button>


### PR DESCRIPTION
This fixes #289

Summary
---

Uses [use-mobile-breakpoint](https://github.com/tarasglek/chatcraft.org/blob/main/src/hooks/use-mobile-breakpoint.ts) (as `isNarrowScreen`) to render the keyboard hint when on mobile (when ChatCraft detects a screen below the 480px cutoff).

### Without conditional rendering (iPhone SE)
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/1fc5e1d1-833b-4275-b5bf-5e74f7f8b2c4)

### With conditional rendering (iPhone SE)
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/c8ef5f45-4593-447d-8815-2dc186deae5c)

### How to test
- Run `npm run dev`
- submit any query to ChatCraft
- Left-click "edit message" on your message
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/d87f50d0-1ac6-437d-8b36-52985d39c62b)

- Enter your browser's developer tools by pressing **F12** (or equivalent) on your keyboard
- Enable device emulation
- Select viewports with a pixel width **<= 480px** (e.g., **iPhone SE**, **iPhone 14 Pro Max**)
