### PR TITLE
Add: Resize the image size to meet OpenAI requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@emotion/styled": "^11.11.0",
     "@szhsin/react-menu": "^4.1.0",
     "@uiw/react-codemirror": "^4.21.21",
+    "browser-image-compression": "^2.0.2",
     "compromise": "^14.11.2",
     "cookie": "^0.6.0",
     "dexie": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   '@uiw/react-codemirror':
     specifier: ^4.21.21
     version: 4.21.21(@babel/runtime@7.23.2)(@codemirror/autocomplete@6.10.2)(@codemirror/language@6.9.1)(@codemirror/lint@6.4.2)(@codemirror/search@6.5.4)(@codemirror/state@6.3.1)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.21.3)(codemirror@6.0.1)(react-dom@18.2.0)(react@18.2.0)
+  browser-image-compression:
+    specifier: ^2.0.2
+    version: 2.0.2
   compromise:
     specifier: ^14.11.2
     version: 14.11.2
@@ -4634,6 +4637,12 @@ packages:
   /brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
     dev: true
+
+  /browser-image-compression@2.0.2:
+    resolution: {integrity: sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==}
+    dependencies:
+      uzip: 0.20201231.0
+    dev: false
 
   /browser-resolve@2.0.0:
     resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
@@ -10307,6 +10316,10 @@ packages:
       diff: 5.1.0
       kleur: 4.1.5
       sade: 1.8.1
+    dev: false
+
+  /uzip@0.20201231.0:
+    resolution: {integrity: sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==}
     dev: false
 
   /validate-npm-package-name@4.0.0:

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -22,7 +22,7 @@ import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { useUser } from "../hooks/use-user";
 import { useAlert } from "../hooks/use-alert";
 import ShareModal from "./ShareModal";
