### PR TITLE
Replaced padding to use relative value

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -320,7 +320,7 @@ function ChatBase({ chat }: ChatBaseProps) {
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">
-        <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px={1}>
+        <Flex direction="column" h="100%" maxH="100%" maxW="900px" mx="auto" px="0.9%">
           {
             /* Show a "Follow Chat" button if the user breaks auto scroll during loading */
             !!scrollProgress && !shouldAutoScroll && (


### PR DESCRIPTION
- @Amnish04 and I noticed that the alignment was perfect on a 13 inch macbook whereas was wrong in a monitor of a bigger size.
- Changed padding value to use relative % so that it should adjust according to screen width.

