### PR TITLE
Fix redundant scrollbar bug caused by React Menu

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -20,6 +20,7 @@ const Menu: React.FC<MenuProps> = (props) => {
   return (
     <Box>
       <ReactMenu
+        align={"end"}
         theming={colorMode === "dark" ? "dark" : undefined}
         menuButton={
           <IconButton

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -5,7 +5,13 @@ import React from "react";
 const SubMenu: React.FC<SubMenuProps> = (props) => {
   return (
     <Box>
-      <ReactMenuSubMenu {...props}>{props.children}</ReactMenuSubMenu>
+      <ReactMenuSubMenu
+        menuStyle={{ maxHeight: "50vw", overflow: "auto" }}
+        align="center"
+        {...props}
+      >
+        {props.children}
+      </ReactMenuSubMenu>
     </Box>
   );
 };


### PR DESCRIPTION
#374 added [React Menu](https://szhsin.github.io/react-menu/docs) wrapper components and started replacing the existing Chakra Menus.

However, it also introduced a bug where the we get a redundant scrollbar on smaller screens with menu expanded. There was also an issue where the viewport auto-scrolled when I tried opening a submenu with a lot of options.

**Issue Demo**

![301360044-7f8fa02b-da98-4652-bb21-9a08b5902b4b](https://github.com/tarasglek/chatcraft.org/assets/78865303/c2b0af45-7be6-475a-8601-0a5fe7df67fb)

***
![301359889-a28dde0e-d41a-4b4c-974c-8c2af6f845e5](https://github.com/tarasglek/chatcraft.org/assets/78865303/a393e975-d3b8-4979-93b5-129f2f14c465)

***

In this PR, I have tried to pin-point the causes and fix these issues.

1. The scrollbar issue was happening as the menu was positioned in a manner that made if overflow horizontal in its parent container. To fix that I have used the `align` property to make sure it stays inside the container's available space.
2. The auto-scroll issue was occurring when the list of options in the submenu was pretty long and the first list element tried to gain focus automatically. I have capped the max-height of submenus and added vertical scrollbars if the list grows beyond that limit. I made sure that it aligns with [recommended UX guidelines](https://balsamiq.com/learn/ui-control-guidelines/scrollbars/#scrolling-in-a-dropdown) before making the decision.

This closes #398 