### PR TITLE
Make AudioPlayer queue global

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -45,6 +45,7 @@ import { ChatCraftCommandRegistry } from "../lib/commands";
 import { ChatCraftCommand } from "../lib/ChatCraftCommand";
 import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 import { TbSearch } from "react-icons/tb";
+import useAudioPlayer from "../hooks/use-audio-player";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -65,6 +66,7 @@ function ChatBase({ chat }: ChatBaseProps) {
   const inputPromptRef = useRef<HTMLTextAreaElement>(null);
   const { error } = useAlert();
   const { user } = useUser();
+  const { clearAudioQueue } = useAudioPlayer();
 
   // If we can't load models, it's a bad sign for API connectivity.
   // Show an error so the user is aware.
@@ -264,6 +266,8 @@ function ChatBase({ chat }: ChatBaseProps) {
 
         // NOTE: we strip out the ChatCraft App messages before sending to OpenAI.
         const messages = chat.messages({ includeAppMessages: false });
+        // Clear any previous audio clips
+        clearAudioQueue();
         const response = await callChatApi(messages, {
           functions,
           functionToCall,

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -5,6 +5,7 @@ import { TbMicrophone } from "react-icons/tb";
 import { useAlert } from "../../hooks/use-alert";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { SpeechRecognition } from "../../lib/speech-recognition";
+import useAudioPlayer from "../../hooks/use-audio-player";
 
 type MicIconProps = {
   onRecording: () => void;
@@ -26,8 +27,10 @@ export default function MicIcon({
   const micIconRef = useRef<HTMLButtonElement | null>(null);
   const speechRecognitionRef = useRef<SpeechRecognition | null>(null);
   const { error } = useAlert();
+  const { clearAudioQueue } = useAudioPlayer();
 
   const onRecordingStart = async () => {
+    clearAudioQueue();
     speechRecognitionRef.current = new SpeechRecognition();
 
     // Try to get access to the user's microphone. This may or may not work...

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -17,6 +17,7 @@ import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { usingOfficialOpenAI } from "../../lib/ai";
 import { useMemo } from "react";
+import useAudioPlayer from "../../hooks/use-audio-player";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -29,6 +30,8 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
   }, [models]);
+
+  const { clearAudioQueue } = useAudioPlayer();
 
   return (
     <ButtonGroup variant="outline" isAttached>
@@ -56,9 +59,13 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
               icon={
                 settings.announceMessages ? <MdVolumeUp size={25} /> : <MdVolumeOff size={25} />
               }
-              onClick={() =>
-                setSettings({ ...settings, announceMessages: !settings.announceMessages })
-              }
+              onClick={() => {
+                if (settings.announceMessages) {
+                  // Flush any remaining audio clips being announced
+                  clearAudioQueue();
+                }
+                setSettings({ ...settings, announceMessages: !settings.announceMessages });
+              }}
             />
           </Tooltip>
         )}
@@ -93,6 +100,8 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
   }, [models]);
 
+  const { clearAudioQueue } = useAudioPlayer();
+
   return (
     <ButtonGroup isAttached>
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
@@ -105,9 +114,13 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           <Button
             type="button"
             size="sm"
-            onClick={() =>
-              setSettings({ ...settings, announceMessages: !settings.announceMessages })
-            }
+            onClick={() => {
+              if (settings.announceMessages) {
+                // Flush any remaining audio clips being announced
+                clearAudioQueue();
+              }
+              setSettings({ ...settings, announceMessages: !settings.announceMessages });
+            }}
           >
             {settings.announceMessages ? <MdVolumeUp size={18} /> : <MdVolumeOff size={18} />}
           </Button>

--- a/src/hooks/use-audio-player.tsx
+++ b/src/hooks/use-audio-player.tsx
@@ -1,12 +1,25 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, createContext, useContext, ReactNode, FC } from "react";
 
-const useAudioPlayer = () => {
+type AudioPlayerContextType = {
+  addToAudioQueue: (audioClipUri: Promise<string>) => void;
+  clearAudioQueue: () => void;
+};
+
+const AudioPlayerContext = createContext<AudioPlayerContextType>({
+  addToAudioQueue: () => {},
+  clearAudioQueue: () => {},
+});
+
+const useAudioPlayer = () => useContext(AudioPlayerContext);
+
+export const AudioPlayerProvider: FC<{ children: ReactNode }> = ({ children }) => {
   // We are managing promises of audio urls instead of directly storing strings
   // because there is no guarantee when openai tts api finishes processing and resolves a specific url
   // For more info, check this comment:
   // https://github.com/tarasglek/chatcraft.org/pull/357#discussion_r1473470003
   const [queue, setQueue] = useState<Promise<string>[]>([]);
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
+  const [currentAudioUrl, setCurrentAudioUrl] = useState<string | null>();
 
   useEffect(() => {
     if (!isPlaying && queue.length > 0) {
@@ -19,18 +32,31 @@ const useAudioPlayer = () => {
     const audioUrl: string = await audioClipUri;
     const audio = new Audio(audioUrl);
     audio.onended = () => {
+      setCurrentAudioUrl(null);
       URL.revokeObjectURL(audioUrl);
       setQueue((oldQueue) => oldQueue.slice(1));
       setIsPlaying(false);
     };
     audio.play();
+    setCurrentAudioUrl(audioUrl);
   };
 
   const addToAudioQueue = (audioClipUri: Promise<string>) => {
     setQueue((oldQueue) => [...oldQueue, audioClipUri]);
   };
 
-  return { addToAudioQueue };
+  const clearAudioQueue = () => {
+    if (currentAudioUrl) {
+      URL.revokeObjectURL(currentAudioUrl);
+      setCurrentAudioUrl(null);
+    }
+
+    setQueue((oldQueue) => oldQueue.splice(0));
+  };
+
+  const value = { addToAudioQueue, clearAudioQueue };
+
+  return <AudioPlayerContext.Provider value={value}>{children}</AudioPlayerContext.Provider>;
 };
 
 export default useAudioPlayer;

--- a/src/hooks/use-audio-player.tsx
+++ b/src/hooks/use-audio-player.tsx
@@ -10,7 +10,10 @@ const AudioPlayerContext = createContext<AudioPlayerContextType>({
   clearAudioQueue: () => {},
 });
 
-const useAudioPlayer = () => useContext(AudioPlayerContext);
+type AudioClip = {
+  audioUrl: string;
+  audioElement: HTMLAudioElement;
+};
 
 export const AudioPlayerProvider: FC<{ children: ReactNode }> = ({ children }) => {
   // We are managing promises of audio urls instead of directly storing strings
@@ -69,9 +72,6 @@ export const AudioPlayerProvider: FC<{ children: ReactNode }> = ({ children }) =
   return <AudioPlayerContext.Provider value={value}>{children}</AudioPlayerContext.Provider>;
 };
 
-export default useAudioPlayer;
+const useAudioPlayer = () => useContext(AudioPlayerContext);
 
-type AudioClip = {
-  audioUrl: string;
-  audioElement: HTMLAudioElement;
-};
+export default useAudioPlayer;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,20 +9,23 @@ import { SettingsProvider } from "./hooks/use-settings";
 import { UserProvider } from "./hooks/use-user";
 import { ModelsProvider } from "./hooks/use-models";
 import { CostProvider } from "./hooks/use-cost";
+import { AudioPlayerProvider } from "./hooks/use-audio-player";
 
 ReactDOM.createRoot(document.querySelector("main") as HTMLElement).render(
   <React.StrictMode>
     <ChakraProvider theme={theme}>
-      <SettingsProvider>
-        <CostProvider>
-          <ModelsProvider>
-            <UserProvider>
-              <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-              <RouterProvider router={router} />
-            </UserProvider>
-          </ModelsProvider>
-        </CostProvider>
-      </SettingsProvider>
+      <AudioPlayerProvider>
+        <SettingsProvider>
+          <CostProvider>
+            <ModelsProvider>
+              <UserProvider>
+                <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+                <RouterProvider router={router} />
+              </UserProvider>
+            </ModelsProvider>
+          </CostProvider>
+        </SettingsProvider>
+      </AudioPlayerProvider>
     </ChakraProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
In #357, I was able to stream audio responses as the LLM response was generated and also optimize the playback.

But there were some problems with it, and follow ups were filed.

This is regarding one of those follow ups - #391.

The problem was that once an audio clip was added to the audio queue, there was no way to stop it from other parts of the application since every invocation to `useAudioPlayer` hook resulted in a fresh audio queue. This was pretty annoying and made the TTS feature unusable as users had to wait for the previous message announcement to finish before it started playing for the next one.

To fix this issue, I have made the Audio Player queue global, by creating and providing an `AudioPlayerContext` at the root of the application.

https://github.com/tarasglek/chatcraft.org/compare/amnish04/global-audio-player?expand=1#diff-1cd8b18798a1a103bfe13bef54354c1f3a3bea29a31c8eea1a0c67a3a839b811

This allowed me to expose another function from the hook called `clearAudioQueue` which can now be called from any application component to pause the current audio clip, and flush the remaining clips in the queue.

Currently, I am using it for 2 scenarios:
1. The audio for previous message will instantly stop playing as soon as the user asks a new question.
2. Any audio clips being played via `useAudioPlayer` will instantly stop as soon as the user disables the TTS setting.

This approach also makes the audio system more robust any we now have a single source of truth for audio clips, and the risk to play multiple audio clips at once is also reduced.

This fixes #391 