### PR TITLE
Add download as image

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "esbuild-wasm": "^0.19.5",
     "framer-motion": "^10.16.4",
     "get-video-id": "^3.6.5",
+    "html2canvas": "^1.4.1",
     "iframe-resizer-react": "^1.1.0",
     "jose": "^4.15.4",
     "katex": "^0.16.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   get-video-id:
     specifier: ^3.6.5
     version: 3.6.5
+  html2canvas:
+    specifier: ^1.4.1
+    version: 1.4.1
   iframe-resizer-react:
     specifier: ^1.1.0
     version: 1.1.0(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
@@ -4580,6 +4583,11 @@ packages:
     resolution: {integrity: sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==}
     dev: false
 
+  /base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+    dev: false
+
   /base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
     dev: true
@@ -5125,6 +5133,12 @@ packages:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
     dependencies:
       hyphenate-style-name: 1.0.4
+    dev: false
+
+  /css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
+    dependencies:
+      utrie: 1.0.2
     dev: false
 
   /css-tree@1.1.3:
@@ -6795,6 +6809,14 @@ packages:
 
   /html-url-attributes@3.0.0:
     resolution: {integrity: sha512-/sXbVCWayk6GDVg3ctOX6nxaVj7So40FcFAnWlWGNAB1LpYKcV5Cd10APjPjW80O7zYW2MsjBV4zZ7IZO5fVow==}
+    dev: false
+
+  /html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
     dev: false
 
   /http-cache-semantics@4.1.1:
@@ -9928,6 +9950,12 @@ packages:
       source-map-support: 0.5.21
     dev: true
 
+  /text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
+    dependencies:
+      utrie: 1.0.2
+    dev: false
+
   /text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
     dev: true
@@ -10367,6 +10395,12 @@ packages:
       is-typed-array: 1.1.12
       which-typed-array: 1.1.13
     dev: true
+
+  /utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    dev: false
 
   /uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, useColorMode } from "@chakra-ui/react";
-import { Menu as ReactMenu } from "@szhsin/react-menu";
+import { Menu as ReactMenu, type MenuProps as ReactMenuProps } from "@szhsin/react-menu";
 
 import React from "react";
 import { TbDots } from "react-icons/tb";
@@ -11,12 +11,11 @@ import "@szhsin/react-menu/dist/theme-dark.css";
 import "@szhsin/react-menu/dist/transitions/slide.css";
 import "./Menu.css";
 
-interface MenuProps {
-  children: React.ReactNode;
-  isLoading?: boolean;
-}
+export type MenuProps = Omit<ReactMenuProps, "menuButton" | "theming" | "transition"> & {
+  isDisabled?: boolean;
+};
 
