### PR TITLE
"Show More..." button's text is improperly layered and visible through the options menu

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -182,7 +182,7 @@ function OptionsButton({
           Options
         </MenuButton>
       )}
-      <MenuList>
+      <MenuList zIndex={11}>
         <MenuItem as={ReactRouterLink} to="/new">
           Clear
         </MenuItem>

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -21,6 +21,7 @@ import { useUser } from "../hooks/use-user";
 import { useAlert } from "../hooks/use-alert";
 import ShareModal from "./ShareModal";
 import { download, compressImageToBase64 } from "../lib/utils";
+import theme from "../theme";
 
 function ShareMenuItem({ chat }: { chat?: ChatCraftChat }) {
   const supportsWebShare = !!navigator.share;
@@ -182,7 +183,7 @@ function OptionsButton({
           Options
         </MenuButton>
       )}
-      <MenuList zIndex={11}>
+      <MenuList zIndex={theme.zIndices.dropdown}>
         <MenuItem as={ReactRouterLink} to="/new">
           Clear
         </MenuItem>


### PR DESCRIPTION
According to 
`<Button zIndex={10} size="sm" variant="ghost" onClick={() => onToggle()}>
                      {isOpen ? "Show Less" : "Show More..."}
                    </Button>` in file `https://github.com/tarasglek/chatcraft.org/tree/b87536cced902bc61292c0c12d438bd6270d152d/src/components/Message/MessageBase.tsx`, set a higher zindex for MenuList

closes #441 