### PR TITLE
Don't include functions with vision model messages

### DIFF
--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -49,7 +49,9 @@ export class ChatCraftModel {
    * https://platform.openai.com/docs/guides/gpt/function-calling
    */
   get supportsFunctionCalling() {
-    return this.name.startsWith("gpt-3.5-turbo") || this.name.startsWith("gpt-4");
+    const { name } = this;
+    // The OpenAI vision models can't do function calling
+    return !this.supportsImages && (name.startsWith("gpt-3.5-turbo") || name.startsWith("gpt-4"));
   }
 
   get supportsImages() {


### PR DESCRIPTION
Fixes #435 

To trigger the bug without this fix:

- Modify your system prompt to include a function, for example:

```
- @fn-url:https://gist.github.com/humphd/74cf88283239c62f53caff5cddf4cfe5
```

- Add an image
- Send the chat
- Notice the error message about validation errors for `function_call`

Now with this branch, you should be able to do it with or without functions defined.