### PR TITLE
Fix viewport pushed by switching chats

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -155,7 +155,7 @@ function OptionsButton({
   }, [chat, fetcher]);
 
   return (
-    <Menu>
+    <Menu strategy="fixed">
       {iconOnly ? (
         <MenuButton
           isDisabled={isDisabled}


### PR DESCRIPTION
This fixes #442 

Just re-read my blog post for the solution
https://dev.to/amnish04/no-backing-away-when-hacking-away-2h27

When the page is loaded and the options menu is never opened, the menu list is overflowing below the visible page, effectively creating hidden scrollbars.
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/34d92008-4fc2-4660-a3c6-24ce94b76ada)

The view is fixed when you open the menu at least once
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/7b34f626-fa88-4070-a8af-d3a1f84dfbc6)


But setting the position to fixed eliminates the issue altogether
