### PR TITLE
Pack Sidebar in its own module

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -1,51 +1,30 @@
+import { Box, Button, Flex, Grid, GridItem, Text, useDisclosure } from "@chakra-ui/react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import {
-  Box,
-  Button,
-  Flex,
-  Text,
-  useDisclosure,
-  Grid,
-  GridItem,
-  Drawer,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerCloseButton,
-  DrawerHeader,
-  DrawerBody,
-  InputGroup,
-  Input,
-  IconButton,
-  useColorModeValue,
-  keyframes,
-} from "@chakra-ui/react";
-import { Form, ScrollRestoration } from "react-router-dom";
 import { CgArrowDownO } from "react-icons/cg";
+import { ScrollRestoration } from "react-router-dom";
 
-import PromptForm from "../components/PromptForm";
-import MessagesView from "../components/MessagesView";
 import Header from "../components/Header";
+import MessagesView from "../components/MessagesView";
+import OptionsButton from "../components/OptionsButton";
+import PromptForm from "../components/PromptForm";
 import Sidebar from "../components/Sidebar";
+import { useAlert } from "../hooks/use-alert";
+import useAudioPlayer from "../hooks/use-audio-player";
+import { useAutoScroll } from "../hooks/use-autoscroll";
 import useChatOpenAI from "../hooks/use-chat-openai";
+import { useModels } from "../hooks/use-models";
+import { useSettings } from "../hooks/use-settings";
+import { useUser } from "../hooks/use-user";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { ChatCraftCommand } from "../lib/ChatCraftCommand";
+import { ChatCraftFunction } from "../lib/ChatCraftFunction";
 import {
   ChatCraftFunctionCallMessage,
   ChatCraftFunctionResultMessage,
   ChatCraftHumanMessage,
 } from "../lib/ChatCraftMessage";
-import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { useUser } from "../hooks/use-user";
-import OptionsButton from "../components/OptionsButton";
-import { useSettings } from "../hooks/use-settings";
-import { useModels } from "../hooks/use-models";
-import ChatHeader from "./ChatHeader";
-import { ChatCraftFunction } from "../lib/ChatCraftFunction";
-import { useAutoScroll } from "../hooks/use-autoscroll";
-import { useAlert } from "../hooks/use-alert";
 import { ChatCraftCommandRegistry } from "../lib/commands";
-import { ChatCraftCommand } from "../lib/ChatCraftCommand";
-import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
-import { TbSearch } from "react-icons/tb";
-import useAudioPlayer from "../hooks/use-audio-player";
+import ChatHeader from "./ChatHeader";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -319,32 +298,6 @@ function ChatBase({ chat }: ChatBaseProps) {
     resume();
   }
 
