### PR TITLE
Provider refactoring - settings.currentProvider, ChatCraftProvider child classes

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -154,7 +154,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                       {title}
                     </Link>
                   </Text>
-                  {settings.apiKey && (
+                  {settings.currentProvider?.apiKey && (
                     <IconButton
                       variant="ghost"
                       size="sm"
@@ -179,7 +179,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                 <MenuItem onClick={() => handleCopyChatClick()}>Copy</MenuItem>
                 <MenuItem onClick={() => handleDownloadClick()}>Download</MenuItem>
 
-                {!chat.readonly && settings.apiKey && (
+                {!chat.readonly && settings.currentProvider?.apiKey && (
                   <>
                     <MenuDivider />
                     <MenuItem onClick={onOpen}>Share Chat...</MenuItem>

--- a/src/components/Message/AiMessage.tsx
+++ b/src/components/Message/AiMessage.tsx
@@ -96,7 +96,7 @@ function AiMessage(props: AiMessageProps) {
 
   const handleRetryClick = useCallback(
     async (model: ChatCraftModel) => {
-      if (!settings.apiKey) {
+      if (!settings.currentProvider?.apiKey) {
         return;
       }
 
@@ -130,7 +130,7 @@ function AiMessage(props: AiMessageProps) {
         setRetrying(false);
       }
     },
-    [props.chatId, settings.apiKey, message, callChatApi]
+    [props.chatId, settings.currentProvider?.apiKey, message, callChatApi]
   );
 
   // While we're streaming in a new version, use a different display

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -80,7 +80,7 @@ function MessagesView({
     if (
       messages.length === 1 &&
       messages[0] instanceof ChatCraftSystemMessage &&
-      !settings.apiKey
+      !settings.currentProvider?.apiKey
     ) {
       return;
     }
@@ -115,7 +115,7 @@ function MessagesView({
     });
   }, [
     messages,
-    settings.apiKey,
+    settings.currentProvider?.apiKey,
     chatId,
     onPrompt,
     isLoading,
@@ -125,7 +125,7 @@ function MessagesView({
 
   const instructions = useMemo(() => {
     // If there's no API key in storage, show instructions so we get one
-    if (!settings.apiKey) {
+    if (!settings.currentProvider?.apiKey) {
       const message = ChatCraftAppMessage.instructions();
       return (
         <Message
@@ -138,7 +138,7 @@ function MessagesView({
         />
       );
     }
-  }, [settings.apiKey, chatId, onPrompt, isLoading]);
+  }, [settings.currentProvider?.apiKey, chatId, onPrompt, isLoading]);
 
   return (
     <Box minHeight="100%" scrollBehavior="smooth">

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -36,9 +36,10 @@ import { download, isMac } from "../lib/utils";
 import db from "../lib/db";
 import { useModels } from "../hooks/use-models";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import { ChatCraftProvider, supportedProviders } from "../lib/ChatCraftProvider";
-import { OPENAI_API_URL } from "../lib/settings";
-import { openRouterPkceRedirect, usingOfficialOpenAI, validateApiKey } from "../lib/ai";
+import { providerFromUrl, providerFromJSON, getSupportedProviders } from "../lib/providers";
+import { OpenAiProvider } from "../lib/providers/OpenAiProvider";
+import { OpenRouterProvider } from "../lib/providers/OpenRouterProvider";
+import { validateApiKey } from "../lib/ai";
 import { useAlert } from "../hooks/use-alert";
 
 // https://dexie.org/docs/StorageManager
@@ -65,16 +66,16 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
   const [isPersisted, setIsPersisted] = useState(false);
   const { info, error } = useAlert();
   const inputRef = useRef<HTMLInputElement>(null);
-  const provider = settings.apiUrl === OPENAI_API_URL ? "OpenAI" : "OpenRouter.ai";
   const [isApiKeyInvalid, setIsApiKeyInvalid] = useState(false);
+  const supportedProviders = getSupportedProviders();
+
   // Check the API Key, but debounce requests if user is typing
   useDebounce(
     () => {
-      const { apiKey } = settings;
-      if (!apiKey) {
+      if (!settings.currentProvider?.apiKey) {
         setIsApiKeyInvalid(true);
       } else {
-        validateApiKey(apiKey)
+        validateApiKey(settings.currentProvider?.apiKey)
           .then((result: boolean) => setIsApiKeyInvalid(!result))
           .catch((err) => {
             console.warn("Error validating API key", err);
@@ -83,7 +84,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
       }
     },
     500,
-    [settings.apiKey]
+    [settings.currentProvider?.apiKey]
   );
 
   useEffect(() => {
@@ -155,35 +156,17 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
 
   const handleProviderChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
-      const currentProvider = ChatCraftProvider.fromUrl(settings.apiUrl, settings.apiKey);
-      const selectedProvider = ChatCraftProvider.fromUrl(e.target.value);
+      // Get stored data from settings.providers array if exists
+      const newProvider = settings.providers[e.target.value]
+        ? providerFromJSON(settings.providers[e.target.value])
+        : providerFromUrl(e.target.value);
 
-      // If new provider exists in settings.providers, parse it to ChatCraftProvider
-      const newProvider = settings.providers[selectedProvider.name]
-        ? ChatCraftProvider.fromJSON(settings.providers[selectedProvider.name])
-        : selectedProvider;
-
-      // Store old provider in settings.providers array if not already there
-      // Set current apiKey to value loaded from settings.providers or undefined
-      if (currentProvider.apiKey && !(currentProvider.name in settings.providers)) {
-        setSettings({
-          ...settings,
-          apiUrl: newProvider.apiUrl,
-          apiKey: newProvider.apiKey,
-          providers: {
-            ...settings.providers,
-            [currentProvider.name]: currentProvider,
-          },
-        });
-      } else {
-        setSettings({
-          ...settings,
-          apiUrl: newProvider.apiUrl,
-          apiKey: newProvider.apiKey,
-        });
-      }
+      setSettings({
+        ...settings,
+        currentProvider: newProvider,
+      });
     },
-    [settings, setSettings]
+    [setSettings, settings]
   );
 
   return (
@@ -193,222 +176,236 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
         <ModalHeader>User Settings</ModalHeader>
         <ModalCloseButton />
         <ModalBody>
-          <VStack gap={4}>
-            <FormControl>
-              <FormLabel>API URL</FormLabel>
-              <Select value={settings.apiUrl} onChange={handleProviderChange}>
-                {Object.values(supportedProviders).map((provider) => (
-                  <option key={provider.apiUrl} value={provider.apiUrl}>
-                    {provider.name} ({provider.apiUrl})
-                  </option>
-                ))}
-              </Select>
-              <FormHelperText>
-                Advanced option for use with other OpenAI-compatible APIs
-              </FormHelperText>
-            </FormControl>
-
-            <FormControl isInvalid={isApiKeyInvalid}>
-              <FormLabel>
-                {provider} API Key{" "}
-                <ButtonGroup ml={2}>
-                  <Button
-                    size="xs"
-                    onClick={() => copyToClipboard(settings.apiKey || "")}
-                    isDisabled={!settings.apiKey}
-                  >
-                    Copy
-                  </Button>
-                  <Button
-                    size="xs"
-                    colorScheme="red"
-                    onClick={() => {
-                      const currentProvider = ChatCraftProvider.fromUrl(
-                        settings.apiUrl,
-                        settings.apiKey
-                      );
-                      const updatedProviders = { ...settings.providers };
-
-                      if (currentProvider.name in updatedProviders) {
-                        delete updatedProviders[currentProvider.name];
-                      }
-
-                      setSettings({
-                        ...settings,
-                        apiKey: undefined,
-                        providers: updatedProviders,
-                      });
-                    }}
-                    isDisabled={!settings.apiKey}
-                  >
-                    Remove
-                  </Button>
-                </ButtonGroup>
-              </FormLabel>
-              <RevealablePasswordInput
-                type="password"
-                value={settings.apiKey || ""}
-                onChange={(e) => {
-                  const newProvider = ChatCraftProvider.fromUrl(settings.apiUrl, e.target.value);
-
-                  setSettings({
-                    ...settings,
-                    apiKey: newProvider.apiKey,
-                    providers: {
-                      ...settings.providers,
-                      [newProvider.name]: newProvider,
-                    },
-                  });
-                }}
-              />
-              {provider === "OpenRouter.ai" && !settings.apiKey && (
-                <Button mt="3" size="sm" onClick={openRouterPkceRedirect}>
-                  Get API key from OpenRouter{" "}
-                </Button>
-              )}
-              <FormHelperText>Your API Key is stored in browser storage</FormHelperText>
-              <FormErrorMessage>Unable to verify API Key with {provider}.</FormErrorMessage>
-            </FormControl>
-
-            <FormControl>
-              <FormLabel>
-                Offline database is {isPersisted ? "persisted" : "not persisted"}
-                <ButtonGroup ml={2}>
-                  <Button
-                    size="xs"
-                    onClick={() => handlePersistClick()}
-                    isDisabled={isPersisted}
-                    variant="outline"
-                  >
-                    Persist
-                  </Button>
-                  <Button size="xs" onClick={() => handleImportClick()}>
-                    Import
-                  </Button>
-                  <Input
-                    type="file"
-                    ref={inputRef}
-                    onChange={handleFileChange}
-                    style={{ display: "none" }}
-                  />
-                  <Button size="xs" onClick={() => handleExportClick()}>
-                    Export
-                  </Button>
-                </ButtonGroup>
-              </FormLabel>
-              <FormHelperText>
-                Persisted databases use the{" "}
-                <Link
-                  href="https://developer.mozilla.org/en-US/docs/Web/API/Storage_API"
-                  textDecoration="underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Storage API
-                </Link>{" "}
-                and are retained by the browser as long as possible. See{" "}
-                <Link
-                  href="https://dexie.org/docs/ExportImport/dexie-export-import"
-                  textDecoration="underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  docs
-                </Link>{" "}
-                for database export details.
-              </FormHelperText>
-            </FormControl>
-
-            <FormControl>
-              <FormLabel>GPT Model</FormLabel>
-              <Select
-                value={settings.model.id}
-                onChange={(e) =>
-                  setSettings({ ...settings, model: new ChatCraftModel(e.target.value) })
-                }
-              >
-                {models
-                  .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
-                  .map((model) => (
-                    <option key={model.id} value={model.id}>
-                      {model.prettyModel}
+          {!supportedProviders ? (
+            <Box>Loading providers...</Box>
+          ) : (
+            <VStack gap={4}>
+              <FormControl>
+                <FormLabel>API URL</FormLabel>
+                <Select value={settings.currentProvider?.apiUrl} onChange={handleProviderChange}>
+                  {Object.values(supportedProviders).map((provider) => (
+                    <option key={provider.apiUrl} value={provider.apiUrl}>
+                      {provider.name} ({provider.apiUrl})
                     </option>
                   ))}
-              </Select>
-              <FormHelperText>
-                See{" "}
-                <Link
-                  href="https://platform.openai.com/docs/models/gpt-4"
-                  textDecoration="underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  docs
-                </Link>{" "}
-                and{" "}
-                <Link
-                  href="https://openai.com/pricing"
-                  textDecoration="underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  pricing
-                </Link>
-                . NOTE: not all accounts have access to GPT - 4
-              </FormHelperText>
-            </FormControl>
+                </Select>
+                <FormHelperText>
+                  Advanced option for use with other OpenAI-compatible APIs
+                </FormHelperText>
+              </FormControl>
 
-            <FormControl>
-              <FormLabel>Temperature: {settings.temperature}</FormLabel>
-              <Box px="5">
-                <Slider
-                  value={settings.temperature}
-                  onChange={(value) => setSettings({ ...settings, temperature: value })}
-                  min={0}
-                  max={2}
-                  step={0.05}
+              <FormControl isInvalid={isApiKeyInvalid}>
+                <FormLabel>
+                  {settings.currentProvider?.name} API Key{" "}
+                  <ButtonGroup ml={2}>
+                    <Button
+                      size="xs"
+                      onClick={() => copyToClipboard(settings.currentProvider?.apiKey || "")}
+                      isDisabled={!settings.currentProvider?.apiKey}
+                    >
+                      Copy
+                    </Button>
+                    <Button
+                      size="xs"
+                      colorScheme="red"
+                      onClick={async () => {
+                        // Create provider that has no key
+                        const newProvider = providerFromUrl(settings.currentProvider?.apiUrl);
+
+                        // Get array with provider removed
+                        const updatedProviders = { ...settings.providers };
+                        if (updatedProviders[settings.currentProvider?.apiUrl]) {
+                          delete updatedProviders[settings.currentProvider?.apiUrl];
+                        }
+
+                        setSettings({
+                          ...settings,
+                          providers: updatedProviders,
+                          currentProvider: newProvider,
+                        });
+                      }}
+                      isDisabled={!settings.currentProvider?.apiKey}
+                    >
+                      Remove
+                    </Button>
+                  </ButtonGroup>
+                </FormLabel>
+                <RevealablePasswordInput
+                  type="password"
+                  value={settings.currentProvider?.apiKey || ""}
+                  onChange={async (e) => {
+                    const newProvider = providerFromUrl(
+                      settings.currentProvider?.apiUrl,
+                      e.target.value
+                    );
+
+                    setSettings({
+                      ...settings,
+                      currentProvider: newProvider,
+                      providers: {
+                        ...settings.providers,
+                        [newProvider.apiUrl]: newProvider,
+                      },
+                    });
+                  }}
+                />
+                {settings.currentProvider instanceof OpenRouterProvider &&
+                  !settings.currentProvider?.apiKey && (
+                    <Button mt="3" size="sm" onClick={OpenRouterProvider.openRouterPkceRedirect}>
+                      Get API key from OpenRouter{" "}
+                    </Button>
+                  )}
+
+                <FormErrorMessage>
+                  Unable to verify API Key with {settings.currentProvider?.name}.
+                </FormErrorMessage>
+                <FormHelperText>Your API Key is stored in browser storage</FormHelperText>
+              </FormControl>
+
+              <FormControl>
+                <FormLabel>
+                  Offline database is {isPersisted ? "persisted" : "not persisted"}
+                  <ButtonGroup ml={2}>
+                    <Button
+                      size="xs"
+                      onClick={() => handlePersistClick()}
+                      isDisabled={isPersisted}
+                      variant="outline"
+                    >
+                      Persist
+                    </Button>
+                    <Button size="xs" onClick={() => handleImportClick()}>
+                      Import
+                    </Button>
+                    <Input
+                      type="file"
+                      ref={inputRef}
+                      onChange={handleFileChange}
+                      style={{ display: "none" }}
+                    />
+                    <Button size="xs" onClick={() => handleExportClick()}>
+                      Export
+                    </Button>
+                  </ButtonGroup>
+                </FormLabel>
+                <FormHelperText>
+                  Persisted databases use the{" "}
+                  <Link
+                    href="https://developer.mozilla.org/en-US/docs/Web/API/Storage_API"
+                    textDecoration="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Storage API
+                  </Link>{" "}
+                  and are retained by the browser as long as possible. See{" "}
+                  <Link
+                    href="https://dexie.org/docs/ExportImport/dexie-export-import"
+                    textDecoration="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    docs
+                  </Link>{" "}
+                  for database export details.
+                </FormHelperText>
+              </FormControl>
+
+              <FormControl>
+                <FormLabel>GPT Model</FormLabel>
+                <Select
+                  value={settings.model.id}
+                  onChange={(e) =>
+                    setSettings({ ...settings, model: new ChatCraftModel(e.target.value) })
+                  }
                 >
-                  <SliderTrack>
-                    <SliderFilledTrack />
-                  </SliderTrack>
-                  <SliderThumb />
-                </Slider>
-              </Box>
-              <FormErrorMessage>Temperature must be a number between 0 and 2.</FormErrorMessage>
-              <FormHelperText>
-                The temperature increases the randomness of the response (0.0 - 2.0).
-              </FormHelperText>
-            </FormControl>
+                  {models
+                    .filter(
+                      (model) =>
+                        !(settings.currentProvider instanceof OpenAiProvider) ||
+                        model.id.includes("gpt")
+                    )
+                    .map((model) => (
+                      <option key={model.id} value={model.id}>
+                        {model.prettyModel}
+                      </option>
+                    ))}
+                </Select>
+                <FormHelperText>
+                  See{" "}
+                  <Link
+                    href="https://platform.openai.com/docs/models/gpt-4"
+                    textDecoration="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    docs
+                  </Link>{" "}
+                  and{" "}
+                  <Link
+                    href="https://openai.com/pricing"
+                    textDecoration="underline"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    pricing
+                  </Link>
+                  . NOTE: not all accounts have access to GPT - 4
+                </FormHelperText>
+              </FormControl>
 
-            <FormControl>
-              <FormLabel>
-                When writing a prompt, press <Kbd>Enter</Kbd> to...
-              </FormLabel>
-              <RadioGroup
-                value={settings.enterBehaviour}
-                onChange={(nextValue) =>
-                  setSettings({ ...settings, enterBehaviour: nextValue as EnterBehaviour })
-                }
-              >
-                <Stack>
-                  <Radio value="send">Send the message</Radio>
-                  <Radio value="newline">
-                    Start a new line (use {isMac() ? <Kbd>Command ⌘</Kbd> : <Kbd>Ctrl</Kbd>} +
-                    <Kbd>Enter</Kbd> to send)
-                  </Radio>
-                </Stack>
-              </RadioGroup>
-            </FormControl>
+              <FormControl>
+                <FormLabel>Temperature: {settings.temperature}</FormLabel>
+                <Box px="5">
+                  <Slider
+                    value={settings.temperature}
+                    onChange={(value) => setSettings({ ...settings, temperature: value })}
+                    min={0}
+                    max={2}
+                    step={0.05}
+                  >
+                    <SliderTrack>
+                      <SliderFilledTrack />
+                    </SliderTrack>
+                    <SliderThumb />
+                  </Slider>
+                </Box>
+                <FormErrorMessage>Temperature must be a number between 0 and 2.</FormErrorMessage>
+                <FormHelperText>
+                  The temperature increases the randomness of the response (0.0 - 2.0).
+                </FormHelperText>
+              </FormControl>
 
-            <FormControl>
-              <Checkbox
-                isChecked={settings.countTokens}
-                onChange={(e) => setSettings({ ...settings, countTokens: e.target.checked })}
-              >
-                Track and Display Token Count and Cost
-              </Checkbox>
-            </FormControl>
-          </VStack>
+              <FormControl>
+                <FormLabel>
+                  When writing a prompt, press <Kbd>Enter</Kbd> to...
+                </FormLabel>
+                <RadioGroup
+                  value={settings.enterBehaviour}
+                  onChange={(nextValue) =>
+                    setSettings({ ...settings, enterBehaviour: nextValue as EnterBehaviour })
+                  }
+                >
+                  <Stack>
+                    <Radio value="send">Send the message</Radio>
+                    <Radio value="newline">
+                      Start a new line (use {isMac() ? <Kbd>Command ⌘</Kbd> : <Kbd>Ctrl</Kbd>} +
+                      <Kbd>Enter</Kbd> to send)
+                    </Radio>
+                  </Stack>
+                </RadioGroup>
+              </FormControl>
+
+              <FormControl>
+                <Checkbox
+                  isChecked={settings.countTokens}
+                  onChange={(e) => setSettings({ ...settings, countTokens: e.target.checked })}
+                >
+                  Track and Display Token Count and Cost
+                </Checkbox>
+              </FormControl>
+            </VStack>
+          )}
         </ModalBody>
 
         <ModalFooter></ModalFooter>

--- a/src/components/PromptForm/index.tsx
+++ b/src/components/PromptForm/index.tsx
@@ -20,7 +20,7 @@ export default function PromptForm(props: PromptFormProps) {
   const isMobile = useMobileBreakpoint();
 
   // Skip showing anything if we don't have an API Key to use
-  if (!settings.apiKey) {
+  if (!settings.currentProvider?.apiKey) {
     return null;
   }
 

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -85,7 +85,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
   );
 
   const handleSummarizeClick = useCallback(async () => {
-    if (!settings.apiKey) {
+    if (!settings.currentProvider?.apiKey) {
       return;
     }
     try {
@@ -98,7 +98,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     } finally {
       setIsSummarizing(false);
     }
-  }, [settings.apiKey, chat, setIsSummarizing, summarizeChat]);
+  }, [settings.currentProvider?.apiKey, chat, setIsSummarizing, summarizeChat]);
 
   const handleCopyClick = useCallback(() => {
     copyToClipboard(url);
@@ -120,7 +120,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
           <Button
             variant="outline"
             onClick={() => handleSummarizeClick()}
-            isDisabled={!settings.apiKey}
+            isDisabled={!settings.currentProvider?.apiKey}
             isLoading={isSummarizing}
             loadingText="Summarizing..."
           >

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -45,7 +45,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { settings, setSettings } = useSettings();
 
   useEffect(() => {
-    const apiKey = settings.apiKey;
+    const apiKey = settings.currentProvider?.apiKey;
     if (!apiKey || isFetching.current) {
       return;
     }
@@ -70,7 +70,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
 
     fetchModels();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [settings.apiUrl, settings.apiKey]);
+  }, [settings.currentProvider]);
 
   const value = {
     models: models || defaultModels,

--- a/src/hooks/use-settings.tsx
+++ b/src/hooks/use-settings.tsx
@@ -11,7 +11,6 @@ import { useLocalStorage } from "react-use";
 
 import { serializer, deserializer, key, defaults, type Settings } from "../lib/settings";
 import { OpenRouterProvider } from "../lib/providers/OpenRouterProvider";
-// import { providerFromUrl } from "../lib/providers";
 
 type SettingsContextType = {
   settings: Settings;
@@ -84,31 +83,7 @@ export const SettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   }, [openRouterCode]);
 
   useEffect(() => {
-    if (!settings) {
-      setState(defaults);
-      return;
-    }
-
-    // No current provider, check if we need to handle migration of deprecated apiKey, apiUrl
-    // const { apiUrl, apiKey, ...restSettings } = settings as any;
-    // if (apiKey && apiUrl) {
-    //   const newProvider = providerFromUrl(apiUrl, apiKey);
-    //   setState({
-    //     ...restSettings,
-    //     currentProvider: newProvider,
-    //     providers: {
-    //       ...restSettings.providers,
-    //       [newProvider.apiUrl]: newProvider,
-    //     },
-    //   });
-
-    //   console.warn("Migrated deprecated apiKey, apiUrl");
-    //   return;
-    // }
-
-    setState(settings);
-
-    // switching providers glitches if settings is set as dependency
+    setState(settings || defaults);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/lib/ChatCraftProvider.ts
+++ b/src/lib/ChatCraftProvider.ts
@@ -1,6 +1,6 @@
 import { nanoid } from "nanoid";
 
-type ProviderName = "OpenAI" | "OpenRouter.ai";
+export type ProviderName = "OpenAI" | "OpenRouter.ai";
 
 export const OPENAI_API_URL = "https://api.openai.com/v1";
 export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
@@ -21,7 +21,7 @@ export type SerializedChatCraftProvider = {
   apiKey?: string;
 };
 
-export class ChatCraftProvider {
+export abstract class ChatCraftProvider {
   id: string;
   name: ProviderName;
   apiUrl: string;
@@ -33,23 +33,4 @@ export class ChatCraftProvider {
     this.apiUrl = url;
     this.apiKey = key;
   }
-
-  // Parses url into instance of ChatCraftProvider
-  static fromUrl(url: string, key?: string) {
-    return new ChatCraftProvider(url, key);
-  }
-
-  // Parse from serialized JSON
-  static fromJSON({ id, name, apiUrl, apiKey }: SerializedChatCraftProvider): ChatCraftProvider {
-    const provider = new ChatCraftProvider(apiUrl, apiKey);
-    provider.id = id;
-    provider.name = name;
-    return provider;
-  }
 }
-
-// Currently supported providers
-export const supportedProviders: ProviderData = {
-  OpenAI: new ChatCraftProvider(OPENAI_API_URL),
-  "OpenRouter.ai": new ChatCraftProvider(OPENROUTER_API_URL),
-};

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -7,14 +7,17 @@ import {
 import { ChatCraftModel } from "./ChatCraftModel";
 import { ChatCraftFunction } from "./ChatCraftFunction";
 import { getReferer } from "./utils";
-import { getSettings, OPENAI_API_URL, OPENROUTER_API_URL } from "./settings";
+import { getSettings } from "./settings";
+import { OPENAI_API_URL, OPENROUTER_API_URL } from "./ChatCraftProvider";
+import { OpenAiProvider } from "./providers/OpenAiProvider";
+import { OpenRouterProvider } from "./providers/OpenRouterProvider";
 import { Stream } from "openai/streaming";
-
 import type { Tiktoken } from "tiktoken/lite";
 import type { ChatCompletionChunk } from "openai/resources";
 
-export const usingOfficialOpenAI = () => getSettings().apiUrl === OPENAI_API_URL;
-export const usingOfficialOpenRouter = () => getSettings().apiUrl === OPENROUTER_API_URL;
+export const usingOfficialOpenAI = () => getSettings().currentProvider?.apiUrl === OPENAI_API_URL;
+export const usingOfficialOpenRouter = () =>
+  getSettings().currentProvider?.apiUrl === OPENROUTER_API_URL;
 
 const createClient = (apiKey: string, apiUrl?: string) => {
   // If we're using OpenRouter, add extra headers
@@ -41,11 +44,11 @@ const createClient = (apiKey: string, apiUrl?: string) => {
 export const defaultModelForProvider = () => {
   // OpenAI
   if (usingOfficialOpenAI()) {
-    return new ChatCraftModel("gpt-3.5-turbo");
+    return new ChatCraftModel(OpenAiProvider.defaultModel());
   }
 
   // OpenRouter.ai
-  return new ChatCraftModel("openai/gpt-3.5-turbo");
+  return new ChatCraftModel(OpenRouterProvider.defaultModel());
 };
 
 export type ChatOptions = {
@@ -111,12 +114,12 @@ function parseOpenAIResponse(response: OpenAI.Chat.ChatCompletion) {
 }
 
 export const transcribe = async (audio: File) => {
-  const { apiKey, apiUrl } = getSettings();
-  if (!apiKey) {
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiKey) {
     throw new Error("Missing OpenAI API Key");
   }
 
-  const { openai } = createClient(apiKey, apiUrl);
+  const { openai } = createClient(currentProvider?.apiKey, currentProvider?.apiUrl);
   const transcriptions = new OpenAI.Audio.Transcriptions(openai);
   const transcription = await transcriptions.create({
     file: audio,
@@ -255,11 +258,12 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
     throw new Error(`OpenAI API Returned Error: ${error.message}`);
   };
 
-  const { apiKey, apiUrl } = getSettings();
-  if (!apiKey) {
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiKey) {
     throw new Error("Missing API Key");
   }
-  const { openai, headers } = createClient(apiKey, apiUrl);
+
+  const { openai, headers } = createClient(currentProvider?.apiKey, currentProvider?.apiUrl);
 
   const chatCompletionParams: OpenAI.Chat.ChatCompletionCreateParams = {
     model: model ? model.id : getSettings().model.id,
@@ -350,8 +354,12 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
 };
 
 export async function queryModels(apiKey: string) {
-  const { apiUrl } = getSettings();
-  const { openai } = createClient(apiKey, apiUrl);
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiUrl) {
+    throw new Error("Missing API Url");
+  }
+
+  const { openai } = createClient(apiKey, currentProvider?.apiUrl);
 
   try {
     const models = [];
@@ -365,33 +373,13 @@ export async function queryModels(apiKey: string) {
   }
 }
 
-export async function validateOpenAiApiKey(apiKey: string) {
-  return !!(await queryModels(apiKey));
-}
-
-export async function validateOpenRouterApiKey(apiKey: string) {
-  // Use response from https://openrouter.ai/docs#limits to check if API key is valid
-  const res = await fetch(`https://openrouter.ai/api/v1/auth/key`, {
-    method: "GET",
-    headers: {
-      Authorization: `Bearer ${apiKey}`,
-    },
-  });
-
-  if (!res.ok) {
-    throw new Error(`${res.status} ${await res.text()}`);
-  }
-
-  return true;
-}
-
 export async function validateApiKey(apiKey: string) {
   if (usingOfficialOpenAI()) {
-    return validateOpenAiApiKey(apiKey);
+    return OpenAiProvider.validateApiKey(apiKey);
   }
 
   if (usingOfficialOpenRouter()) {
-    return validateOpenRouterApiKey(apiKey);
+    return OpenRouterProvider.validateApiKey(apiKey);
   }
 
   // If not either of those providers, something is wrong
@@ -441,23 +429,20 @@ export const calculateTokenCost = (tokens: number, model: ChatCraftModel) => {
   return 0;
 };
 
-export const openRouterPkceRedirect = () => {
-  const callbackUrl = location.origin;
-  // Redirect the user to the OpenRouter authentication page in the same tab
-  location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
-};
-
 /**
  * Only meant to be used outside components or hooks
  * where useModels cannot be used.
  */
 export async function isTtsSupported() {
-  const { apiKey } = getSettings();
-  if (!apiKey) {
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiKey) {
     throw new Error("Missing API Key");
   }
 
-  return (await queryModels(apiKey)).filter((model: string) => model.includes("tts"))?.length > 0;
+  return (
+    (await queryModels(currentProvider?.apiKey)).filter((model: string) => model.includes("tts"))
+      ?.length > 0
+  );
 }
 
 /**
@@ -466,11 +451,11 @@ export async function isTtsSupported() {
  * @returns The URL of generated audio clip
  */
 export const textToSpeech = async (message: string): Promise<string> => {
-  const { apiKey, apiUrl } = getSettings();
-  if (!apiKey) {
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiKey) {
     throw new Error("Missing API Key");
   }
-  const { openai } = createClient(apiKey, apiUrl);
+  const { openai } = createClient(currentProvider?.apiKey, currentProvider?.apiUrl);
 
   const mp3 = await openai.audio.speech.create({
     model: "tts-1",

--- a/src/lib/providers/OpenAiProvider.ts
+++ b/src/lib/providers/OpenAiProvider.ts
@@ -1,0 +1,37 @@
+import { queryModels } from "../ai";
+import {
+  ChatCraftProvider,
+  SerializedChatCraftProvider,
+  OPENAI_API_URL,
+  ProviderName,
+} from "../ChatCraftProvider";
+
+export type SerializedOpenAiProvider = {
+  id: string;
+  name: ProviderName;
+  apiUrl: string;
+  apiKey?: string;
+};
+
+export class OpenAiProvider extends ChatCraftProvider {
+  constructor(key?: string) {
+    super(OPENAI_API_URL, key);
+  }
+
+  // Parse from serialized JSON
+  static fromJSON({ apiKey }: SerializedChatCraftProvider): OpenAiProvider {
+    return new OpenAiProvider(apiKey);
+  }
+
+  static async validateApiKey(apiKey: string) {
+    return !!(await queryModels(apiKey));
+  }
+
+  static logoUrl() {
+    return "/openai-logo.png";
+  }
+
+  static defaultModel() {
+    return "gpt-3.5-turbo";
+  }
+}

--- a/src/lib/providers/OpenRouterProvider.ts
+++ b/src/lib/providers/OpenRouterProvider.ts
@@ -1,0 +1,55 @@
+import {
+  ChatCraftProvider,
+  SerializedChatCraftProvider,
+  OPENROUTER_API_URL,
+  ProviderName,
+} from "../ChatCraftProvider";
+
+export type SerializedOpenRouterProvider = {
+  id: string;
+  name: ProviderName;
+  apiUrl: string;
+  apiKey?: string;
+};
+
+export class OpenRouterProvider extends ChatCraftProvider {
+  constructor(key?: string) {
+    super(OPENROUTER_API_URL, key);
+  }
+
+  // Parse from serialized JSON
+  static fromJSON({ apiKey }: SerializedChatCraftProvider): OpenRouterProvider {
+    return new OpenRouterProvider(apiKey);
+  }
+
+  static async validateApiKey(apiKey: string) {
+    // Use response from https://openrouter.ai/docs#limits to check if API key is valid
+    const res = await fetch(`https://openrouter.ai/api/v1/auth/key`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`${res.status} ${await res.text()}`);
+    }
+
+    return true;
+  }
+
+  static openRouterPkceRedirect = () => {
+    const callbackUrl = location.origin;
+    // Redirect the user to the OpenRouter authentication page in the same tab
+    location.href = `https://openrouter.ai/auth?callback_url=${encodeURIComponent(callbackUrl)}`;
+  };
+
+  static logoUrl() {
+    // If we don't know, use the OpenAI logo as a fallback
+    return "/openai-logo.png";
+  }
+
+  static defaultModel() {
+    return "openai/gpt-3.5-turbo";
+  }
+}

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -1,0 +1,51 @@
+import {
+  ChatCraftProvider,
+  OPENAI_API_URL,
+  OPENROUTER_API_URL,
+  ProviderData,
+  SerializedChatCraftProvider,
+} from "../ChatCraftProvider";
+import { OpenAiProvider } from "./OpenAiProvider";
+import { OpenRouterProvider } from "./OpenRouterProvider";
+
+// Parses url into instance of ChatCraftProvider
+export function providerFromUrl(url: string, key?: string) {
+  if (url === OPENAI_API_URL) {
+    return new OpenAiProvider(key);
+  }
+
+  if (url === OPENROUTER_API_URL) {
+    return new OpenRouterProvider(key);
+  }
+
+  throw new Error(`Error parsing provider from url, unsupported url: ${url}`);
+}
+
+// Parse JSON into instance of ChatCraftProvider
+export function providerFromJSON({
+  id,
+  name,
+  apiUrl,
+  apiKey,
+}: SerializedChatCraftProvider): ChatCraftProvider {
+  if (apiUrl === OPENAI_API_URL) {
+    return OpenAiProvider.fromJSON({ id, name, apiUrl, apiKey });
+  }
+
+  if (apiUrl === OPENROUTER_API_URL) {
+    return OpenRouterProvider.fromJSON({ id, name, apiUrl, apiKey });
+  }
+
+  throw new Error(`Error parsing provider from JSON, unsupported url: ${apiUrl}`);
+}
+
+// Returns list of supported providers
+export const getSupportedProviders = (): ProviderData => {
+  const openAi = new OpenAiProvider();
+  const openRouter = new OpenRouterProvider();
+
+  return {
+    [openAi.apiUrl]: openAi,
+    [openRouter.apiUrl]: openRouter,
+  };
+};


### PR DESCRIPTION
Closes #478 

### Code changes:

- Created `providers/OpenAiProvider.ts`, `providers/OpenRouterAiProvider.ts`, `providers/index.ts` containing provider-specific methods

- Refactored code to use those methods and removed those methods from `ai.ts`

- Removed `settings.apiUrl` and `settings.apiKey` and replaced with `settings.currentProvider`

- Modified code **throughout the project** to use `settings.currentProvider` instead of the now removed `settings.apiUrl` and `settings.apiKey`

- Handled deserialization of `settings.currentProvider` in `deserializer` function of `settings.ts`
- Handled migration of `settings.apiUrl` and `settings.apiKey` deserializer function `settings.ts`. This means current users of ChatCraft will have their `settings.apiUrl` and `settings.apiKey` values migrated to `settings.currentProvider` and `settings.providers`, and then `settings.apiUrl` and `settings.apiKey` will be deleted afterwards from their localStorage

- the `API URL` dropdown field in `Instructions.tsx` now iterates through the list of `supportedProviders` (missed updating this last time)

### Test API key storage in currentProvider:

Open Chrome Dev Tools
![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/bda551e6-1df4-4d15-8e41-06ad71e5f6c8)
Your current apiKey and apiUrl is stored in settings.currentProvider
If you have keys of multiple providers stored, your providers are stored in settings.providers array

### Test Migration:

Paste the following to localStorage so that you will have apiKey and apiUrl in localStorage, then refresh the page to test the migration process. You have to replace YOUR_KEY with a valid OpenAI key.

```
{"model":"gpt-3.5-turbo","apiUrl":"https://api.openai.com/v1","temperature":0,"enterBehaviour":"send","countTokens":false,"sidebarVisible":false,"alwaysSendFunctionResult":false,"announceMessages":false,"apiKey":"YOUR_KEY"}
```