### PR TITLE
Add dynamic imports for Mermaid and Math Rendering

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { Box, useColorModeValue } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
 import "katex/dist/katex.min.css";
 
@@ -17,8 +16,9 @@ import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
 
-// Load rehypeKatex dynamically at runtime if needed due to size
+// Load these math rendering libraries dynamically at runtime if needed due to size
 const rehypeKatex = await import("rehype-katex");
+const remarkMath = await import("rehype-external-links");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -72,7 +72,7 @@ function Markdown({
     <ReactMarkdown
       className={className}
       children={children}
-      remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
+      remarkPlugins={[remarkGfm, [remarkMath.default, { singleDollarTextMath: false }]]}
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -18,7 +18,7 @@ import MermaidPreview from "./MermaidPreview";
 
 // Load these math rendering libraries dynamically at runtime if needed due to size
 const rehypeKatex = await import("rehype-katex");
-const remarkMath = await import("rehype-external-links");
+const remarkMath = await import("remark-math");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -4,7 +4,6 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
-import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 
 // Use highlight.js (via lowlight) vs. prism.js (via refractor) due to
@@ -17,6 +16,9 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
+
+// Load rehypeKatex dynamically at runtime if needed due to size
+const rehypeKatex = await import("rehype-katex");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -74,7 +76,7 @@ function Markdown({
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],
-        rehypeKatex,
+        rehypeKatex.default,
       ]}
       components={{
         code({ className, children, ...props }) {

--- a/src/components/MermaidPreview.tsx
+++ b/src/components/MermaidPreview.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
-import mermaid from "mermaid";
 import { TbCopy } from "react-icons/tb";
 import { nanoid } from "nanoid";
 import { useAlert } from "../hooks/use-alert";
@@ -25,24 +24,27 @@ const MermaidPreview = ({ children }: MermaidPreviewProps) => {
 
   // Render the diagram as an SVG into our card's body
   useEffect(() => {
-    const diagramDiv = diagramRef.current;
-    if (!diagramDiv) {
-      return;
-    }
-
-    const mermaidDiagramId = `mermaid-diagram-${nanoid().toLowerCase()}`;
-    mermaid
-      .render(mermaidDiagramId, code, diagramDiv)
-      .then(({ svg, bindFunctions }) => {
-        setValue(svg);
-        diagramDiv.innerHTML = svg;
-        bindFunctions?.(diagramDiv);
-      })
-      .catch((err) => {
-        // When the diagram fails, use the error vs. diagram for copying (to debug)
-        setValue(err);
-        console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err);
-      });
+    const renderMermaidDiagram = async () => {
+      const diagramDiv = diagramRef.current;
+      if (!diagramDiv) {
+        return;
+      }
+      const mermaidDiagramId = `mermaid-diagram-${nanoid().toLowerCase()}`;
+      const mermaid = await import("mermaid");
+      mermaid.default
+        .render(mermaidDiagramId, code, diagramDiv)
+        .then(({ svg, bindFunctions }) => {
+          setValue(svg);
+          diagramDiv.innerHTML = svg;
+          bindFunctions?.(diagramDiv);
+        })
+        .catch((err) => {
+          // When the diagram fails, use the error vs. diagram for copying (to debug)
+          setValue(err);
+          console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err);
+        });
+    };
+    renderMermaidDiagram();
   }, [diagramRef, code, setValue]);
 
   return (

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo } from "react";
 import { Box, useColorMode } from "@chakra-ui/react";
-import mermaid from "mermaid";
 
 import Message from "./Message";
 import NewMessage from "./Message/NewMessage";
@@ -44,11 +43,15 @@ function MessagesView({
   // Make sure that any Mermaid diagrams use the same light/dark theme as rest of app.
   // Use a layout effect vs. regular effect so it happens after DOM is ready.
   useLayoutEffect(() => {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: colorMode === "dark" ? "dark" : "default",
-      securityLevel: "loose",
-    });
+    const initializeMermaid = async () => {
+      const mermaid = await import("mermaid");
+      mermaid.default.initialize({
+        startOnLoad: false,
+        theme: colorMode === "dark" ? "dark" : "default",
+        securityLevel: "loose",
+      });
+    };
+    initializeMermaid();
   }, [colorMode]);
 
   // Memoize the onRemoveMessage callback to reduce re-renders


### PR DESCRIPTION
This fixes #365 

Summary
---
`src/components/Markdown.tsx`: Changed the following modules to dynamic imports:
- **remarkMath** (directly depends on `katex`) 
- **rehypeKatex** (indirectly depends on `katex` via `micromark-extension-math`)

`src/components/MermaidPreview.tsx` **and** `src/components/MessagesView.tsx`: Changed the following module to dynamic import:
- **mermaid** (directly depends on `elkjs` and `cytoscape`)


Explanation
---

#365  identified three large modules for dynamic importing:
1. **elkjs** (for Mermaid)
2. **cytoscape** (for Mermaid)
3. **katex** (for Math rendering)

The **elkjs** and **cytoscape** modules are _both_ dependencies of **mermaid**:
https://github.com/tarasglek/chatcraft.org/blob/ca5ef709661bfc7415638d1708a1e539d7a858aa/pnpm-lock.yaml#L7688-L7701

The **katex** module is a dependecncy of **two modules**:
- **rehype-katex**:
https://github.com/tarasglek/chatcraft.org/blob/ca5ef709661bfc7415638d1708a1e539d7a858aa/pnpm-lock.yaml#L9145-L9152
- and **micromark-extension-math** (not directly imported in code):
https://github.com/tarasglek/chatcraft.org/blob/ca5ef709661bfc7415638d1708a1e539d7a858aa/pnpm-lock.yaml#L7828-L7833
...which itself is a dependency of **remark-math** (directly imported in code):
https://github.com/tarasglek/chatcraft.org/blob/ca5ef709661bfc7415638d1708a1e539d7a858aa/pnpm-lock.yaml#L9170-L9175
