### PR TITLE
Use a Natural Language Processing library to parse LLM response for TTS generation

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -463,7 +463,7 @@ export async function isTtsSupported() {
 /**
  *
  * @param message The text for which speech needs to be generated
- * @returns The URL of generated audio clip
+ * @returns A Promise that resolves to the URL of generated audio clip
  */
 export const textToSpeech = async (message: string): Promise<string> => {
   const { apiKey, apiUrl } = getSettings();

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -48,7 +48,7 @@ function markdownToPlainText(markdown: string) {
   return removeMarkdown(markdown).replace(/\r?\n/g, " ").replace(/ {2,}/g, " ");
 }
 
-function tokenize(text: string) {
+export function tokenize(text: string) {
   const sentences: string[] = nlp(text)
     .json()
     .map((s: { text: string }) => s.text);


### PR DESCRIPTION
In #357, wrote a custom regular expression to parse LLM response into sentences and stream them to TTS API.

However, it was suggested that I should be using an [nlp](https://www.techtarget.com/searchenterpriseai/definition/natural-language-processing-NLP) library called [compromise](https://github.com/spencermountain/compromise?tab=readme-ov-file) for parsing purposes, which is what I've done in this PR.

1. I am now using `tokenize` methods defined in `summarize.ts` that was already using this library.
2. When a sentence starts going over the **Buffer Threshold** (that I have set to 25 words), I try to break it into clauses using the library and pass the first clause for speech generation.
3. Updated the docstring for `textToSpeech` function, which was a little inaccurate before.

This closes #386 