### PR TITLE
Fix html not syntax highlight

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -42,6 +42,8 @@ const fixLanguageName = (language: string | null) => {
     case "sh":
     case "shell":
       return "bash";
+    case "html":
+      return "htmlbars";
     default:
       return language;
   }

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -43,7 +43,7 @@ const fixLanguageName = (language: string | null) => {
     case "shell":
       return "bash";
     case "html":
-      return "htmlbars";
+      return "xml";
     default:
       return language;
   }


### PR DESCRIPTION
Fixes #429 

This is weird, because I couldn't find the html language from the demo list [react-syntax-highlighter](https://github.com/react-syntax-highlighter/react-syntax-highlighter). Currently I can see it is default use `text` type for the html from developer tools.

I trying to use `htmlbars` to solve this issue.