### PR TITLE
Query available models to determine TTS support

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -57,6 +57,7 @@ import { useAlert } from "../../hooks/use-alert";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
+import { usingOfficialOpenAI } from "../../lib/ai";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -318,13 +319,15 @@ function MessageBase({
                   <>
                     <MenuDivider />
                     <SubMenu label="Retry with...">
-                      {models.map((model) => (
-                        <MenuItem
-                          key={model.id}
-                          label={model.prettyModel}
-                          onClick={() => onRetryClick(model)}
-                        />
-                      ))}
+                      {models
+                        .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+                        .map((model) => (
+                          <MenuItem
+                            key={model.id}
+                            label={model.prettyModel}
+                            onClick={() => onRetryClick(model)}
+                          />
+                        ))}
                     </SubMenu>
                   </>
                 )}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -38,7 +38,7 @@ import { useModels } from "../hooks/use-models";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { ChatCraftProvider } from "../lib/ChatCraftProvider";
 import { OPENAI_API_URL, OPENROUTER_API_URL } from "../lib/settings";
-import { openRouterPkceRedirect, validateApiKey } from "../lib/ai";
+import { openRouterPkceRedirect, usingOfficialOpenAI, validateApiKey } from "../lib/ai";
 import { useAlert } from "../hooks/use-alert";
 
 // https://dexie.org/docs/StorageManager
@@ -301,11 +301,13 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                   setSettings({ ...settings, model: new ChatCraftModel(e.target.value) })
                 }
               >
-                {models.map((model) => (
-                  <option key={model.id} value={model.id}>
-                    {model.prettyModel}
-                  </option>
-                ))}
+                {models
+                  .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+                  .map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.prettyModel}
+                    </option>
+                  ))}
               </Select>
               <FormHelperText>
                 See{" "}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -15,9 +15,7 @@ import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
-import { isTtsSupported, usingOfficialOpenAI } from "../../lib/ai";
-import { useEffect, useState } from "react";
-import { useAlert } from "../../hooks/use-alert";
+import { usingOfficialOpenAI } from "../../lib/ai";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -27,24 +25,9 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
 
