### PR TITLE
Allow store and toggle of multiple providers info

### DIFF
--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -153,6 +153,39 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
     [inputRef]
   );
 
+  const handleProviderChange = useCallback(
+    (e: ChangeEvent<HTMLSelectElement>) => {
+      const currentProvider = ChatCraftProvider.fromUrl(settings.apiUrl, settings.apiKey);
+      const selectedProvider = ChatCraftProvider.fromUrl(e.target.value);
+
+      // If new provider exists in settings.providers, parse it to ChatCraftProvider
+      const newProvider = settings.providers[selectedProvider.name]
+        ? ChatCraftProvider.fromJSON(settings.providers[selectedProvider.name])
+        : selectedProvider;
+
+      // Store old provider in settings.providers array if not already there
+      // Set current apiKey to value loaded from settings.providers or undefined
+      if (currentProvider.apiKey && !(currentProvider.name in settings.providers)) {
+        setSettings({
+          ...settings,
+          apiUrl: newProvider.apiUrl,
+          apiKey: newProvider.apiKey,
+          providers: {
+            ...settings.providers,
+            [currentProvider.name]: currentProvider,
+          },
+        });
+      } else {
+        setSettings({
+          ...settings,
+          apiUrl: newProvider.apiUrl,
+          apiKey: newProvider.apiKey,
+        });
+      }
+    },
+    [settings, setSettings]
+  );
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} size="lg" finalFocusRef={finalFocusRef}>
       <ModalOverlay />
@@ -163,17 +196,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
           <VStack gap={4}>
             <FormControl>
               <FormLabel>API URL</FormLabel>
-              <Select
-                value={settings.apiUrl}
-                onChange={(e) => {
-                  setSettings({
-                    ...settings,
-                    apiUrl: e.target.value,
-                    apiKey: undefined,
-                    providers: {},
-                  });
-                }}
-              >
+              <Select value={settings.apiUrl} onChange={handleProviderChange}>
                 <option value={OPENAI_API_URL}>OpenAI ({OPENAI_API_URL})</option>
                 <option value={OPENROUTER_API_URL}>OpenRouter.ai ({OPENROUTER_API_URL})</option>
               </Select>
@@ -227,7 +250,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
 
                   setSettings({
                     ...settings,
-                    apiKey: e.target.value,
+                    apiKey: newProvider.apiKey,
                     providers: {
                       ...settings.providers,
                       [newProvider.name]: newProvider,


### PR DESCRIPTION
Closes #345 

### Summary:
Api keys for multiple provider are stored in settings.providers so user can toggle between providers without re-entering api key.

![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/5cbeef17-84c3-42ec-bb21-6ff6dcd7b631)

See previously merged PR https://github.com/tarasglek/chatcraft.org/pull/371 (set up done to make this possible)

### Code changes in this PR:

`src/components/PreferencesModal.tsx`: Modified code of the event handler of the `API URL` dropdown field, so that when users toggle the dropdown:

- we save the old provider key to settings.providers (if it is not there already and if the key is not blank) (this logic is necessary because for old users, their current api info is saved to settings.apiUrl and settings.apiKey but not yet saved to settings.providers)
- then, we check if we have any stored provider key for the newly selected provider in settings.providers and load it if we do

### Ways to test

**New user:** Clear browser cache, enter key, go to Settings, toggle to a different provider, enter another key, toggle back and forth

**Old user:** Copy the following string 

```
{"model":"gpt-3.5-turbo","apiUrl":"https://api.openai.com/v1","temperature":0,"enterBehaviour":"send","countTokens":false,"sidebarVisible":false,"alwaysSendFunctionResult":false,"announceMessages":false,"apiKey":"YOUR_API_KEY"}
```

, replace YOUR_API_KEY with a valid openai key, and paste it in the localStorage, settings field. This will mimic you being a user of ChatCraft that has not logged on since prior to release 1.1. We can use this to test the following:

- we save the old provider key to settings.providers (if it is not there already and if the key is not blank)

Note: the reason we cannot use a new user to test this is because for new users, your provider will be in settings.providers already.

---
Made a separate issue #423 for allowing the API URL dropdown to read from a list of ChatCraftProvider objects
