### PR TITLE
Add loading indicator for the image compression

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -75,7 +75,7 @@ type OptionsButtonProps = {
   variant?: "outline" | "solid" | "ghost";
   iconOnly?: boolean;
   // Optional until we support on mobile...
-  onFileSelected?: (base64: string) => void;
+  onFileSelected?: (base64: string, index: number) => void;
   isDisabled?: boolean;
 };
 
@@ -103,9 +103,12 @@ function OptionsButton({
       if (files) {
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
+          onFileSelected("", i);
           if (file.type.startsWith("image/")) {
             compressImageToBase64(file)
-              .then((base64) => onFileSelected(base64))
+              .then((base64) => {
+                onFileSelected(base64, i);
+              })
               .catch((err) => {
                 console.error(err);
                 error({ title: "Error processing images", message: err.message });
@@ -113,7 +116,7 @@ function OptionsButton({
           } else {
             const reader = new FileReader();
             reader.onload = (e) => {
-              onFileSelected(e.target?.result as string);
+              onFileSelected(e.target?.result as string, i);
             };
             reader.readAsDataURL(file);
           }

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -75,7 +75,7 @@ type OptionsButtonProps = {
   variant?: "outline" | "solid" | "ghost";
   iconOnly?: boolean;
   // Optional until we support on mobile...
-  onFileSelected?: (base64: string, index: number) => void;
+  onFileSelected?: (base64: string) => void;
   isDisabled?: boolean;
 };
 
@@ -103,10 +103,10 @@ function OptionsButton({
       if (files) {
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
-          onFileSelected("", i);
           if (file.type.startsWith("image/")) {
+            onFileSelected("");
             compressImageToBase64(file)
-              .then((base64) => onFileSelected(base64, i))
+              .then((base64) => onFileSelected(base64))
               .catch((err) => {
                 console.error(err);
                 error({ title: "Error processing images", message: err.message });
@@ -114,7 +114,7 @@ function OptionsButton({
           } else {
             const reader = new FileReader();
             reader.onload = (e) => {
-              onFileSelected(e.target?.result as string, i);
+              onFileSelected(e.target?.result as string);
             };
             reader.readAsDataURL(file);
           }

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -106,9 +106,7 @@ function OptionsButton({
           onFileSelected("", i);
           if (file.type.startsWith("image/")) {
             compressImageToBase64(file)
-              .then((base64) => {
-                onFileSelected(base64, i);
-              })
+              .then((base64) => onFileSelected(base64, i))
               .catch((err) => {
                 console.error(err);
                 error({ title: "Error processing images", message: err.message });

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -16,7 +16,7 @@ import {
 import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
-import { getMetaKey, compressImageToBase64, updateImageUrlsAtIndex } from "../../lib/utils";
+import { getMetaKey, compressImageToBase64, updateImageUrls } from "../../lib/utils";
 import { TiDeleteOutline } from "react-icons/ti";
 import OptionsButton from "../OptionsButton";
 import MicIcon from "./MicIcon";
@@ -424,8 +424,8 @@ function DesktopPromptForm({
                   forkUrl={forkUrl}
                   variant="outline"
                   isDisabled={isLoading}
-                  onFileSelected={(base64String, index) => {
-                    updateImageUrlsAtIndex(base64String, index, setInputImageUrls);
+                  onFileSelected={(base64String) => {
+                    updateImageUrls(base64String, setInputImageUrls);
                   }}
                 />
 

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -16,7 +16,7 @@ import {
 import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
-import { getMetaKey, compressImageToBase64 } from "../../lib/utils";
+import { getMetaKey, compressImageToBase64, updateImageUrlsAtIndex } from "../../lib/utils";
 import { TiDeleteOutline } from "react-icons/ti";
 import OptionsButton from "../OptionsButton";
 import MicIcon from "./MicIcon";
@@ -425,11 +425,7 @@ function DesktopPromptForm({
                   variant="outline"
                   isDisabled={isLoading}
                   onFileSelected={(base64String, index) => {
-                    setInputImageUrls((prevImageUrls) => {
-                      const newImageUrls = prevImageUrls.length === 0 ? [""] : [...prevImageUrls];
-                      newImageUrls[index] = base64String;
-                      return newImageUrls;
-                    });
+                    updateImageUrlsAtIndex(base64String, index, setInputImageUrls);
                   }}
                 />
 

--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -1,5 +1,5 @@
 import { FormEvent, KeyboardEvent, useEffect, useState, type RefObject } from "react";
-import { Box, chakra, Flex, Image, CloseButton } from "@chakra-ui/react";
+import { Box, chakra, Flex, Image, CloseButton, Spinner } from "@chakra-ui/react";
 import AutoResizingTextarea from "../AutoResizingTextarea";
 
 import { useSettings } from "../../hooks/use-settings";
@@ -187,12 +187,24 @@ function MobilePromptForm({
                   alignItems="center"
                   m={2}
                 >
-                  <Image
-                    src={imageUrl}
-                    alt={`Image# ${index}`}
-                    style={{ height: "70px", objectFit: "cover" }}
-                    cursor="pointer"
-                  />
+                  {imageUrl === "" ? (
+                    <Box
+                      width={70}
+                      height={70}
+                      display="flex"
+                      alignItems="center"
+                      justifyContent="center"
+                    >
+                      <Spinner size="xl" />
+                    </Box>
+                  ) : (
+                    <Image
+                      src={imageUrl}
+                      alt={`Image# ${index}`}
+                      style={{ height: "70px", objectFit: "cover" }}
+                      cursor="pointer"
+                    />
+                  )}
                   <Box
                     key={`${index}-close`}
                     display="flex"

--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -11,7 +11,7 @@ import PromptSendButton from "./PromptSendButton";
 import AudioStatus from "./AudioStatus";
 import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
-import { updateImageUrlsAtIndex } from "../../lib/utils";
+import { updateImageUrls } from "../../lib/utils";
 
 type MobilePromptFormProps = {
   chat: ChatCraftChat;
@@ -171,8 +171,8 @@ function MobilePromptForm({
             forkUrl={forkUrl}
             variant="outline"
             iconOnly
-            onFileSelected={(base64String, index) => {
-              updateImageUrlsAtIndex(base64String, index, setInputImageUrls);
+            onFileSelected={(base64String) => {
+              updateImageUrls(base64String, setInputImageUrls);
             }}
           />
 

--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -11,6 +11,7 @@ import PromptSendButton from "./PromptSendButton";
 import AudioStatus from "./AudioStatus";
 import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
+import { updateImageUrlsAtIndex } from "../../lib/utils";
 
 type MobilePromptFormProps = {
   chat: ChatCraftChat;
@@ -170,9 +171,9 @@ function MobilePromptForm({
             forkUrl={forkUrl}
             variant="outline"
             iconOnly
-            onFileSelected={(base64String) =>
-              setInputImageUrls((prevImageUrls) => [...prevImageUrls, base64String])
-            }
+            onFileSelected={(base64String, index) => {
+              updateImageUrlsAtIndex(base64String, index, setInputImageUrls);
+            }}
           />
 
           <Box flex={1}>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -115,3 +115,16 @@ export const compressImageToBase64 = (file: File): Promise<string> => {
       throw err;
     });
 };
+
+export const updateImageUrlsAtIndex = (
+  base64String: string,
+  index: number,
+  setInputImageUrls: React.Dispatch<React.SetStateAction<string[]>>
+): void => {
+  setInputImageUrls((prevImageUrls) => {
+    // An empty string is used as an loading indicator, compressImageToBase64 update it after compression process
+    const newImageUrls = prevImageUrls.length === 0 ? [""] : [...prevImageUrls];
+    newImageUrls[index] = base64String;
+    return newImageUrls;
+  });
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -116,15 +116,24 @@ export const compressImageToBase64 = (file: File): Promise<string> => {
     });
 };
 
-export const updateImageUrlsAtIndex = (
+export const updateImageUrls = (
   base64String: string,
-  index: number,
   setInputImageUrls: React.Dispatch<React.SetStateAction<string[]>>
 ): void => {
   setInputImageUrls((prevImageUrls) => {
-    // An empty string is used as an loading indicator, compressImageToBase64 update it after compression process
-    const newImageUrls = prevImageUrls.length === 0 ? [""] : [...prevImageUrls];
-    newImageUrls[index] = base64String;
-    return newImageUrls;
+    if (base64String) {
+      const newImageUrls = [...prevImageUrls];
+      const placeholderIndex = prevImageUrls.indexOf("");
+      if (placeholderIndex !== -1) {
+        // Replace the first placeholder with the actual base64 string
+        newImageUrls[placeholderIndex] = base64String;
+      } else {
+        return [...prevImageUrls, base64String];
+      }
+      return newImageUrls;
+    } else {
+      //set imageUrl "" as placeholder
+      return [...prevImageUrls, ""];
+    }
   });
 };


### PR DESCRIPTION
## Explanation

I set the `imageUrl` to empty string firstly inside the process image functions and then update it with real url result when compression is done. If it is empty, the `spinner` in a square box will be rendered as loading status.

## Result

|**Desktop**|**Mobile**|
|:---:|:---:|
| ![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/0ef78a46-923e-485e-b298-4fedf179c144)| ![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/930182a5-6d2d-4455-b1b4-5622e0d6e407) |

Fixes: #467 