-  const { error } = useAlert();
-
-  const [isTTSSupported, setIsTTSSupported] = useState(false);
-
-  useEffect(() => {
-    async function checkTtsSupport() {
-      try {
-        const supported = await isTtsSupported();
-        setIsTTSSupported(supported);
-      } catch (err: any) {
-        error({
-          title: "Error checking TTS support",
-          message: err.message,
-        });
-      }
-    }
-    checkTtsSupport();
-  }, [error]);
+  function isTtsSupported() {
+    return !!models.filter((model) => model.id.includes("tts"))?.length;
+  }
 
   return (
     <ButtonGroup variant="outline" isAttached>
@@ -58,7 +41,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           isLoading={isLoading}
           icon={<TbSend />}
         />
-        {isTTSSupported && (
+        {isTtsSupported() && (
           <Tooltip
             label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
           >
@@ -105,31 +88,16 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
 
-  const { error } = useAlert();
-
-  const [isTTSSupported, setIsTTSSupported] = useState(false);
-
-  useEffect(() => {
-    async function checkTtsSupport() {
-      try {
-        const supported = await isTtsSupported();
-        setIsTTSSupported(supported);
-      } catch (err: any) {
-        error({
-          title: "Error checking TTS support",
-          message: err.message,
-        });
-      }
-    }
-    checkTtsSupport();
-  }, [error]);
+  function isTtsSupported() {
+    return !!models.filter((model) => model.id.includes("tts"))?.length;
+  }
 
   return (
     <ButtonGroup isAttached>
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      {isTTSSupported && (
+      {isTtsSupported() && (
         <Tooltip
           label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
         >

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -15,7 +15,7 @@ import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
-import { isTtsSupported } from "../../lib/ai";
+import { isTtsSupported, usingOfficialOpenAI } from "../../lib/ai";
 import { useEffect, useState } from "react";
 import { useAlert } from "../../hooks/use-alert";
 
@@ -88,11 +88,13 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
-          {models.map((model) => (
-            <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
-              {model.prettyModel}
-            </MenuItem>
-          ))}
+          {models
+            .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+            .map((model) => (
+              <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                {model.prettyModel}
+              </MenuItem>
+            ))}
         </MenuList>
       </Menu>
     </ButtonGroup>
@@ -151,11 +153,13 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
-          {models.map((model) => (
-            <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
-              {model.prettyModel}
-            </MenuItem>
-          ))}
+          {models
+            .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+            .map((model) => (
+              <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                {model.prettyModel}
+              </MenuItem>
+            ))}
         </MenuList>
       </Menu>
     </ButtonGroup>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -16,6 +16,8 @@ import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { isTtsSupported } from "../../lib/ai";
+import { useEffect, useState } from "react";
+import { useAlert } from "../../hooks/use-alert";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -24,6 +26,25 @@ type PromptSendButtonProps = {
 function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
+
+  const { error } = useAlert();
+
+  const [isTTSSupported, setIsTTSSupported] = useState(false);
+
+  useEffect(() => {
+    async function checkTtsSupport() {
+      try {
+        const supported = await isTtsSupported();
+        setIsTTSSupported(supported);
+      } catch (err: any) {
+        error({
+          title: "Error checking TTS support",
+          message: err.message,
+        });
+      }
+    }
+    checkTtsSupport();
+  }, [error]);
 
   return (
     <ButtonGroup variant="outline" isAttached>
@@ -37,7 +58,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           isLoading={isLoading}
           icon={<TbSend />}
         />
-        {isTtsSupported() && (
+        {isTTSSupported && (
           <Tooltip
             label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
           >
@@ -82,12 +103,31 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
 
+  const { error } = useAlert();
+
+  const [isTTSSupported, setIsTTSSupported] = useState(false);
+
+  useEffect(() => {
+    async function checkTtsSupport() {
+      try {
+        const supported = await isTtsSupported();
+        setIsTTSSupported(supported);
+      } catch (err: any) {
+        error({
+          title: "Error checking TTS support",
+          message: err.message,
+        });
+      }
+    }
+    checkTtsSupport();
+  }, [error]);
+
   return (
     <ButtonGroup isAttached>
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      {isTtsSupported() && (
+      {isTTSSupported && (
         <Tooltip
           label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
         >

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -16,6 +16,7 @@ import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { usingOfficialOpenAI } from "../../lib/ai";
+import { useMemo } from "react";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -25,9 +26,9 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
 
-  function isTtsSupported() {
+  const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
-  }
+  }, [models]);
 
   return (
     <ButtonGroup variant="outline" isAttached>
@@ -41,7 +42,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           isLoading={isLoading}
           icon={<TbSend />}
         />
-        {isTtsSupported() && (
+        {isTtsSupported && (
           <Tooltip
             label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
           >
@@ -88,16 +89,16 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
 
-  function isTtsSupported() {
+  const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
-  }
+  }, [models]);
 
   return (
     <ButtonGroup isAttached>
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      {isTtsSupported() && (
+      {isTtsSupported && (
         <Tooltip
           label={settings.announceMessages ? "Text-to-Speech Enabled" : "Text-to-Speech Disabled"}
         >

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -44,7 +44,7 @@ function useChatOpenAI() {
   const { addToAudioQueue } = useAudioPlayer();
 
   const callChatApi = useCallback(
-    (
+    async (
       messages: ChatCraftMessage[],
       {
         model = settings.model,
@@ -63,6 +63,7 @@ function useChatOpenAI() {
       setShouldAutoScroll(true);
       resetScrollProgress();
 
+      const ttsSupported = await isTtsSupported();
       // Set a maximum words in a sentence that we need to wait for.
       // This reduces latency and number of TTS api calls
       const TTS_BUFFER_THRESHOLD = 25;
@@ -87,7 +88,7 @@ function useChatOpenAI() {
             // Hook tts code here
             ttsWordsBuffer = currentText.slice(ttsCursor);
 
-            if (isTtsSupported() && getSettings().announceMessages) {
+            if (ttsSupported && getSettings().announceMessages) {
               if (
                 sentenceEndRegex.test(ttsWordsBuffer) // Has full sentence
               ) {
@@ -158,7 +159,7 @@ function useChatOpenAI() {
           setShouldAutoScroll(false);
 
           if (
-            isTtsSupported() &&
+            ttsSupported &&
             getSettings().announceMessages &&
             ttsWordsBuffer.slice(ttsCursor).length
           ) {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -347,11 +347,7 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
  * @param filterPredicate A function used to filter the array of returned models
  * @returns A list of ChatCraft models
  */
-export async function queryModels(
-  apiKey: string,
-  filterPredicate: (model: ChatCraftModel) => boolean = (model) =>
-    !usingOfficialOpenAI() || model.id.includes("gpt")
-) {
+export async function queryModels(apiKey: string) {
   const { apiUrl } = getSettings();
   const { openai } = createClient(apiKey, apiUrl);
 
@@ -361,9 +357,7 @@ export async function queryModels(
       models.push(page);
     }
 
-    return models
-      .filter((model: any) => filterPredicate(model))
-      .map((model: any) => model.id) as string[];
+    return models.map((model: any) => model.id) as string[];
   } catch (err: any) {
     throw new Error(err.message ?? `error querying models API`);
   }
@@ -457,13 +451,7 @@ export async function isTtsSupported() {
     throw new Error("Missing API Key");
   }
 
-  return (
-    (
-      await queryModels(apiKey, (model: ChatCraftModel) => {
-        return model.id.includes("tts");
-      })
-    )?.length > 0
-  );
+  return (await queryModels(apiKey)).filter((model: string) => model.includes("tts"))?.length > 0;
 }
 
 /**

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -341,12 +341,6 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
   };
 };
 
-/**
- *
- * @param apiKey Api key for the provider
- * @param filterPredicate A function used to filter the array of returned models
- * @returns A list of ChatCraft models
- */
 export async function queryModels(apiKey: string) {
   const { apiUrl } = getSettings();
   const { openai } = createClient(apiKey, apiUrl);
@@ -445,6 +439,10 @@ export const openRouterPkceRedirect = () => {
   location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
 };
 
+/**
+ * Only meant to be used outside components or hooks
+ * where useModels cannot be used.
+ */
 export async function isTtsSupported() {
   const { apiKey } = getSettings();
   if (!apiKey) {


### PR DESCRIPTION
I am now querying the available models to determine if tts is supported rather than just checking if we are using openai.

For this, I have modified the `queryModels` function to accept a custom predicate for filtering purposes. I have added the previously used predicate as default value so other placed don't break.
```ts
filterPredicate: (model: ChatCraftModel) => boolean = (model) =>
    !usingOfficialOpenAI() || model.id.includes("gpt")
```

and `isTtsSupported` now looks like this

```ts
export async function isTtsSupported() {
  const { apiKey } = getSettings();
  if (!apiKey) {
    throw new Error("Missing API Key");
  }

  return (
    (
      await queryModels(apiKey, (model: ChatCraftModel) => {
        return model.id.includes("tts");
      })
    )?.length > 0
  );
}
```

This closes #387 