### PR TITLE
Search Bar Placeholder Text

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,7 +93,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
               name="q"
               defaultValue={searchText}
               isRequired
-              placeholder="Search"
+              placeholder="Search chat history"
             />
             <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
           </InputGroup>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -93,7 +93,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
               name="q"
               defaultValue={searchText}
               isRequired
-              placeholder="Enter keywords to search"
+              placeholder="Search"
             />
             <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
           </InputGroup>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -88,7 +88,13 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       <Box flex={1} maxW="500px">
         <Form action="/s" method="get">
           <InputGroup size="sm" variant="outline">
-            <Input type="search" name="q" defaultValue={searchText} isRequired />
+            <Input
+              type="search"
+              name="q"
+              defaultValue={searchText}
+              isRequired
+              placeholder="Enter keywords to search"
+            />
             <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
           </InputGroup>
         </Form>


### PR DESCRIPTION
Summary
---
Task of #439 

This fixes #447 

This adds placeholder text to the searchbar:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/10292cec-008a-47a8-81a3-778bdd629670)

Concerns
---
PR https://github.com/tarasglek/chatcraft.org/pull/437 adds additional search bar renders, which may also require placeholder text.

@Amnish04, I think I'll update this PR once #437 lands. Or, would it be better to add placeholder text in your PR?
@humphd which approach would be better?
