### PR TITLE
updated KaTeX rule in default system prompt to address inline KaTeX

### DIFF
--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,7 +10,7 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- If responding with math markdown, inline or otherwise, I use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
+- If responding with math markdown, inline or otherwise, I use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,7 +10,9 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- If responding with math, use KaTeX syntax in your math Markdown, inline or otherwise, by enclosing it with double-dollar signs rather than parentheses, for example: $$O(n\\log n)$$
+- If responding with math, I follow these rules:
+  - Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by ALWAYS enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
+  - I NEVER wrap mathematical expressions, equations, variables, or formulas in brackets or parentheses. For example, instead of responding with \(V_{max}\), I would respond with $$V_{max}$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,7 +10,7 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- If responding with math, use KaTeX syntax in your Markdown by enclosing it with double-dollar signs rather than parentheses, for example: $$O(n\\log n)$$
+- If responding with math, use KaTeX syntax in your math Markdown, inline or otherwise, by enclosing it with double-dollar signs rather than parentheses, for example: $$O(n\\log n)$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,9 +10,8 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- If responding with math, I follow these rules:
-  - Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by ALWAYS enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
-  - I NEVER wrap mathematical expressions, equations, variables, or formulas in brackets or parentheses. For example, instead of responding with \(V_{max}\), I would respond with $$V_{max}$$
+- Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
+- I NEVER wrap mathematical expressions, equations, variables, or formulas in round brackets, \`(\`, \`)\`. For example, instead of responding with (V_{max}), I would respond with $$V_{max}$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,8 +10,7 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
-- I NEVER wrap mathematical expressions, equations, variables, or formulas in round brackets, \`(\`, \`)\`. For example, instead of responding with (V_{max}), I would respond with $$V_{max}$$
+- When responding with math, inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,7 +10,7 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- When responding with math, inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
+- If responding with math markdown, inline or otherwise, I use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 `;
 
 export const defaultSystemPrompt = () => {

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -10,7 +10,7 @@ I follow these rules when responding:
 - Format ALL lines of code to 80 characters or fewer
 - Use Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
-- Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs ($$), for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
+- Inline or otherwise, I ALWAYS use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 - I NEVER wrap mathematical expressions, equations, variables, or formulas in round brackets, \`(\`, \`)\`. For example, instead of responding with (V_{max}), I would respond with $$V_{max}$$
 `;
 


### PR DESCRIPTION
This fixes #460

Summary
---
I've updated the system prompt to also wrap inline response elements in double-dollar signs for KaTeX rendering.

Observations
---
It looks like in the original issue, ChatCraft returns in-line math using [LaTeX math mode](https://www1.cmc.edu/pages/faculty/aaksoy/latex/latexthree.html#:~:text=There%20are%20a%20few%20ways,%5Cend%7Bequation%7D%20commands.) 
(e.g., `\(2^{20}\)` instead of `$$(2^{20})$$`)
When working on this issue I found that I had to be very explicit with the math rendering rules for consistent results.
I found that explicitly requesting KaTeX syntax for inline math expressions fixes the issue in #460 by either rendering inline math expressions in KaTeX or avoiding LaTeX math mode syntax.
I'll admit my current rules are verbose, but trying to shorten these rules gave me poor results.

Tests
---
[Replicating the conditions ](https://issue-460.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/hIlmNr-NQCNk8P6Yl3wxD) from #460: 
```
Sure! When converting bytes to megabytes, we divide the number of bytes by 1024 twice because:

1. There are 1024 bytes in a kilobyte (KB).
2. There are 1024 kilobytes in a megabyte (MB).

So, to convert bytes to megabytes, we divide the number of bytes by $$1024^2$$. This calculation gives us the equivalent size in megabytes.
```
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/84685e7f-9826-4918-8d4f-9f5c37337c71)


[Asking ChatCraft to describe a formula](https://issue-460.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/NDF2k7zbEg-RonWoi0kPz):
```
The Michaelis-Menten equation is a mathematical model that describes the rate of enzymatic reactions. It is commonly used in biochemistry to understand how enzymes interact with substrates. The formula is given by:

$$V = \frac{V_{max} \cdot [S]}{K_m + [S]}$$

Where:
- $$V$$ is the initial reaction velocity
- $$V_{max}$$ is the maximum reaction velocity
- $$[S]$$ is the substrate concentration
- $$K_m$$ is the Michaelis constant

The Michaelis-Menten equation shows that the reaction velocity ($$V$$) increases with increasing substrate concentration up to a point where the enzyme becomes saturated (approaching $$V_{max}$$). The Michaelis constant ($$K_m$$) represents the substrate concentration at which the reaction velocity is half of the maximum velocity.

This formula is essential for understanding enzyme kinetics and is widely used in biochemistry and pharmacology.
```
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/380415a9-c2a7-4b83-a4bf-ee165446d3c9)


[Quadratic formula](https://issue-460.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/20jBW9TyqtDyf7OIX8ilC):\
```
The quadratic formula is a formula used to find the roots of a quadratic equation of the form $$ax^2 + bx + c = 0$$. The roots are the values of $$x$$ that satisfy the equation.

The quadratic formula is given by: 

$$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$$

where:
- $$a$$, $$b$$, and $$c$$ are coefficients of the quadratic equation $$ax^2 + bx + c = 0$$
- $$\pm$$ indicates that there are two possible solutions, one with a plus sign and one with a minus sign
- $$\sqrt{b^2 - 4ac}$$ is the square root of the discriminant, which determines the nature of the roots:
  - If $$b^2 - 4ac > 0$$, the equation has two distinct real roots
  - If $$b^2 - 4ac = 0$$, the equation has one real root (a repeated root)
  - If $$b^2 - 4ac < 0$$, the equation has two complex roots

By substituting the coefficients $$a$$, $$b$$, and $$c$$ into the formula, you can find the values of $$x$$ that satisfy the quadratic equation.
```
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/98281751-2a92-4202-88c3-31b60af1afe1)
