### PR TITLE
Handle paste with text and images, preferring text

### DIFF
--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -147,11 +147,11 @@ function DesktopPromptForm({
   useEffect(() => {
     const textAreaElement = inputPromptRef.current;
     if (textAreaElement) {
-      textAreaElement.addEventListener("paste", handlePasteImage);
+      textAreaElement.addEventListener("paste", handlePaste);
     }
     return () => {
       if (textAreaElement) {
-        textAreaElement.removeEventListener("paste", handlePasteImage);
+        textAreaElement.removeEventListener("paste", handlePaste);
       }
     };
     // eslint-disable-next-line
@@ -263,13 +263,36 @@ function DesktopPromptForm({
   };
   const closeModal = () => setImageModalOpen(false);
 
-  const handlePasteImage = (e: ClipboardEvent) => {
-    const clipboardData = e.clipboardData;
+  const handlePaste = (e: ClipboardEvent) => {
+    const { clipboardData } = e;
+    if (!clipboardData) {
+      return;
+    }
+
+    // See if we have meaningful text. Some apps will place multiple versions in
+    // the clipboard. For example, MS Word will include text/plain, text/html,
+    // text/rtf, and finally image/png. Each is a different version that tries to
+    // preserve formatting (the image is a bitmap of the formatted text). If we
+    // have a usable text version, but also an image, we should prefer the text
+    // over images. The most common are text, html, or uri-list.
+    if (
+      clipboardData.getData("text/plain") !== "" ||
+      clipboardData.getData("text/html") !== "" ||
+      clipboardData.getData("text/uri-list") !== ""
+    ) {
+      return;
+    }
+
+    // Maybe there is an image we can use
     const items = Array.from(clipboardData?.items || []);
     const imageFiles = items
+      .filter((item) => item.kind === "file" && item.type.startsWith("image/"))
       .map((item) => item.getAsFile())
-      .filter((file): file is File => file != null && file.type.startsWith("image/"));
-    if (imageFiles.length > 0) {
+      .filter((file): file is File => file != null);
+
+    if (imageFiles.length) {
+      // Handle the clipboard contents here instead, creating image URLs
+      e.preventDefault();
       Promise.all(imageFiles.map((file) => getBase64FromFile(file)))
         .then((base64Strings) => {
           setInputImageUrls((prevImageUrls) => [...prevImageUrls, ...base64Strings]);
@@ -282,6 +305,8 @@ function DesktopPromptForm({
           });
         });
     }
+
+    // Otherwise, let the default paste handling happen
   };
 
   return (


### PR DESCRIPTION
My daughter ran into an interesting bug with our new image handling:

- copy text from an MS Word document
- paste into ChatCraft
- notice an image is added vs. text

In researching what is happening here, I learned that when you copy text in MS Word, it puts 4 things on the clipboard (i.e., 4 representations of the same text):

- text/plain
- text/html
- text/rtf
- image/png

The final `image/png` is a bitmap of the formatted text.  I guess the idea is to try to maintain the formatting on the text, even if it has to be rendered into an image!

The result is that it's impossible to paste text when there's an image representation also in the same clipboard data.

I've updated our paste handling for the prompt form so that it prefers text if the text is available.  If you copy an image, we'll only have the image, so that will get used.

I've also added `e.preventDefault()` to the image handling case so that we use our custom handler; however, in the case of text, we let it fall through and do the default thing (e.g. pasting the text).

