### PR TITLE
Created list of supported ChatCraftProviders

### DIFF
--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -36,8 +36,8 @@ import { download, isMac } from "../lib/utils";
 import db from "../lib/db";
 import { useModels } from "../hooks/use-models";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import { ChatCraftProvider } from "../lib/ChatCraftProvider";
-import { OPENAI_API_URL, OPENROUTER_API_URL } from "../lib/settings";
+import { ChatCraftProvider, supportedProviders } from "../lib/ChatCraftProvider";
+import { OPENAI_API_URL } from "../lib/settings";
 import { openRouterPkceRedirect, usingOfficialOpenAI, validateApiKey } from "../lib/ai";
 import { useAlert } from "../hooks/use-alert";
 
@@ -197,8 +197,11 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
             <FormControl>
               <FormLabel>API URL</FormLabel>
               <Select value={settings.apiUrl} onChange={handleProviderChange}>
-                <option value={OPENAI_API_URL}>OpenAI ({OPENAI_API_URL})</option>
-                <option value={OPENROUTER_API_URL}>OpenRouter.ai ({OPENROUTER_API_URL})</option>
+                {Object.values(supportedProviders).map((provider) => (
+                  <option key={provider.apiUrl} value={provider.apiUrl}>
+                    {provider.name} ({provider.apiUrl})
+                  </option>
+                ))}
               </Select>
               <FormHelperText>
                 Advanced option for use with other OpenAI-compatible APIs

--- a/src/lib/ChatCraftProvider.ts
+++ b/src/lib/ChatCraftProvider.ts
@@ -10,6 +10,10 @@ const urlToNameMap: { [key: string]: ProviderName } = {
   [OPENROUTER_API_URL]: "OpenRouter.ai",
 };
 
+export interface ProviderData {
+  [key: string]: ChatCraftProvider;
+}
+
 export type SerializedChatCraftProvider = {
   id: string;
   name: ProviderName;
@@ -43,3 +47,9 @@ export class ChatCraftProvider {
     return provider;
   }
 }
+
+// Currently supported providers
+export const supportedProviders: ProviderData = {
+  OpenAI: new ChatCraftProvider(OPENAI_API_URL),
+  "OpenRouter.ai": new ChatCraftProvider(OPENROUTER_API_URL),
+};

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,17 +6,13 @@
  * when you only need to read something.
  */
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import { ChatCraftProvider } from "../lib/ChatCraftProvider";
+import { ProviderData } from "../lib/ChatCraftProvider";
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
  */
 export const OPENAI_API_URL = "https://api.openai.com/v1";
 export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
-
-interface ProviderData {
-  [key: string]: ChatCraftProvider;
-}
 
 export type Settings = {
   apiKey?: string;


### PR DESCRIPTION
Closes #423 

### Summary:
- Settings `API URL` field now displays list of `supportedProviders` which is stored in `ChatCraftProvider.ts`

![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/5cbeef17-84c3-42ec-bb21-6ff6dcd7b631)

### Code changes in this PR:

`src/components/PreferencesModal.tsx`:

- Modified code of the event handler of the `API URL` dropdown field, so that it iterates through the list of `supportedProviders`

`src/lib/ChatCraftProvider.ts`: 

- Moved `ProviderData` (associative array of ChatCraftProvider) from `src/lib/settings.ts` to `src/lib/ChatCraftProvider.ts` since it is something that is solely used by settings
- Added `supportedProviders` (list of currently supported providers)

 `src/lib/settings.ts`:

- Moved `ProviderData` out of this file, see above explanation