-  const isMobile = useMobileBreakpoint();
-  const sidebarColor = useColorModeValue("blue.600", "blue.200");
-
-  const sidebarOpenAnimationKeyframes = keyframes`
-    from {
-      opacity: 0;
-    }
-
-    to {
-      opacity: 1;
-    }
-  `;
-
-  const sidebarCloseAnimationKeyframes = keyframes`
-    from {
-      transform: scaleX(1);
-    }
-
-    to {
-      transform: scaleX(0);
-    }
-  `;
-
-  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
-  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
-
   return (
     <Grid
       w="100%"
@@ -368,49 +321,11 @@ function ChatBase({ chat }: ChatBaseProps) {
 
       {/* Sidebar */}
       <GridItem rowSpan={2} overflowY="auto">
-        {isMobile ? (
-          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
-            <DrawerOverlay />
-            <DrawerContent>
-              <DrawerHeader mt={2} p={2}>
-                <Text
-                  position={"relative"}
-                  top={-1}
-                  ml={2}
-                  mb={2}
-                  fontSize="lg"
-                  fontWeight="bold"
-                  color={sidebarColor}
-                >
-                  &lt;ChatCraft /&gt;
-                </Text>
-                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
-                  <InputGroup size="sm" variant="outline">
-                    <Input type="search" name="q" isRequired placeholder="Search chat history" />
-                    <IconButton
-                      aria-label="Search"
-                      variant="ghost"
-                      icon={<TbSearch />}
-                      type="submit"
-                    />
-                  </InputGroup>
-                </Form>
-                <DrawerCloseButton />
-              </DrawerHeader>
-
-              <DrawerBody m={0} p={0}>
-                <Sidebar selectedChat={chat} />
-              </DrawerBody>
-            </DrawerContent>
-          </Drawer>
-        ) : (
-          <Box
-            transformOrigin={"left"}
-            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
-          >
-            <Sidebar selectedChat={chat} />
-          </Box>
-        )}
+        <Sidebar
+          selectedChat={chat}
+          isSidebarVisible={isSidebarVisible}
+          handleToggleSidebarVisible={handleToggleSidebarVisible}
+        ></Sidebar>
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -3,41 +3,30 @@ import {
   Card,
   CardBody,
   CardFooter,
-  Drawer,
-  DrawerBody,
-  DrawerCloseButton,
-  DrawerContent,
-  DrawerHeader,
-  DrawerOverlay,
   Flex,
   Grid,
   GridItem,
   Heading,
   IconButton,
-  Input,
-  InputGroup,
   Menu,
   MenuButton,
   MenuDivider,
   MenuItem,
   MenuList,
   Text,
-  keyframes,
-  useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
 import debounce from "lodash-es/debounce";
 import { useCallback, useMemo, useRef } from "react";
 import { LuFunctionSquare } from "react-icons/lu";
-import { Form, useFetcher, useLoaderData } from "react-router-dom";
+import { useFetcher, useLoaderData } from "react-router-dom";
 import { useCopyToClipboard } from "react-use";
 
 import { useLiveQuery } from "dexie-react-hooks";
-import { TbDots, TbSearch } from "react-icons/tb";
+import { TbDots } from "react-icons/tb";
 import Header from "../components/Header";
 import Sidebar from "../components/Sidebar";
 import { useAlert } from "../hooks/use-alert";
-import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 import { useSettings } from "../hooks/use-settings";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
 import { download, formatDate } from "../lib/utils";
@@ -54,31 +43,6 @@ export default function Function() {
     defaultIsOpen: settings.sidebarVisible,
   });
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
-  const isMobile = useMobileBreakpoint();
-  const sidebarColor = useColorModeValue("blue.600", "blue.200");
-
-  const sidebarOpenAnimationKeyframes = keyframes`
-    from {
-      opacity: 0;
-    }
-
-    to {
-      opacity: 1;
-    }
-  `;
-
-  const sidebarCloseAnimationKeyframes = keyframes`
-    from {
-      transform: scaleX(1);
-    }
-
-    to {
-      transform: scaleX(0);
-    }
-  `;
-
-  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
-  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
 
   const func = useLiveQuery<ChatCraftFunction | undefined>(() => {
     if (funcId) {
@@ -158,49 +122,11 @@ export default function Function() {
       </GridItem>
 
       <GridItem rowSpan={3} overflowY="auto">
-        {isMobile ? (
-          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
-            <DrawerOverlay />
-            <DrawerContent>
-              <DrawerHeader mt={2} p={2}>
-                <Text
-                  position={"relative"}
-                  top={-1}
-                  ml={2}
-                  mb={2}
-                  fontSize="lg"
-                  fontWeight="bold"
-                  color={sidebarColor}
-                >
-                  &lt;ChatCraft /&gt;
-                </Text>
-                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
-                  <InputGroup size="sm" variant="outline">
-                    <Input type="search" name="q" isRequired placeholder="Search chat history" />
-                    <IconButton
-                      aria-label="Search"
-                      variant="ghost"
-                      icon={<TbSearch />}
-                      type="submit"
-                    />
-                  </InputGroup>
-                </Form>
-                <DrawerCloseButton />
-              </DrawerHeader>
-
-              <DrawerBody m={0} p={0}>
-                <Sidebar selectedFunction={func} />
-              </DrawerBody>
-            </DrawerContent>
-          </Drawer>
-        ) : (
-          <Box
-            transformOrigin={"left"}
-            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
-          >
-            <Sidebar selectedFunction={func} />
-          </Box>
-        )}
+        <Sidebar
+          selectedFunction={func}
+          isSidebarVisible={isSidebarVisible}
+          handleToggleSidebarVisible={handleToggleSidebarVisible}
+        ></Sidebar>
       </GridItem>
 
       <GridItem overflowY="auto" pos="relative">

--- a/src/Search.tsx
+++ b/src/Search.tsx
@@ -1,38 +1,25 @@
-import { useCallback, useRef } from "react";
 import {
   Box,
+  Card,
+  CardBody,
+  Center,
   Flex,
-  useDisclosure,
   Grid,
   GridItem,
   Heading,
-  Center,
-  Card,
-  CardBody,
-  Drawer,
-  DrawerOverlay,
-  DrawerContent,
-  DrawerHeader,
-  InputGroup,
-  Input,
-  IconButton,
-  DrawerCloseButton,
-  DrawerBody,
-  useColorModeValue,
-  Text,
-  keyframes,
+  useDisclosure,
 } from "@chakra-ui/react";
-import { type LoaderFunctionArgs, redirect, useLoaderData, Form } from "react-router-dom";
-import { TbListSearch, TbSearch } from "react-icons/tb";
+import { useCallback, useRef } from "react";
+import { TbListSearch } from "react-icons/tb";
+import { redirect, useLoaderData, type LoaderFunctionArgs } from "react-router-dom";
 
 import Header from "./components/Header";
-import Sidebar from "./components/Sidebar";
-import db, { ChatCraftMessageTable } from "./lib/db";
 import Message from "./components/Message";
-import { ChatCraftMessage } from "./lib/ChatCraftMessage";
 import OptionsButton from "./components/OptionsButton";
+import Sidebar from "./components/Sidebar/";
 import { useSettings } from "./hooks/use-settings";
-import useMobileBreakpoint from "./hooks/use-mobile-breakpoint";
+import { ChatCraftMessage } from "./lib/ChatCraftMessage";
+import db, { ChatCraftMessageTable } from "./lib/db";
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url);
@@ -86,32 +73,6 @@ export default function Search() {
     setSettings({ ...settings, sidebarVisible: newValue });
   }, [isSidebarVisible, settings, setSettings, toggleSidebarVisible]);
 
-  const isMobile = useMobileBreakpoint();
-  const sidebarColor = useColorModeValue("blue.600", "blue.200");
-
-  const sidebarOpenAnimationKeyframes = keyframes`
-    from {
-      opacity: 0;
-    }
-
-    to {
-      opacity: 1;
-    }
-  `;
-
-  const sidebarCloseAnimationKeyframes = keyframes`
-    from {
-      transform: scaleX(1);
-    }
-
-    to {
-      transform: scaleX(0);
-    }
-  `;
-
-  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
-  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
-
   return (
     <Grid
       w="100%"
@@ -134,55 +95,11 @@ export default function Search() {
       </GridItem>
 
       <GridItem rowSpan={3} overflowY="auto">
-        {isMobile ? (
-          <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
-            <DrawerOverlay />
-            <DrawerContent>
-              <DrawerHeader mt={2} p={2}>
-                <Text
-                  position={"relative"}
-                  top={-1}
-                  ml={2}
-                  mb={2}
-                  fontSize="lg"
-                  fontWeight="bold"
-                  color={sidebarColor}
-                >
-                  &lt;ChatCraft /&gt;
-                </Text>
-                <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
-                  <InputGroup size="sm" variant="outline">
-                    <Input
-                      type="search"
-                      defaultValue={searchText}
-                      name="q"
-                      isRequired
-                      placeholder="Search chat history"
-                    />
-                    <IconButton
-                      aria-label="Search"
-                      variant="ghost"
-                      icon={<TbSearch />}
-                      type="submit"
-                    />
-                  </InputGroup>
-                </Form>
-                <DrawerCloseButton />
-              </DrawerHeader>
-
-              <DrawerBody m={0} p={0}>
-                <Sidebar />
-              </DrawerBody>
-            </DrawerContent>
-          </Drawer>
-        ) : (
-          <Box
-            transformOrigin={"left"}
-            animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
-          >
-            <Sidebar />
-          </Box>
-        )}
+        <Sidebar
+          searchText={searchText}
+          isSidebarVisible={isSidebarVisible}
+          handleToggleSidebarVisible={handleToggleSidebarVisible}
+        ></Sidebar>
       </GridItem>
 
       <GridItem overflowY="auto" ref={messageListRef} pos="relative">

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -27,13 +27,13 @@ import { LuFunctionSquare } from "react-icons/lu";
 import { useKey } from "react-use";
 import { Link, useNavigate } from "react-router-dom";
 
-import db from "../lib/db";
-import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { formatDate, formatNumber } from "../lib/utils";
-import { SharedChatCraftChat } from "../lib/SharedChatCraftChat";
-import { useUser } from "../hooks/use-user";
-import { ChatCraftFunction } from "../lib/ChatCraftFunction";
-import { useAlert } from "../hooks/use-alert";
+import db from "../../lib/db";
+import { ChatCraftChat } from "../../lib/ChatCraftChat";
+import { formatDate, formatNumber } from "../../lib/utils";
+import { SharedChatCraftChat } from "../../lib/SharedChatCraftChat";
+import { useUser } from "../../hooks/use-user";
+import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
+import { useAlert } from "../../hooks/use-alert";
 
 /**
  * Chat Sidebar Items
@@ -266,12 +266,12 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
  * Sidebar
  */
 
-type SidebarProps = {
+export type SidebarContentProps = {
   selectedChat?: ChatCraftChat;
   selectedFunction?: ChatCraftFunction;
 };
 
-function Sidebar({ selectedChat, selectedFunction }: SidebarProps) {
+function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps) {
   const { user } = useUser();
   const navigate = useNavigate();
   const [recentCount, setRecentCount] = useState(10);
@@ -474,4 +474,4 @@ function Sidebar({ selectedChat, selectedFunction }: SidebarProps) {
   );
 }
 
-export default Sidebar;
+export default SidebarContent;

--- a/src/components/Sidebar/SidebarDesktop.tsx
+++ b/src/components/Sidebar/SidebarDesktop.tsx
@@ -1,0 +1,42 @@
+import { Box, keyframes } from "@chakra-ui/react";
+import SidebarContent, { SidebarContentProps } from "./SidebarContent";
+
+type SidebarDesktopProps = SidebarContentProps & {
+  isSidebarVisible: boolean;
+};
+
+function SidebarDesktop({ isSidebarVisible, selectedChat, selectedFunction }: SidebarDesktopProps) {
+  const sidebarOpenAnimationKeyframes = keyframes`
+    from {
+      opacity: 0;
+    }
+
+    to {
+      opacity: 1;
+    }
+  `;
+
+  const sidebarCloseAnimationKeyframes = keyframes`
+    from {
+      transform: scaleX(1);
+    }
+
+    to {
+      transform: scaleX(0);
+    }
+  `;
+
+  const sidebarOpenAnimation = `${sidebarOpenAnimationKeyframes} 500ms ease-in-out forwards`;
+  const sidebarCloseAnimation = `${sidebarCloseAnimationKeyframes} 100ms ease-in-out forwards`;
+
+  return (
+    <Box
+      transformOrigin={"left"}
+      animation={isSidebarVisible ? sidebarOpenAnimation : sidebarCloseAnimation}
+    >
+      <SidebarContent selectedChat={selectedChat} selectedFunction={selectedFunction} />
+    </Box>
+  );
+}
+
+export default SidebarDesktop;

--- a/src/components/Sidebar/SidebarMobile.tsx
+++ b/src/components/Sidebar/SidebarMobile.tsx
@@ -31,7 +31,12 @@ function SidebarMobile({
   const brandColor = useColorModeValue("blue.600", "blue.200");
 
   return (
-    <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
+    <Drawer
+      autoFocus={false}
+      isOpen={isSidebarVisible}
+      onClose={handleToggleSidebarVisible}
+      placement="left"
+    >
       <DrawerOverlay />
       <DrawerContent>
         <DrawerHeader mt={2} p={2}>

--- a/src/components/Sidebar/SidebarMobile.tsx
+++ b/src/components/Sidebar/SidebarMobile.tsx
@@ -1,0 +1,72 @@
+import {
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  IconButton,
+  Input,
+  InputGroup,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
+import { TbSearch } from "react-icons/tb";
+import { Form } from "react-router-dom";
+import SidebarContent, { SidebarContentProps } from "./SidebarContent";
+
+type SidebarMobileProps = SidebarContentProps & {
+  searchText?: string;
+  handleToggleSidebarVisible: () => void;
+  isSidebarVisible: boolean;
+};
+
+function SidebarMobile({
+  searchText,
+  handleToggleSidebarVisible,
+  isSidebarVisible,
+  selectedChat,
+  selectedFunction,
+}: SidebarMobileProps) {
+  const brandColor = useColorModeValue("blue.600", "blue.200");
+
+  return (
+    <Drawer isOpen={isSidebarVisible} onClose={handleToggleSidebarVisible} placement="left">
+      <DrawerOverlay />
+      <DrawerContent>
+        <DrawerHeader mt={2} p={2}>
+          <Text
+            position={"relative"}
+            top={-1}
+            ml={2}
+            mb={2}
+            fontSize="lg"
+            fontWeight="bold"
+            color={brandColor}
+          >
+            &lt;ChatCraft /&gt;
+          </Text>
+          <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
+            <InputGroup size="sm" variant="outline">
+              <Input
+                type="search"
+                defaultValue={searchText}
+                name="q"
+                isRequired
+                placeholder="Search chat history"
+              />
+              <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
+            </InputGroup>
+          </Form>
+          <DrawerCloseButton />
+        </DrawerHeader>
+
+        <DrawerBody m={0} p={0}>
+          <SidebarContent selectedChat={selectedChat} selectedFunction={selectedFunction} />
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+export default SidebarMobile;

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,0 +1,19 @@
+import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
+import { ChatCraftChat } from "../../lib/ChatCraftChat";
+import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
+import SidebarDesktop from "./SidebarDesktop";
+import SidebarMobile from "./SidebarMobile";
+
+export type SidebarProps = {
+  searchText?: string; // For the search field in mobile sidebar
+  selectedChat?: ChatCraftChat;
+  selectedFunction?: ChatCraftFunction;
+  isSidebarVisible: boolean;
+  handleToggleSidebarVisible: () => void;
+};
+
+export default function Sidebar(props: SidebarProps) {
+  const isMobile = useMobileBreakpoint();
+
+  return isMobile ? <SidebarMobile {...props} /> : <SidebarDesktop {...props} />;
+}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -4,7 +4,7 @@ import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
 import SidebarDesktop from "./SidebarDesktop";
 import SidebarMobile from "./SidebarMobile";
 
-export type SidebarProps = {
+type SidebarProps = {
   searchText?: string; // For the search field in mobile sidebar
   selectedChat?: ChatCraftChat;
   selectedFunction?: ChatCraftFunction;


### PR DESCRIPTION
#437 introduced a lot of duplication for sidebar related styles and logic as we now had different sidebar views for mobile and desktop.

I have tried to minimize that duplication, by creating separate components for mobile and desktop sidebar and exposing through a common `Sidebar` api, taking inspiration from the way `PromptForm` is done.

This way, the places that use the sidebar now look the same as before since all the changes have been abstracted in its own module.

Here's a summary of changes:
1. Renamed the existing `Sidebar` component to `SidebarContent`.
2. Added a `SidebarMobile` component that uses `SidebarContent` and extends it by adding the search field and ChatCraft brand at the top.
3. Similarly, `SidebarDesktop` component wraps `SidebarContent` to apply the new open/close transition effect. This way, we don't have to repeat the `keyframe` definitions at evey place where sidebar is used.
4. These Sidebar components are exposed by the common `Sidebar` in index.tsx based on the screen width using `isMobile` hook.

This fixes #457.