-const Menu: React.FC<MenuProps> = ({ children, isLoading }) => {
+const Menu: React.FC<MenuProps> = (props) => {
   const { colorMode } = useColorMode();
   return (
     <Box>
@@ -27,12 +26,12 @@ const Menu: React.FC<MenuProps> = ({ children, isLoading }) => {
             aria-label="Message Menu"
             icon={<TbDots />}
             variant="ghost"
-            isDisabled={isLoading}
+            isDisabled={props.isDisabled}
           />
         }
         transition={true}
       >
-        {children}
+        {props.children}
       </ReactMenu>
     </Box>
   );

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,18 +1,13 @@
-import React from "react";
-import { MenuItem as ReactMenuItem } from "@szhsin/react-menu";
+import React, { type ReactNode } from "react";
+import {
+  MenuItem as ReactMenuItem,
+  type MenuItemProps as ReactMenuItemProps,
+} from "@szhsin/react-menu";
 
-export interface MenuItemProps {
-  label: React.ReactNode;
-  onClick?: () => void;
-  className?: string;
-}
+export type MenuItemProps = ReactMenuItemProps & { label: ReactNode };
 
-const MenuItem: React.FC<MenuItemProps> = ({ label, onClick, className }) => {
-  return (
-    <ReactMenuItem onClick={onClick} className={className}>
-      {label}
-    </ReactMenuItem>
-  );
+const MenuItem: React.FC<MenuItemProps> = (props) => {
+  return <ReactMenuItem {...props}>{props.label}</ReactMenuItem>;
 };
 
 export default MenuItem;

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -1,16 +1,11 @@
 import { Box } from "@chakra-ui/react";
-import { SubMenu as ReactMenuSubMenu } from "@szhsin/react-menu";
+import { SubMenu as ReactMenuSubMenu, type SubMenuProps } from "@szhsin/react-menu";
 import React from "react";
 
-export interface SubMenuProps {
-  label: string;
-  children: React.ReactNode;
-}
-
-const SubMenu: React.FC<SubMenuProps> = ({ label, children }) => {
+const SubMenu: React.FC<SubMenuProps> = (props) => {
   return (
     <Box>
-      <ReactMenuSubMenu label={label}>{children}</ReactMenuSubMenu>
+      <ReactMenuSubMenu {...props}>{props.children}</ReactMenuSubMenu>
     </Box>
   );
 };

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -39,7 +39,7 @@ import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
 import { Link as ReactRouterLink } from "react-router-dom";
 
-import { formatDate, download, formatNumber, getMetaKey } from "../../lib/utils";
+import { formatDate, download, formatNumber, getMetaKey, screenshotElement } from "../../lib/utils";
 import Markdown from "../Markdown";
 import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
 import {
@@ -109,6 +109,7 @@ function MessageBase({
   const [tokens, setTokens] = useState<number | null>(null);
   const isNarrowScreen = useMobileBreakpoint();
   const messageForm = useRef<HTMLFormElement>(null);
+  const messageContent = useRef<HTMLDivElement>(null);
   const meta = useMemo(getMetaKey, []);
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
   const isLongMessage = text.length > 5000;
@@ -136,13 +137,49 @@ function MessageBase({
     });
   }, [onCopy, info]);
 
-  const handleDownload = useCallback(() => {
-    download(text, "message.md");
+  const handleDownloadMarkdown = useCallback(() => {
+    download(text, "message.md", "text/markdown");
     info({
       title: "Downloaded",
-      message: "Message was downloaded as a file",
+      message: "Message was downloaded as a Markdown file",
     });
   }, [info, text]);
+
+  const handleDownloadImage = useCallback(() => {
+    const elem = messageContent.current;
+    if (!elem) {
+      return;
+    }
+
+    try {
+      screenshotElement(elem).then((blob) => {
+        download(blob, "message.png", "image/png");
+        info({
+          title: "Downloaded",
+          message: "Message was downloaded as an image file",
+        });
+      });
+    } catch (err: any) {
+      console.warn("Unable to download image", err);
+      error({
+        title: `Error Saving Message as Image`,
+        message: err.message,
+      });
+    }
+  }, [messageContent, info, error]);
+
+  const handleDownloadPlainText = useCallback(() => {
+    if (messageContent.current) {
+      const text = messageContent.current.textContent;
+      if (text) {
+        download(text, "message.txt", "text/plain");
+        info({
+          title: "Downloaded",
+          message: "Message was downloaded as text file",
+        });
+      }
+    }
+  }, [messageContent, info]);
 
   const handleClick = useCallback((e: MouseEvent<HTMLButtonElement>) => {
     messageForm.current?.setAttribute("data-action", e.currentTarget.name);
@@ -287,9 +324,19 @@ function MessageBase({
                   )}
                 </ButtonGroup>
               )}
-              <Menu isLoading={isLoading}>
+              <Menu isDisabled={isLoading}>
                 <MenuItem label="Copy" onClick={handleCopy} />
-                <MenuItem label="Download" onClick={handleDownload} />
+                <SubMenu label="Download">
+                  <MenuItem label="Download as Markdown" onClick={handleDownloadMarkdown} />
+                  <MenuItem label="Download as Text" onClick={handleDownloadPlainText} />
+                  <MenuItem
+                    label="Download as Image"
+                    onClick={handleDownloadImage}
+                    // If we're editing, or showing only a summary, don't enable download as image
+                    // since we need the whole element to exist in order to render into the canvas.
+                    disabled={displaySummaryText !== false || editing}
+                  />
+                </SubMenu>
                 {!disableFork && (
                   <MenuItem
                     label={
@@ -349,7 +396,15 @@ function MessageBase({
         </CardHeader>
         <CardBody p={0}>
           <Flex direction="column" gap={3}>
-            <Box maxWidth="100%" minH="2em" overflow="hidden" px={6} pb={2}>
+            <Box
+              maxWidth="100%"
+              minH="2em"
+              overflow="hidden"
+              // Offset for the extra pixel of padding added to the messageContent box below
+              m={-1}
+              px={6}
+              pb={2}
+            >
               {
                 // only display the button before message if the message is too long and toggled
                 !editing && isLongMessage && isOpen ? (
@@ -407,7 +462,11 @@ function MessageBase({
                   </VStack>
                 </form>
               ) : (
-                <>
+                <Box
+                  ref={messageContent}
+                  // Add a single pixel of offset for rendering to canvas (offset handled above with m=-1)
+                  p={1}
+                >
                   <Markdown
                     previewCode={!hidePreviews && !displaySummaryText}
                     isLoading={isLoading}
@@ -421,7 +480,7 @@ function MessageBase({
                       {isOpen ? "Show Less" : "Show More..."}
                     </Button>
                   ) : undefined}
-                </>
+                </Box>
               )}
             </Box>
           </Flex>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -60,3 +60,26 @@ export const isProd = () => location.origin === "https://chatcraft.org";
 export const isDev = () => !isProd();
 
 export const getMetaKey = () => (isMac() ? "Command ⌘" : "Ctrl");
+
+export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
+  return import("html2canvas")
+    .then((module) => {
+      const html2canvas = module.default;
+      return html2canvas(element, {
+        windowWidth: element.scrollWidth,
+        windowHeight: element.scrollHeight,
+      });
+    })
+    .then(
+      (canvas) =>
+        new Promise((resolve, reject) => {
+          canvas.toBlob((blob) => {
+            if (!blob) {
+              reject(new Error("Unable to screenshot element"));
+              return;
+            }
+            resolve(blob);
+          });
+        })
+    );
+};


### PR DESCRIPTION
My daughter wants to be able to download a rendered version of an image (e.g., if it contains KaTeX math equations, which don't work in plain text).

This updates our message menu to include 3 different ways to download the message:

- Markdown (default)
- Plain Text
- Image (PNG)

A few things to note about how I've done this:

1. For the image screenshot feature to work, you have to have the element fully expanded (i.e., it renders what's in the DOM) and you can't be editing it.  Therefore I disable the menu item if it's not possible.  There might be a better way to indicate this, I'm not sure.
2. I had to fix the TypeScript for the `Menu` components so we properly expose everything we need from the underlying react-menu props, but also add our own.  While I was doing this, I added it to the others as well
3. I'm dynamically importing `html2canvas` on first use so it doesn't waste space in the bundle
4. I made the `screenshotElement()` a separate function so we can re-use it later to do things like generate a share OG image.
5. I had to add 1 pixel of padding around the message content in order for it to work in the canvas (otherwise the edges get cut off).  To compensate, I've used a negative margin of 1 pixel on the container.  If there is a better way to do this, let me know.

To test this, create a new chat and pick a message.  In the **Download** menu, try each option

<img width="1049" alt="Screenshot 2024-02-04 at 12 07 27 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/eab66387-598c-465c-a2c5-e7e03fd44c85">

p.s. I *love* having submenus!