### PR TITLE
Sidebar Enhancement Reboot

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -382,7 +382,7 @@ function ChatBase({ chat }: ChatBaseProps) {
                 </Text>
                 <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
                   <InputGroup size="sm" variant="outline">
-                    <Input type="search" name="q" isRequired />
+                    <Input type="search" name="q" isRequired placeholder="Search chat history" />
                     <IconButton
                       aria-label="Search"
                       variant="ghost"

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -1,6 +1,24 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Box, Button, Flex, Text, useDisclosure, Grid, GridItem } from "@chakra-ui/react";
-import { ScrollRestoration } from "react-router-dom";
+import {
+  Box,
+  Button,
+  Flex,
+  Text,
+  useDisclosure,
+  Grid,
+  GridItem,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerCloseButton,
+  DrawerHeader,
+  DrawerBody,
+  InputGroup,
+  Input,
+  IconButton,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { Form, ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
 
 import PromptForm from "../components/PromptForm";
@@ -24,6 +42,8 @@ import { useAutoScroll } from "../hooks/use-autoscroll";
 import { useAlert } from "../hooks/use-alert";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import { ChatCraftCommand } from "../lib/ChatCraftCommand";
+import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
+import { TbSearch } from "react-icons/tb";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -294,13 +314,16 @@ function ChatBase({ chat }: ChatBaseProps) {
     resume();
   }
 
+  const isMobile = useMobileBreakpoint();
+  const sidebarColor = useColorModeValue("blue.600", "blue.200");
+
   return (
     <Grid
       w="100%"
       h="100%"
       gridTemplateRows="min-content 1fr min-content"
       gridTemplateColumns={{
-        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
+        base: "0 1fr",
         sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
         md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
       }}
@@ -315,8 +338,45 @@ function ChatBase({ chat }: ChatBaseProps) {
         />
       </GridItem>
 
+      {/* Sidebar */}
       <GridItem rowSpan={2} overflowY="auto">
-        <Sidebar selectedChat={chat} />
+        {isMobile ? (
+          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerHeader>
+                <Text
+                  position={"relative"}
+                  top={-1}
+                  mb={2}
+                  fontSize="lg"
+                  fontWeight="bold"
+                  color={sidebarColor}
+                >
+                  &lt;ChatCraft /&gt;
+                </Text>
+                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
+                  <InputGroup size="sm" variant="outline">
+                    <Input type="search" name="q" isRequired />
+                    <IconButton
+                      aria-label="Search"
+                      variant="ghost"
+                      icon={<TbSearch />}
+                      type="submit"
+                    />
+                  </InputGroup>
+                </Form>
+                <DrawerCloseButton />
+              </DrawerHeader>
+
+              <DrawerBody m={0} p={0}>
+                <Sidebar selectedChat={chat} />
+              </DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        ) : (
+          <Sidebar selectedChat={chat} />
+        )}
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -368,10 +368,11 @@ function ChatBase({ chat }: ChatBaseProps) {
           <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
             <DrawerOverlay />
             <DrawerContent>
-              <DrawerHeader>
+              <DrawerHeader mt={2} p={2}>
                 <Text
                   position={"relative"}
                   top={-1}
+                  ml={2}
                   mb={2}
                   fontSize="lg"
                   fontWeight="bold"

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -17,6 +17,7 @@ import {
   Input,
   IconButton,
   useColorModeValue,
+  keyframes,
 } from "@chakra-ui/react";
 import { Form, ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
@@ -317,6 +318,29 @@ function ChatBase({ chat }: ChatBaseProps) {
   const isMobile = useMobileBreakpoint();
   const sidebarColor = useColorModeValue("blue.600", "blue.200");
 
+  const sidebarOpenAnimationKeyframes = keyframes`
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  `;
+
+  const sidebarCloseAnimationKeyframes = keyframes`
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0);
+    }
+  `;
+
+  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
+  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
+
   return (
     <Grid
       w="100%"
@@ -324,9 +348,9 @@ function ChatBase({ chat }: ChatBaseProps) {
       gridTemplateRows="min-content 1fr min-content"
       gridTemplateColumns={{
         base: "0 1fr",
-        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
+        sm: isSidebarVisible ? "300px 4fr" : "0: 1fr",
       }}
+      transition={"150ms"}
       bgGradient="linear(to-b, white, gray.100)"
       _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
     >
@@ -375,7 +399,12 @@ function ChatBase({ chat }: ChatBaseProps) {
             </DrawerContent>
           </Drawer>
         ) : (
-          <Sidebar selectedChat={chat} />
+          <Box
+            transformOrigin={"left"}
+            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
+          >
+            <Sidebar selectedChat={chat} />
+          </Box>
         )}
       </GridItem>
 

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -162,10 +162,11 @@ export default function Function() {
           <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
             <DrawerOverlay />
             <DrawerContent>
-              <DrawerHeader>
+              <DrawerHeader mt={2} p={2}>
                 <Text
                   position={"relative"}
                   top={-1}
+                  ml={2}
                   mb={2}
                   fontSize="lg"
                   fontWeight="bold"

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -176,7 +176,7 @@ export default function Function() {
                 </Text>
                 <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
                   <InputGroup size="sm" variant="outline">
-                    <Input type="search" name="q" isRequired />
+                    <Input type="search" name="q" isRequired placeholder="Search chat history" />
                     <IconButton
                       aria-label="Search"
                       variant="ghost"

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -14,22 +14,26 @@ import {
   GridItem,
   Heading,
   IconButton,
+  Input,
+  InputGroup,
   Menu,
   MenuButton,
   MenuDivider,
   MenuItem,
   MenuList,
   Text,
+  keyframes,
+  useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
 import debounce from "lodash-es/debounce";
 import { useCallback, useMemo, useRef } from "react";
 import { LuFunctionSquare } from "react-icons/lu";
-import { useFetcher, useLoaderData } from "react-router-dom";
+import { Form, useFetcher, useLoaderData } from "react-router-dom";
 import { useCopyToClipboard } from "react-use";
 
 import { useLiveQuery } from "dexie-react-hooks";
-import { TbDots } from "react-icons/tb";
+import { TbDots, TbSearch } from "react-icons/tb";
 import Header from "../components/Header";
 import Sidebar from "../components/Sidebar";
 import { useAlert } from "../hooks/use-alert";
@@ -51,6 +55,30 @@ export default function Function() {
   });
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
   const isMobile = useMobileBreakpoint();
+  const sidebarColor = useColorModeValue("blue.600", "blue.200");
+
+  const sidebarOpenAnimationKeyframes = keyframes`
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  `;
+
+  const sidebarCloseAnimationKeyframes = keyframes`
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0);
+    }
+  `;
+
+  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
+  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
 
   const func = useLiveQuery<ChatCraftFunction | undefined>(() => {
     if (funcId) {
@@ -118,10 +146,10 @@ export default function Function() {
       h="100%"
       gridTemplateRows="min-content 1fr min-content"
       gridTemplateColumns={{
-        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
+        base: "0 1fr",
+        sm: isSidebarVisible ? "300px 4fr" : "0: 1fr",
       }}
+      transition={"150ms"}
       bgGradient="linear(to-b, white, gray.100)"
       _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
     >
@@ -134,7 +162,28 @@ export default function Function() {
           <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
             <DrawerOverlay />
             <DrawerContent>
-              <DrawerHeader mt={8}>
+              <DrawerHeader>
+                <Text
+                  position={"relative"}
+                  top={-1}
+                  mb={2}
+                  fontSize="lg"
+                  fontWeight="bold"
+                  color={sidebarColor}
+                >
+                  &lt;ChatCraft /&gt;
+                </Text>
+                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
+                  <InputGroup size="sm" variant="outline">
+                    <Input type="search" name="q" isRequired />
+                    <IconButton
+                      aria-label="Search"
+                      variant="ghost"
+                      icon={<TbSearch />}
+                      type="submit"
+                    />
+                  </InputGroup>
+                </Form>
                 <DrawerCloseButton />
               </DrawerHeader>
 
@@ -144,7 +193,12 @@ export default function Function() {
             </DrawerContent>
           </Drawer>
         ) : (
-          <Sidebar selectedFunction={func} />
+          <Box
+            transformOrigin={"left"}
+            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
+          >
+            <Sidebar selectedFunction={func} />
+          </Box>
         )}
       </GridItem>
 

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -1,36 +1,43 @@
-import { useCallback, useMemo, useRef } from "react";
 import {
   Box,
+  Card,
+  CardBody,
+  CardFooter,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
   Flex,
-  useDisclosure,
   Grid,
   GridItem,
   Heading,
-  Card,
-  CardBody,
-  Text,
+  IconButton,
   Menu,
   MenuButton,
-  IconButton,
-  MenuList,
-  MenuItem,
   MenuDivider,
-  CardFooter,
+  MenuItem,
+  MenuList,
+  Text,
+  useDisclosure,
 } from "@chakra-ui/react";
+import debounce from "lodash-es/debounce";
+import { useCallback, useMemo, useRef } from "react";
 import { LuFunctionSquare } from "react-icons/lu";
 import { useFetcher, useLoaderData } from "react-router-dom";
 import { useCopyToClipboard } from "react-use";
-import debounce from "lodash-es/debounce";
 
+import { useLiveQuery } from "dexie-react-hooks";
+import { TbDots } from "react-icons/tb";
 import Header from "../components/Header";
 import Sidebar from "../components/Sidebar";
+import { useAlert } from "../hooks/use-alert";
+import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 import { useSettings } from "../hooks/use-settings";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
-import FunctionEditor from "./FunctionEditor";
-import { TbDots } from "react-icons/tb";
 import { download, formatDate } from "../lib/utils";
-import { useLiveQuery } from "dexie-react-hooks";
-import { useAlert } from "../hooks/use-alert";
+import FunctionEditor from "./FunctionEditor";
 
 export default function Function() {
   const [, copyToClipboard] = useCopyToClipboard();
@@ -43,6 +50,7 @@ export default function Function() {
     defaultIsOpen: settings.sidebarVisible,
   });
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
+  const isMobile = useMobileBreakpoint();
 
   const func = useLiveQuery<ChatCraftFunction | undefined>(() => {
     if (funcId) {
@@ -122,7 +130,22 @@ export default function Function() {
       </GridItem>
 
       <GridItem rowSpan={3} overflowY="auto">
-        <Sidebar selectedFunction={func} />
+        {isMobile ? (
+          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerHeader mt={8}>
+                <DrawerCloseButton />
+              </DrawerHeader>
+
+              <DrawerBody m={0} p={0}>
+                <Sidebar selectedFunction={func} />
+              </DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        ) : (
+          <Sidebar selectedFunction={func} />
+        )}
       </GridItem>
 
       <GridItem overflowY="auto" pos="relative">

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -9,9 +9,18 @@ import {
   Center,
   Card,
   CardBody,
+  Drawer,
+  DrawerOverlay,
+  DrawerContent,
+  DrawerHeader,
+  InputGroup,
+  Input,
+  IconButton,
+  DrawerCloseButton,
+  DrawerBody,
 } from "@chakra-ui/react";
-import { type LoaderFunctionArgs, redirect, useLoaderData } from "react-router-dom";
-import { TbListSearch } from "react-icons/tb";
+import { type LoaderFunctionArgs, redirect, useLoaderData, Form } from "react-router-dom";
+import { TbListSearch, TbSearch } from "react-icons/tb";
 
 import Header from "./components/Header";
 import Sidebar from "./components/Sidebar";
@@ -20,6 +29,7 @@ import Message from "./components/Message";
 import { ChatCraftMessage } from "./lib/ChatCraftMessage";
 import OptionsButton from "./components/OptionsButton";
 import { useSettings } from "./hooks/use-settings";
+import useMobileBreakpoint from "./hooks/use-mobile-breakpoint";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
@@ -73,6 +83,8 @@ export default function Search() {
     setSettings({ ...settings, sidebarVisible: newValue });
   }, [isSidebarVisible, settings, setSettings, toggleSidebarVisible]);
 
+  const isMobile = useMobileBreakpoint();
+
   return (
     <Grid
       w="100%"
@@ -95,7 +107,33 @@ export default function Search() {
       </GridItem>
 
       <GridItem rowSpan={3} overflowY="auto">
-        <Sidebar />
+        {isMobile ? (
+          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
+            <DrawerOverlay />
+            <DrawerContent>
+              <DrawerHeader mt={8}>
+                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
+                  <InputGroup size="sm" variant="outline">
+                    <Input type="search" name="q" isRequired />
+                    <IconButton
+                      aria-label="Search"
+                      variant="ghost"
+                      icon={<TbSearch />}
+                      type="submit"
+                    />
+                  </InputGroup>
+                </Form>
+                <DrawerCloseButton />
+              </DrawerHeader>
+
+              <DrawerBody m={0} p={0}>
+                <Sidebar />
+              </DrawerBody>
+            </DrawerContent>
+          </Drawer>
+        ) : (
+          <Sidebar />
+        )}
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -18,6 +18,9 @@ import {
   IconButton,
   DrawerCloseButton,
   DrawerBody,
+  useColorModeValue,
+  Text,
+  keyframes,
 } from "@chakra-ui/react";
 import { type LoaderFunctionArgs, redirect, useLoaderData, Form } from "react-router-dom";
 import { TbListSearch, TbSearch } from "react-icons/tb";
@@ -84,6 +87,30 @@ export default function Search() {
   }, [isSidebarVisible, settings, setSettings, toggleSidebarVisible]);
 
   const isMobile = useMobileBreakpoint();
+  const sidebarColor = useColorModeValue("blue.600", "blue.200");
+
+  const sidebarOpenAnimationKeyframes = keyframes`
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  `;
+
+  const sidebarCloseAnimationKeyframes = keyframes`
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0);
+    }
+  `;
+
+  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
+  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
 
   return (
     <Grid
@@ -91,10 +118,10 @@ export default function Search() {
       h="100%"
       gridTemplateRows="min-content 1fr min-content"
       gridTemplateColumns={{
-        base: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        sm: isSidebarVisible ? "300px 1fr" : "0 1fr",
-        md: isSidebarVisible ? "minmax(300px, 1fr) 4fr" : "0: 1fr",
+        base: "0 1fr",
+        sm: isSidebarVisible ? "300px 4fr" : "0: 1fr",
       }}
+      transition={"150ms"}
       bgGradient="linear(to-b, white, gray.100)"
       _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
     >
@@ -111,7 +138,17 @@ export default function Search() {
           <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
             <DrawerOverlay />
             <DrawerContent>
-              <DrawerHeader mt={8}>
+              <DrawerHeader>
+                <Text
+                  position={"relative"}
+                  top={-1}
+                  mb={2}
+                  fontSize="lg"
+                  fontWeight="bold"
+                  color={sidebarColor}
+                >
+                  &lt;ChatCraft /&gt;
+                </Text>
                 <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
                   <InputGroup size="sm" variant="outline">
                     <Input type="search" name="q" isRequired />
@@ -132,7 +169,12 @@ export default function Search() {
             </DrawerContent>
           </Drawer>
         ) : (
-          <Sidebar />
+          <Box
+            transformOrigin={"left"}
+            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
+          >
+            <Sidebar />
+          </Box>
         )}
       </GridItem>
 

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -152,7 +152,13 @@ export default function Search() {
                 </Text>
                 <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
                   <InputGroup size="sm" variant="outline">
-                    <Input type="search" name="q" isRequired />
+                    <Input
+                      type="search"
+                      defaultValue={searchText}
+                      name="q"
+                      isRequired
+                      placeholder="Search chat history"
+                    />
                     <IconButton
                       aria-label="Search"
                       variant="ghost"

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -138,10 +138,11 @@ export default function Search() {
           <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
             <DrawerOverlay />
             <DrawerContent>
-              <DrawerHeader>
+              <DrawerHeader mt={2} p={2}>
                 <Text
                   position={"relative"}
                   top={-1}
+                  ml={2}
                   mb={2}
                   fontSize="lg"
                   fontWeight="bold"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,7 +92,13 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
         {!isMobile && (
           <Form action="/s" method="get">
             <InputGroup size="sm" variant="outline">
-              <Input type="search" name="q" defaultValue={searchText} isRequired />
+              <Input
+                type="search"
+                name="q"
+                defaultValue={searchText}
+                isRequired
+                placeholder="Search chat history"
+              />
               <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
             </InputGroup>
           </Form>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -26,6 +26,7 @@ import { Form } from "react-router-dom";
 import PreferencesModal from "./PreferencesModal";
 import DefaultSystemPromptModal from "./DefaultSystemPromptModal";
 import { useUser } from "../hooks/use-user";
+import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 
 type HeaderProps = {
   chatId?: string;
@@ -55,6 +56,8 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       login(chatId);
     }
   }, [chatId, user, login, logout]);
+
+  const isMobile = useMobileBreakpoint();
 
   return (
     <Flex
@@ -86,18 +89,14 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       </Flex>
 
       <Box flex={1} maxW="500px">
-        <Form action="/s" method="get">
-          <InputGroup size="sm" variant="outline">
-            <Input
-              type="search"
-              name="q"
-              defaultValue={searchText}
-              isRequired
-              placeholder="Search chat history"
-            />
-            <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
-          </InputGroup>
-        </Form>
+        {!isMobile && (
+          <Form action="/s" method="get">
+            <InputGroup size="sm" variant="outline">
+              <Input type="search" name="q" defaultValue={searchText} isRequired />
+              <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
+            </InputGroup>
+          </Form>
+        )}
       </Box>
 
       <ButtonGroup isAttached pr={2} alignItems="center">


### PR DESCRIPTION
Pull Request #300 has been open for a while, and since then a lot of our preferences have changed regarding sidebar.

I really wanted to get it done, but would have been really difficult to continue on that branch. 

Which is why, I have **redone** the sidebar enhancement from scratch.

1. As per our discussion, the overlay effect is only applied to mobile devices now and I am using **Chakra** [Drawer](https://chakra-ui.com/docs/components/drawer/usage) for that.
2. I have also moved the **search field** to the sidebar on mobile devices due to lack of real estate in the header.
3. The behaviour on desktop remains the same, except I have added a few animations to make the **push content** effect smoother.
4. I also made sure there is no redundant animation on page reloads as it was one of the problems in last PR.
5. The Pin Sidebar feature has also been removed

Here's how it looks:

**On Desktop:**
![SidebarRebootDesktop](https://github.com/tarasglek/chatcraft.org/assets/78865303/dfaa70e8-dbbe-4ce1-8035-e77b75937b85)

**On Mobile:**
![SidebarRebootMobile](https://github.com/tarasglek/chatcraft.org/assets/78865303/f64707d2-1c1e-459f-bdaf-c7430aabda17)

**Breakpoint:**
![SidebarRebootBreakpoint](https://github.com/tarasglek/chatcraft.org/assets/78865303/2dfa6aa9-eeeb-46df-b965-4a1725144900)


This fixes #299 