### PR TITLE
Improve audio record button

### DIFF
--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -108,7 +108,7 @@ export default function MicIcon({
   };
 
   return (
-    <Tooltip label={isRecording ? "Stop Recording" : "Start Recording"}>
+    <Tooltip label={isRecording ? "Finish Recording" : "Start Recording"}>
       <IconButton
         isRound
         isDisabled={isDisabled}

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -115,7 +115,8 @@ export default function MicIcon({
         icon={<TbMicrophone />}
         variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
         aria-label="Record speech"
-        size={isMobile ? "lg" : "md"}
+        size={isRecording ? "lg" : "md"}
+        transition={"all 150ms ease-in-out"}
         fontSize="18px"
         ref={micIconRef}
         onClick={handleMicToggle}

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -114,6 +114,7 @@ export default function MicIcon({
         isDisabled={isDisabled}
         icon={<TbMicrophone />}
         variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
+        colorScheme={isRecording ? "red" : "blue"}
         aria-label="Record speech"
         size={isRecording ? "lg" : "md"}
         transition={"all 150ms ease-in-out"}

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from "@chakra-ui/react";
+import { IconButton, Tooltip } from "@chakra-ui/react";
 import { useRef, useState } from "react";
 import { TbMicrophone } from "react-icons/tb";
 
@@ -108,17 +108,19 @@ export default function MicIcon({
   };
 
   return (
-    <IconButton
-      isRound
-      isDisabled={isDisabled}
-      icon={<TbMicrophone />}
-      variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
-      aria-label="Record speech"
-      size={isMobile ? "lg" : "md"}
-      fontSize="18px"
-      ref={micIconRef}
-      onClick={handleMicToggle}
-      onBlur={() => onRecordingCancel()}
-    />
+    <Tooltip label={isRecording ? "Stop Recording" : "Start Recording"}>
+      <IconButton
+        isRound
+        isDisabled={isDisabled}
+        icon={<TbMicrophone />}
+        variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
+        aria-label="Record speech"
+        size={isMobile ? "lg" : "md"}
+        fontSize="18px"
+        ref={micIconRef}
+        onClick={handleMicToggle}
+        onBlur={() => onRecordingCancel()}
+      />
+    </Tooltip>
   );
 }


### PR DESCRIPTION
As requested in #369, I have added a tooltip to the mic button indicating the use to either start or stop recording.

When not Recording:
<img width="226" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/78865303/99d0a59d-e850-47e7-a3dd-ffb1ed470ff1">

When not Recording:
<img width="321" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/78865303/81797bfc-3a9d-46fd-9053-3b61ebb577aa">

**Transition:**
![MicAnimation](https://github.com/tarasglek/chatcraft.org/assets/78865303/be77367e-7604-4950-af14-77e6fb3e94fb)

I tried to find a way to add the animation that @tarasglek suggested, but couldn't find a free and convenient way for that.
https://www.shutterstock.com/video/clip-1071785533-microphone-signal-animated-icon-animation-4k-green

This closes #413 
