### PR TITLE
Add twitter card metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="chatcraft.org" />
     <meta property="og:description" content="Web-based AI Assistant for Software Developers" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="chatcraft.org" />
+    <meta name="twitter:description" content="Web-based AI Assistant for Software Developers" />
+    <meta name="twitter:image" content="https://chatcraft.org/favicon-32x32.png" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="chatcraft.org" />
     <meta property="og:description" content="Web-based AI Assistant for Software Developers" />
-    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="chatcraft.org" />
     <meta name="twitter:description" content="Web-based AI Assistant for Software Developers" />
     <meta name="twitter:image" content="https://chatcraft.org/favicon-32x32.png" />

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <meta name="og:site_name" content="chatcraft.org" />
     <meta property="og:image" content="https://chatcraft.org/favicon-32x32.png" />
     <meta property="og:url" content="https://chatcraft.org" />
+    <meta property="og:type" content="website" />
     <meta property="og:title" content="chatcraft.org" />
     <meta property="og:description" content="Web-based AI Assistant for Software Developers" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -59,7 +59,18 @@ function generateSharingHTML(chat: ChatCraftChat, user: User) {
   // Set various types of titles/summaries
   setMetaContent(clonedDocument, "property", "og:title", chat.summary);
   setMetaContent(clonedDocument, "property", "og:url", createShareUrl(chat, user));
+  setMetaContent(clonedDocument, "property", "og:type", "website");
   setMetaContent(clonedDocument, "name", "description", chat.summary);
+  setMetaContent(clonedDocument, "name", "twitter:card", "summary_large_image");
+  setMetaContent(clonedDocument, "name", "twitter:title", "chatcraft.org");
+  setMetaContent(clonedDocument, "name", "twitter:description", chat.summary);
+  setMetaContent(
+    clonedDocument,
+    "name",
+    "twitter:image",
+    "https://chatcraft.org/favicon-32x32.png"
+  );
+
   setDocumentTitle(clonedDocument, chat.summary);
   // Set OG bulk text to be that of last message
   if (lastMessageText) {


### PR DESCRIPTION
This fixes #432.

Summary
---
- Added an `og:type` property.
From https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/markup,
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/fd5e3b40-f204-422e-90b8-ad660b13c35e)
A Twitter Summary card can be rendered if an `og:type`, `og:title` and `og:description` exist but not `twitter:card`, but I ended up also adding required Twitter meta tags for robustness.
- added Twitter meta tags required to render a Summary Card w/ Image

Testing Requirements?
---
I am going to run the generated preview against the [Twitter Card Validator](https://cards-dev.twitter.com/validator).
I hope the validator can test the preview website

