### PR TITLE
Fix image styling when using gpt4-vision

### DIFF
--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -23,9 +23,15 @@ const ImageModal: React.FC<ImageModalProps> = ({ isOpen, onClose, imageSrc }) =>
       <ModalCloseButton />
       <ModalBody>
         <Flex height={"100%"} justifyContent={"center"} alignItems={"center"}>
-          <Box maxWidth="100%" maxHeight="70vh" overflow={"auto"}>
-            <Image src={imageSrc} alt="Selected Image" m="auto" objectFit="contain" />
-          </Box>
+          <Image
+            maxWidth="100%"
+            maxHeight="70vh"
+            overflow={"auto"}
+            src={imageSrc}
+            alt="Selected Image"
+            m="auto"
+            objectFit="contain"
+          />
         </Flex>
       </ModalBody>
     </ModalContent>

--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -6,6 +6,8 @@ import {
   ModalCloseButton,
   ModalBody,
   Image,
+  Box,
+  Flex,
 } from "@chakra-ui/react";
 
 interface ImageModalProps {
@@ -17,17 +19,14 @@ interface ImageModalProps {
 const ImageModal: React.FC<ImageModalProps> = ({ isOpen, onClose, imageSrc }) => (
   <Modal isOpen={isOpen} onClose={onClose} size="2xl" isCentered>
     <ModalOverlay />
-    <ModalContent maxW="90vw" maxH="90vh">
+    <ModalContent maxW="90vw" height="90vh">
       <ModalCloseButton />
       <ModalBody>
-        <Image
-          src={imageSrc}
-          alt="Selected Image"
-          m="auto"
-          width="100%"
-          maxH="85vh"
-          objectFit="contain"
-        />
+        <Flex height={"100%"} justifyContent={"center"} alignItems={"center"}>
+          <Box maxWidth="100%" maxHeight="70vh" overflow={"auto"}>
+            <Image src={imageSrc} alt="Selected Image" m="auto" objectFit="contain" />
+          </Box>
+        </Flex>
       </ModalBody>
     </ModalContent>
   </Modal>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -419,13 +419,15 @@ function MessageBase({
               ) : (
                 <>
                   {image.map((image, index) => (
-                    <Image
-                      key={`${id}-${index}`}
-                      src={image}
-                      alt={`Images# ${index}`}
-                      width="50%"
-                      onClick={() => openModalWithImage(image)}
-                    />
+                    <Box key={`${id}-${index}`}>
+                      <Image
+                        src={image}
+                        alt={`Images# ${index}`}
+                        margin={"auto"}
+                        maxWidth={"100%"}
+                        onClick={() => openModalWithImage(image)}
+                      />
+                    </Box>
                   ))}
                   <Markdown
                     previewCode={!hidePreviews && !displaySummaryText}


### PR DESCRIPTION
For PR #286

Improved the styling of images in **messages** and **modal preview**.

**Before:**

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/0b873147-9420-4db0-b329-c978842b2438)

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/eb12db24-f0d1-400f-b1f6-7b298b987d37)

***

**After:**

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/033e3039-0645-405b-8706-d0779560fbad)

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/12f2ceb9-6509-4290-b260-54fc6debd2fe)

***

Smaller images will only take as much space as they need.

If the image can't fit, there will be scrollbars to preserve aspect ratio

This fixes #418 