### PR TITLE
Allow running JS/TS remotely via val.town's eval endpoint

### DIFF
--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -180,7 +180,7 @@ function CodeHeader({
         </Box>
         <ButtonGroup isAttached pr={2}>
           {shouldShowRunButton && (
-            <Menu>
+            <Menu strategy="fixed">
               <MenuButton
                 as={IconButton}
                 size="sm"

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -7,6 +7,10 @@ import {
   useColorModeValue,
   Text,
   Box,
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuList,
 } from "@chakra-ui/react";
 import { TbCopy, TbDownload, TbRun, TbExternalLink } from "react-icons/tb";
 
@@ -32,7 +36,7 @@ function CodeHeader({
   codeDownloadFilename,
 }: PreHeaderProps) {
   const { onCopy } = useClipboard(code);
-  const { info } = useAlert();
+  const { info, error } = useAlert();
   // Only show the "Run" button for JS code blocks, and only when we aren't already loading
   const shouldShowRunButton = isRunnable(language) && onPrompt;
 
@@ -52,7 +56,61 @@ function CodeHeader({
     });
   }, [info, code, codeDownloadFilename]);
 
-  const handleRun = useCallback(async () => {
+  const handleRunRemote = useCallback(async () => {
+    if (!onPrompt) {
+      return;
+    }
+
+    // https://docs.val.town/api/eval/
+    const evalUrl = new URL("https://api.val.town/v1/eval");
+    const res = await fetch(evalUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code: code.replaceAll("\n", " ").trim(),
+        args: [],
+      }),
+    });
+
+    if (!res.ok) {
+      error({ title: "Error Running Code", message: "Unable to run code remotely" });
+      return;
+    }
+
+    let result: string;
+    try {
+      // val.town returns an empty body when code doesn't return a value, which breaks res.json()
+      result = await res.json();
+    } catch (err) {
+      error({
+        title: "Server unable to parse code",
+        message: "Try rewriting the code as an async function returning a value.",
+      });
+      return;
+    }
+
+    try {
+      if (typeof result === "string") {
+        // catch corner cases with strings
+        if (!result.length || result[0] === "/") {
+          result = formatAsCodeBlock(JSON.stringify(result), "js");
+        } else if (result.startsWith("<")) {
+          result = formatAsCodeBlock(result, "html");
+        } else {
+          // result is good to include inline, might have formatting, etc
+        }
+      }
+    } catch (error: any) {
+      result = formatAsCodeBlock(
+        error instanceof Error ? `${error.name}: ${error.message}\n${error.stack}` : `${error}`
+      );
+    }
+    if (result !== undefined) {
+      onPrompt(result);
+    }
+  }, [code, onPrompt, error]);
+
+  const handleRunBrowser = useCallback(async () => {
     if (!onPrompt) {
       return;
     }
@@ -122,17 +180,23 @@ function CodeHeader({
         </Box>
         <ButtonGroup isAttached pr={2}>
           {shouldShowRunButton && (
-            <IconButton
-              size="sm"
-              aria-label="Run code"
-              title="Run code"
-              icon={<TbRun />}
-              color="gray.600"
-              _dark={{ color: "gray.300" }}
-              variant="ghost"
-              onClick={handleRun}
-              isDisabled={isLoading}
-            />
+            <Menu>
+              <MenuButton
+                as={IconButton}
+                size="sm"
+                aria-label="Run code"
+                title="Run code"
+                icon={<TbRun />}
+                color="gray.600"
+                _dark={{ color: "gray.300" }}
+                variant="ghost"
+                isDisabled={isLoading}
+              />
+              <MenuList>
+                <MenuItem onClick={handleRunBrowser}>Run in Browser</MenuItem>
+                <MenuItem onClick={handleRunRemote}>Run on Server</MenuItem>
+              </MenuList>
+            </Menu>
           )}
           <IconButton
             size="sm"


### PR DESCRIPTION
Adds the ability to run code in the browser, or remotely via val.town's [/eval endpoint](https://docs.val.town/api/eval/):

<img width="915" alt="Screenshot 2024-02-04 at 2 21 50 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/cbfd813e-2c1f-4cf9-93eb-0c49fabd05e5">

In testing this, I find their endpoint pretty fragile when it comes to the format of the code.  Lots of valid things don't seem to work, and you don't get good error messages back.

I've tried to make this safe to run and give a bit of feedback.  But it's not possible to make it perfect.

Fixes #384 