### PR TITLE
Fix search/share id loading bug

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -452,10 +452,11 @@ function ChatBase({ chat }: ChatBaseProps) {
         <Box maxW="900px" mx="auto" h="100%">
           {chat.readonly ? (
             <Flex w="100%" h="45px" justify="end" align="center" p={2}>
-              <OptionsButton forkUrl={`./fork`} variant="solid" />
+              <OptionsButton chat={chat} forkUrl={`./fork`} variant="solid" />
             </Flex>
           ) : (
             <PromptForm
+              chat={chat}
               forkUrl={`./fork`}
               onSendClick={onPrompt}
               isLoading={loading}

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -9,12 +9,11 @@ import {
   Input,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Link as ReactRouterLink, useFetcher, useLoaderData } from "react-router-dom";
+import { Link as ReactRouterLink, useFetcher } from "react-router-dom";
 import { TbShare2, TbTrash, TbCopy, TbDownload } from "react-icons/tb";
 import { PiGearBold } from "react-icons/pi";
 import { BsPaperclip } from "react-icons/bs";
 import { useCallback, useRef } from "react";
-import { useLiveQuery } from "dexie-react-hooks";
 import { useCopyToClipboard } from "react-use";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
@@ -70,6 +69,7 @@ function ShareMenuItem({ chat }: { chat?: ChatCraftChat }) {
 }
 
 type OptionsButtonProps = {
+  chat?: ChatCraftChat;
   forkUrl?: string;
   variant?: "outline" | "solid" | "ghost";
   iconOnly?: boolean;
@@ -79,6 +79,7 @@ type OptionsButtonProps = {
 };
 
 function OptionsButton({
+  chat,
   forkUrl,
   variant = "outline",
   onFileSelected,
@@ -88,12 +89,6 @@ function OptionsButton({
   const fetcher = useFetcher();
   const { info } = useAlert();
   const [, copyToClipboard] = useCopyToClipboard();
-  const chatId = useLoaderData() as string;
-  const chat = useLiveQuery<ChatCraftChat | undefined>(() => {
-    if (chatId) {
-      return Promise.resolve(ChatCraftChat.find(chatId));
-    }
-  }, [chatId]);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const handleFileChange = useCallback(
@@ -213,14 +208,16 @@ function OptionsButton({
             <MenuDivider />
           </>
         )}
-        <MenuItem
-          color="red.400"
-          icon={<TbTrash />}
-          isDisabled={!chat}
-          onClick={() => handleDeleteClick()}
-        >
-          Delete Chat
-        </MenuItem>
+        {!chat?.readonly && (
+          <MenuItem
+            color="red.400"
+            icon={<TbTrash />}
+            isDisabled={!chat}
+            onClick={() => handleDeleteClick()}
+          >
+            Delete Chat
+          </MenuItem>
+        )}
       </MenuList>
     </Menu>
   );

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -27,6 +27,7 @@ import { useLocation } from "react-router-dom";
 import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
 import { useAlert } from "../../hooks/use-alert";
 import ImageModal from "../ImageModal";
+import { ChatCraftChat } from "../../lib/ChatCraftChat";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -59,6 +60,7 @@ function KeyboardHint({ isVisible }: KeyboardHintProps) {
 }
 
 type DesktopPromptFormProps = {
+  chat: ChatCraftChat;
   forkUrl: string;
   onSendClick: (prompt: string, imageUrls: string[]) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
@@ -67,6 +69,7 @@ type DesktopPromptFormProps = {
 };
 
 function DesktopPromptForm({
+  chat,
   forkUrl,
   onSendClick,
   inputPromptRef,
@@ -411,6 +414,7 @@ function DesktopPromptForm({
 
               <Flex w="100%" gap={1} justify={"space-between"} align="center">
                 <OptionsButton
+                  chat={chat}
                   forkUrl={forkUrl}
                   variant="outline"
                   isDisabled={isLoading}

--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -10,8 +10,10 @@ import { useModels } from "../../hooks/use-models";
 import PromptSendButton from "./PromptSendButton";
 import AudioStatus from "./AudioStatus";
 import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
+import { ChatCraftChat } from "../../lib/ChatCraftChat";
 
 type MobilePromptFormProps = {
+  chat: ChatCraftChat;
   forkUrl: string;
   onSendClick: (prompt: string, imageUrls: string[]) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;
@@ -20,6 +22,7 @@ type MobilePromptFormProps = {
 };
 
 function MobilePromptForm({
+  chat,
   forkUrl,
   onSendClick,
   inputPromptRef,
@@ -163,6 +166,7 @@ function MobilePromptForm({
       <chakra.form onSubmit={handlePromptSubmit} h="100%">
         <Flex mt={2} pb={2} px={1} alignItems="end" gap={2}>
           <OptionsButton
+            chat={chat}
             forkUrl={forkUrl}
             variant="outline"
             iconOnly

--- a/src/components/PromptForm/index.tsx
+++ b/src/components/PromptForm/index.tsx
@@ -4,8 +4,10 @@ import MobilePromptForm from "./MobilePromptForm";
 import DesktopPromptForm from "./DesktopPromptForm";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
+import { ChatCraftChat } from "../../lib/ChatCraftChat";
 
 export type PromptFormProps = {
+  chat: ChatCraftChat;
   forkUrl: string;
   onSendClick: (prompt: string) => void;
   inputPromptRef: RefObject<HTMLTextAreaElement>;

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -142,7 +142,7 @@ class ChatCraftDatabase extends Dexie {
           });
         await tx.table("messages").where({ type: "system" }).modify({ starred: undefined });
       });
-    // Version 9 Migration - removes .starred index from messages table
+    // Version 9 Migration - add imageUrls
     this.version(9).stores({
       messages: "id, date, chatId, type, model, user, text, imageUrls, versions",
     });


### PR DESCRIPTION
Fixes #446 

This bug was caused by my refactor of the Share button, moving it out of the chat header, and therefore breaking the connection with the route loader.  The way the data was being passed down from the new loader is different (the old way meant it received a chat id, the new way gets an object).  When we try to use this object with Dexie to get a value by ID, it crashes.

This changes how things work so that we pass the actual chat object to the options, and then can operate on it directly vs. needing to talk to the db.