### PR TITLE
Use material design icons for tts button

### DIFF
--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -14,7 +14,7 @@ import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
-import { AiFillSound, AiOutlineSound } from "react-icons/ai";
+import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { isTtsSupported } from "../../lib/ai";
 
 type PromptSendButtonProps = {
@@ -48,7 +48,9 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
               aria-label={
                 settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"
               }
-              icon={settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
+              icon={
+                settings.announceMessages ? <MdVolumeUp size={25} /> : <MdVolumeOff size={25} />
+              }
               onClick={() =>
                 setSettings({ ...settings, announceMessages: !settings.announceMessages })
               }
@@ -96,7 +98,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
               setSettings({ ...settings, announceMessages: !settings.announceMessages })
             }
           >
-            {settings.announceMessages ? <AiFillSound /> : <AiOutlineSound />}
+            {settings.announceMessages ? <MdVolumeUp size={18} /> : <MdVolumeOff size={18} />}
           </Button>
         </Tooltip>
       )}


### PR DESCRIPTION
I've replaced the current icons with the material design icons as suggested in
https://github.com/tarasglek/chatcraft.org/pull/357#discussion_r1473577322

**Enabled:**
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/e8357b85-7844-4e2c-8b35-f88c68782836)

**Disabled:**
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/79b2e3d7-c878-45bc-8afa-0b1266275681)

This fixes #392 