### PR TITLE
Fix: Don't use Show More... for final message 

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -47,6 +47,7 @@ import {
   ChatCraftAiMessage,
   ChatCraftAiMessageVersion,
   ChatCraftMessage,
+  ChatCraftSystemMessage,
 } from "../../lib/ChatCraftMessage";
 import { ChatCraftModel } from "../../lib/ChatCraftModel";
 import { useModels } from "../../hooks/use-models";
@@ -127,6 +128,14 @@ function MessageBase({
       message.tokens().then(setTokens).catch(console.warn);
     }
   }, [settings.countTokens, message]);
+
+  // If last message is collapsed, auto expand for better view
+  useEffect(() => {
+    if (!onDeleteAfterClick && !isOpen && !(message instanceof ChatCraftSystemMessage)) {
+      onToggle();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const handleCopy = useCallback(() => {
     onCopy();

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -134,8 +134,11 @@ function MessageBase({
     if (!onDeleteAfterClick && !isOpen && !(message instanceof ChatCraftSystemMessage)) {
       onToggle();
     }
+
+    // ignore isOpen as onToggle() will change isOpen status
+    // ignore message as each message has its corresponding onDeleteAfterClick
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [onDeleteAfterClick]);
 
   const handleCopy = useCallback(() => {
     onCopy();

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -76,6 +76,7 @@ export interface MessageBaseProps {
   onDeleteClick?: () => void;
   onDeleteAfterClick?: () => void;
   onRetryClick?: (model: ChatCraftModel) => void;
+  hasMessagesAfter?: boolean;
   disableFork?: boolean;
   disableEdit?: boolean;
 }
@@ -98,6 +99,7 @@ function MessageBase({
   onDeleteAfterClick,
   onPrompt,
   onRetryClick,
+  hasMessagesAfter,
   disableFork,
   disableEdit,
 }: MessageBaseProps) {
@@ -131,14 +133,14 @@ function MessageBase({
 
   // If last message is collapsed, auto expand for better view
   useEffect(() => {
-    if (!onDeleteAfterClick && !isOpen && !(message instanceof ChatCraftSystemMessage)) {
+    if (!hasMessagesAfter && !isOpen && !(message instanceof ChatCraftSystemMessage)) {
       onToggle();
     }
 
     // ignore isOpen as onToggle() will change isOpen status
-    // ignore message as each message has its corresponding onDeleteAfterClick
+    // ignore message as each message has its corresponding hasMessagesAfter
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [onDeleteAfterClick]);
+  }, [hasMessagesAfter]);
 
   const handleCopy = useCallback(() => {
     onCopy();

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -25,6 +25,7 @@ type MessageProps = {
   onDeleteBeforeClick?: () => void;
   onDeleteClick?: () => void;
   onDeleteAfterClick?: () => void;
+  hasMessagesAfter?: boolean;
   disableFork?: boolean;
   disableEdit?: boolean;
 };
@@ -39,6 +40,7 @@ function Message({
   onDeleteClick,
   onDeleteAfterClick,
   onPrompt,
+  hasMessagesAfter,
   disableFork,
   disableEdit,
 }: MessageProps) {
@@ -64,6 +66,7 @@ function Message({
         onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
         disableFork={disableFork}
         disableEdit={message.readonly && disableEdit}
       />
@@ -87,6 +90,7 @@ function Message({
         onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
         disableFork={disableFork}
         disableEdit={message.readonly && disableEdit}
       />
@@ -106,6 +110,7 @@ function Message({
         onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
         disableFork={true}
         disableEdit={message.readonly && disableEdit}
       />
@@ -125,6 +130,7 @@ function Message({
         /* We can't delete anything before the system message, since it's first */
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
       />
     );
   }
@@ -142,6 +148,7 @@ function Message({
         onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
       />
     );
   }
@@ -159,6 +166,7 @@ function Message({
         onDeleteBeforeClick={onDeleteBeforeClick}
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
+        hasMessagesAfter={hasMessagesAfter}
       />
     );
   }

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -109,6 +109,7 @@ function MessagesView({
             hasMessagesAfter ? () => deleteMessages(message.id, "after") : undefined
           }
           onPrompt={onPrompt}
+          hasMessagesAfter={hasMessagesAfter}
         />
       );
     });


### PR DESCRIPTION
Fixes #394 

## Explanation 

Currently all long messages are collapsed, (`isOpen` is `false` by default)

This update adds a `useEffect` to detect message status, if it is the final message and not system message, it toggles the `Show More...` button for users to have a better view.

~~The `onDeleteAfterClick` property is `undefined` when it is the final message and so can be used for the check.~~  updated to `hasMessagesAfter` 

[Result](https://mingming-longmessages-394.console-overthinker-dev.pages.dev/c/chatcraft_dev/xRoHj8zi1inmiPZOykJQi)
