### PR TITLE
HTML Preview: Fix Iframe auto-resize

### DIFF
--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -49,6 +49,7 @@ const HtmlPreview = ({ children, isLoading = false }: HtmlPreviewProps) => {
           src={url}
           style={{ width: "1px", minWidth: "100%" }}
           scrolling={true}
+          heightCalculationMethod={"max"}
         />
       </CardBody>
     </Card>

--- a/src/components/HtmlPreview.tsx
+++ b/src/components/HtmlPreview.tsx
@@ -48,7 +48,6 @@ const HtmlPreview = ({ children, isLoading = false }: HtmlPreviewProps) => {
           checkOrigin={false}
           src={url}
           style={{ width: "1px", minWidth: "100%" }}
-          scrolling={true}
           heightCalculationMethod={"max"}
         />
       </CardBody>


### PR DESCRIPTION
This fixes #379
This PR prevents content overflowing out of an iFrame by setting 

How to Test
---
Open two separate ChatCraft conversations and supply one prompt to each:
- First conversation: Show me a few example HTML pages with Plotly.js
- Second conversation: Show me three example HTML pages of varying sizes

Explanation
---

By default, the IframeResizer [heightCalculationMethod](https://github.com/davidjbradshaw/iframe-resizer/blob/master/docs/parent_page/options.md#heightcalculationmethod) option calculates the iFrame height by converting the `body` margin to px then adding the top and bottom figures to the `body` tag's `offSetHeight` (bodyOffSet).

With this default `heightCalculationMethod`, HTML content tends to overflow outside the body:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/d5aca441-5bbe-4f9c-8f5c-5c83d9d1ed0e)

There are four main values for **heightCalculationMethod**:

- **bodyOffset** uses document.body.offsetHeight
- **bodyScroll** uses document.body.scrollHeight 
- **documentElementOffset** uses document.documentElement.offsetHeight
- **documentElementScroll** uses document.documentElement.scrollHeight 

A `heightCalculationMethod` value of **max** uses the largest value of the above 4, preventing overflow:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/520d4535-181e-46d1-9e5d-9bb3549a91fd)

To keep or remove scrolling
---
I've experimented with other values for `heightCalculationMethod`. For example, `bodyScroll` also prevents text overflow, but when ChatCraft generates HTML pages with Plotly.js, scroll-bars are added to the preview. Using `heightCalculationMethod={max}` prevents both of these from happening.

Using `max` will render entire HTML previews, making scrollbars unnecessary. It is important to note that the default setting, `bodyOffset`, **already renders** ~95% of an HTML preview body.
**We must determine** whether we want to render entire IFrames, or add a `maxHeight` property to the Iframe to make scrollbars necessary.

However, in my tests, adding a maxHeight property to the IFrame allows text overflow/cutting off