-import { download } from "../lib/utils";
+import { download, imageCompressionOptions } from "../lib/utils";
 
 function ShareMenuItem({ chat }: { chat?: ChatCraftChat }) {
   const supportsWebShare = !!navigator.share;
@@ -105,13 +105,6 @@ function OptionsButton({
 
       const files = event.target.files;
 
-      const imageCompressionOptions = {
-        maxSizeMB: 20,
-        maxWidthOrHeight: 2048,
-        useWebWorker: true,
-      };
-
-      // Helper function
       const readFile = (file: File) => {
         const reader = new FileReader();
         reader.onload = (e) => {
@@ -123,12 +116,7 @@ function OptionsButton({
       if (files) {
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
-          if (
-            file.type.startsWith("image/") &&
-            // Make sure image's size is within 20MB
-            // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
-            file.size > imageCompressionOptions.maxSizeMB * 1024 * 1024
-          ) {
+          if (file.type.startsWith("image/")) {
             imageCompression(file, imageCompressionOptions)
               .then((compressedFile) => readFile(compressedFile))
               .catch((err) => {

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -106,7 +106,7 @@ function OptionsButton({
       const files = event.target.files;
 
       const imageCompressionOptions = {
-        maxSizeMB: 20,
+        maxSizeMB: 2,
         maxWidthOrHeight: 2048,
         useWebWorker: true,
       };
@@ -123,21 +123,18 @@ function OptionsButton({
       if (files) {
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
-          if (file.type.startsWith("image/")) {
+          if (
+            file.type.startsWith("image/") &&
             // Make sure image's size is within 20MB
             // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
-            if (file.size > imageCompressionOptions.maxSizeMB * 1024 * 1024) {
-              imageCompression(file, imageCompressionOptions)
-                .then((compressedFile) => {
-                  return readFile(compressedFile);
-                })
-                .catch((err) => {
-                  console.error(err);
-                  error({ title: "Unable to share chat", message: err.message });
-                });
-            } else {
-              readFile(file);
-            }
+            file.size > imageCompressionOptions.maxSizeMB * 1024 * 1024
+          ) {
+            imageCompression(file, imageCompressionOptions)
+              .then((compressedFile) => readFile(compressedFile))
+              .catch((err) => {
+                console.error(err);
+                error({ title: "Unable to share chat", message: err.message });
+              });
           } else {
             readFile(file);
           }

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -117,6 +117,8 @@ function OptionsButton({
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
           if (file.type.startsWith("image/")) {
+            // Make sure image's size is within 20MB and 2048x2048 resolution
+            // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
             imageCompression(file, imageCompressionOptions)
               .then((compressedFile) => readFile(compressedFile))
               .catch((err) => {

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -106,7 +106,7 @@ function OptionsButton({
       const files = event.target.files;
 
       const imageCompressionOptions = {
-        maxSizeMB: 2,
+        maxSizeMB: 20,
         maxWidthOrHeight: 2048,
         useWebWorker: true,
       };

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -16,7 +16,7 @@ import imageCompression from "browser-image-compression";
 import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
-import { getMetaKey } from "../../lib/utils";
+import { getMetaKey, imageCompressionOptions } from "../../lib/utils";
 import { TiDeleteOutline } from "react-icons/ti";
 import OptionsButton from "../OptionsButton";
 import MicIcon from "./MicIcon";
@@ -223,40 +223,23 @@ function DesktopPromptForm({
   };
 
   const getBase64FromFile = (file: File): Promise<string> => {
-    const imageCompressionOptions = {
-      maxSizeMB: 20,
-      maxWidthOrHeight: 2048,
-      useWebWorker: true,
-    };
-
     return new Promise((resolve) => {
-      // Make sure image's size is within 20MB
-      // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
-      if (file.size > imageCompressionOptions.maxSizeMB * 1024 * 1024) {
-        imageCompression(file, imageCompressionOptions)
-          .then((compressedFile) => {
-            const reader = new FileReader();
-            reader.readAsDataURL(compressedFile);
-            reader.onloadend = () => {
-              const base64data = reader.result as string;
-              resolve(base64data);
-            };
-          })
-          .catch((err) => {
-            console.error("Error processing images", err);
-            error({
-              title: "Error Processing Images",
-              message: err.message,
-            });
+      imageCompression(file, imageCompressionOptions)
+        .then((compressedFile) => {
+          const reader = new FileReader();
+          reader.readAsDataURL(compressedFile);
+          reader.onloadend = () => {
+            const base64data = reader.result as string;
+            resolve(base64data);
+          };
+        })
+        .catch((err) => {
+          console.error("Error processing images", err);
+          error({
+            title: "Error Processing Images",
+            message: err.message,
           });
-      } else {
-        const reader = new FileReader();
-        reader.readAsDataURL(file);
-        reader.onloadend = () => {
-          const base64data = reader.result as string;
-          resolve(base64data);
-        };
-      }
+        });
     });
   };
 

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -224,6 +224,8 @@ function DesktopPromptForm({
 
   const getBase64FromFile = (file: File): Promise<string> => {
     return new Promise((resolve) => {
+      // Make sure image's size is within 20MB and 2048x2048 resolution
+      // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
       imageCompression(file, imageCompressionOptions)
         .then((compressedFile) => {
           const reader = new FileReader();

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -83,3 +83,10 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
         })
     );
 };
+
+// Make sure image's size is within 20MB and 2048x2048 resolution
+// https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
+export const imageCompressionOptions = {
+  maxSizeMB: 20,
+  maxWidthOrHeight: 2048,
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -86,11 +86,12 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
 
 // Make sure image's size is within 20MB and 2048x2048 resolution
 // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
-export const imageCompressionOptions = {
-  maxSizeMB: 20,
-  maxWidthOrHeight: 2048,
-};
 export const compressImageToBase64 = (file: File): Promise<string> => {
+  const imageCompressionOptions = {
+    maxSizeMB: 20,
+    maxWidthOrHeight: 2048,
+  };
+
   return import("browser-image-compression")
     .then((imageCompressionModule) => {
       const imageCompression = imageCompressionModule.default;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,8 +84,6 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
     );
 };
 
-// Make sure image's size is within 20MB and 2048x2048 resolution
-// https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
 export const imageCompressionOptions = {
   maxSizeMB: 20,
   maxWidthOrHeight: 2048,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,7 +84,33 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
     );
 };
 
+// Make sure image's size is within 20MB and 2048x2048 resolution
+// https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
 export const imageCompressionOptions = {
   maxSizeMB: 20,
   maxWidthOrHeight: 2048,
+};
+export const compressImageToBase64 = (file: File): Promise<string> => {
+  return import("browser-image-compression")
+    .then((imageCompressionModule) => {
+      const imageCompression = imageCompressionModule.default;
+      return imageCompression(file, imageCompressionOptions);
+    })
+    .then((compressedFile: File) => {
+      return new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.readAsDataURL(compressedFile);
+        reader.onloadend = () => {
+          const base64data = reader.result as string;
+          resolve(base64data);
+        };
+        reader.onerror = (error) => {
+          reject(error);
+        };
+      });
+    })
+    .catch((err) => {
+      console.error("Error processing images", err);
+      throw err;
+    });
 };


### PR DESCRIPTION
## Explanation

This updates make sure users' input image's size is within OpenAI [GPT-4V](https://openai.com/research/gpt-4v-system-card) limit.

The OpenAI requirements for images can be found at [Is there a limit to the size of the image I can upload?](https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload)
 > Yes, we restrict image uploads to 20MB per image.

And [Calculating costs](https://platform.openai.com/docs/guides/vision/calculating-costs)
> `detail: high` images are first scaled to fit within a 2048 x 2048 square, maintaining their aspect ratio. 

I found this tool [browser-image-compression](https://github.com/Donaldcwl/browser-image-compression) focus on the image compression in web browser is great to handle it, supports both file size and px constraints.

I set the values in imageCompressionOptions as:
```
      const imageCompressionOptions = {
        maxSizeMB: 20,
        maxWidthOrHeight: 2048,
        useWebWorker: true,
      };
```

The `useWebWorker` is optional, means the tool will use multi-thread web worker for the compression, fallback to run in main-thread (default: `true`). Although it is default `true`, I added it to align with the document's [Usage](https://github.com/Donaldcwl/browser-image-compression?tab=readme-ov-file#usage)

## How to test

Use some large size image in the prompt, I got a 30MB image from [here](https://sample-videos.com/download-sample-jpg-image.php)

Before

<img width="874" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/b3a6d583-8182-4e86-9f30-42cc4f874d66">

After

![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/0901e34a-26e4-49c7-a811-2783f24fafea)

Fixes #395 https://github.com/tarasglek/chatcraft.org/issues/465
