### PR TITLE
Shorten mobile placeholder

### DIFF
--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -223,7 +223,7 @@ function MobilePromptForm({
                 bg="white"
                 _dark={{ bg: "gray.700" }}
                 overflowY="auto"
-                placeholder="Ask a question"
+                placeholder="Ask about..."
                 mb={1}
               />
             )}


### PR DESCRIPTION
Playing with the new GPT-4 Vision on Mobile tonight, and I can't stand the word-wrapping on the placeholder for the input.

I'm sure we'll fix this in a better way later, but this improves things a bit:

<img width="403" alt="Screenshot 2024-02-14 at 8 56 54 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/fa4ee9c2-879f-43a5-b211-578b1ecdb396">
