### PR TITLE
Fix: Correct margin between HTML preview Button and Content

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -43,7 +43,7 @@ const HtmlPreview = ({ children, isLoading = false }: HtmlPreviewProps) => {
         _dark={{ color: "gray.300" }}
         variant="ghost"
       />
-      <CardBody mt={6} p={2}>
+      <CardBody mt={10} p={2}>
         <IframeResizer
           checkOrigin={false}
           src={url}

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -40,6 +40,7 @@ const HtmlPreview = ({ children, isLoading = false }: HtmlPreviewProps) => {
         title="Open HTML Preview in New Window"
         icon={<TbExternalLink />}
         color="gray.600"
+        _dark={{ color: "gray.300" }}
         variant="ghost"
       />
       <CardBody mt={6} p={2}>


### PR DESCRIPTION
This fixes #367 

Summary
---
- added dark mode styling to **Open HTML Preview in New Window** button to match IconButton darkmode styles in [CodeHeader.tsx](https://github.com/tarasglek/chatcraft.org/blob/main/src/components/CodeHeader.tsx)
- Corrected margin between **Open HTML Preview in New Window** button and HTML Preview:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/e92207c2-faee-47e4-9c9e-81c5d4c1e3e1)
