### PR TITLE
Add Dynamic Imports for Mermaid

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -4,7 +4,6 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
-import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 
 // Use highlight.js (via lowlight) vs. prism.js (via refractor) due to
@@ -17,6 +16,9 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
+
+// Load rehypeKatex dynamically at runtime if needed due to size
+const rehypeKatex = await import("rehype-katex");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -65,7 +67,6 @@ function Markdown({
   className = "message-text",
 }: MarkdownProps) {
   const style = useColorModeValue(oneLight, oneDark);
-
   return (
     <ReactMarkdown
       className={className}
@@ -74,7 +75,7 @@ function Markdown({
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],
-        rehypeKatex,
+        rehypeKatex.default,
       ]}
       components={{
         code({ className, children, ...props }) {

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,7 +2,6 @@ import { memo } from "react";
 import { Box, useColorModeValue } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
@@ -17,6 +16,8 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
+
+const remarkMath = await import("remark-math");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -70,7 +71,7 @@ function Markdown({
     <ReactMarkdown
       className={className}
       children={children}
-      remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
+      remarkPlugins={[remarkGfm, [remarkMath.default, { singleDollarTextMath: false }]]}
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import { Box, useColorModeValue } from "@chakra-ui/react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
@@ -16,8 +17,6 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
-
-const remarkMath = await import("remark-math");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -71,7 +70,7 @@ function Markdown({
     <ReactMarkdown
       className={className}
       children={children}
-      remarkPlugins={[remarkGfm, [remarkMath.default, { singleDollarTextMath: false }]]}
+      remarkPlugins={[remarkGfm, [remarkMath, { singleDollarTextMath: false }]]}
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeExternalLinks from "rehype-external-links";
+import rehypeKatex from "rehype-katex";
 import "katex/dist/katex.min.css";
 
 // Use highlight.js (via lowlight) vs. prism.js (via refractor) due to
@@ -16,9 +17,6 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
-
-// Load rehypeKatex dynamically at runtime if needed due to size
-const rehypeKatex = await import("rehype-katex");
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -67,6 +65,7 @@ function Markdown({
   className = "message-text",
 }: MarkdownProps) {
   const style = useColorModeValue(oneLight, oneDark);
+
   return (
     <ReactMarkdown
       className={className}
@@ -75,7 +74,7 @@ function Markdown({
       rehypePlugins={[
         // Open links in new tab
         [rehypeExternalLinks, { target: "_blank" }],
-        rehypeKatex.default,
+        rehypeKatex,
       ]}
       components={{
         code({ className, children, ...props }) {

--- a/src/components/MermaidPreview.tsx
+++ b/src/components/MermaidPreview.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
-import mermaid from "mermaid";
 import { TbCopy } from "react-icons/tb";
 import { nanoid } from "nanoid";
 import { useAlert } from "../hooks/use-alert";
@@ -25,24 +24,27 @@ const MermaidPreview = ({ children }: MermaidPreviewProps) => {
 
   // Render the diagram as an SVG into our card's body
   useEffect(() => {
-    const diagramDiv = diagramRef.current;
-    if (!diagramDiv) {
-      return;
-    }
-
-    const mermaidDiagramId = `mermaid-diagram-${nanoid().toLowerCase()}`;
-    mermaid
-      .render(mermaidDiagramId, code, diagramDiv)
-      .then(({ svg, bindFunctions }) => {
-        setValue(svg);
-        diagramDiv.innerHTML = svg;
-        bindFunctions?.(diagramDiv);
-      })
-      .catch((err) => {
-        // When the diagram fails, use the error vs. diagram for copying (to debug)
-        setValue(err);
-        console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err);
-      });
+    const renderMermaidDiagram = async () => {
+      const diagramDiv = diagramRef.current;
+      if (!diagramDiv) {
+        return;
+      }
+      const mermaidDiagramId = `mermaid-diagram-${nanoid().toLowerCase()}`;
+      const mermaid = await import("mermaid");
+      mermaid.default
+        .render(mermaidDiagramId, code, diagramDiv)
+        .then(({ svg, bindFunctions }) => {
+          setValue(svg);
+          diagramDiv.innerHTML = svg;
+          bindFunctions?.(diagramDiv);
+        })
+        .catch((err) => {
+          // When the diagram fails, use the error vs. diagram for copying (to debug)
+          setValue(err);
+          console.warn(`Error rendering mermaid diagram ${mermaidDiagramId}`, err);
+        });
+    };
+    renderMermaidDiagram();
   }, [diagramRef, code, setValue]);
 
   return (

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useLayoutEffect, useMemo } from "react";
 import { Box, useColorMode } from "@chakra-ui/react";
-import mermaid from "mermaid";
 
 import Message from "./Message";
 import NewMessage from "./Message/NewMessage";
@@ -44,11 +43,15 @@ function MessagesView({
   // Make sure that any Mermaid diagrams use the same light/dark theme as rest of app.
   // Use a layout effect vs. regular effect so it happens after DOM is ready.
   useLayoutEffect(() => {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: colorMode === "dark" ? "dark" : "default",
-      securityLevel: "loose",
-    });
+    const initializeMermaid = async () => {
+      const mermaid = await import("mermaid");
+      mermaid.default.initialize({
+        startOnLoad: false,
+        theme: colorMode === "dark" ? "dark" : "default",
+        securityLevel: "loose",
+      });
+    };
+    initializeMermaid();
   }, [colorMode]);
 
   // Memoize the onRemoveMessage callback to reduce re-renders


### PR DESCRIPTION
This is a partial fix for #365

Summary
---

`src/components/MermaidPreview.tsx` **and** `src/components/MessagesView.tsx`: Changed the following module to dynamic import:
- **mermaid** (directly depends on `elkjs` and `cytoscape`)


Explanation
---

#365  identified three large modules for dynamic importing:
1. **elkjs** (for Mermaid)
2. **cytoscape** (for Mermaid)
3. **katex** (for Math rendering)

The **elkjs** and **cytoscape** modules are _both_ dependencies of **mermaid**:
https://github.com/tarasglek/chatcraft.org/blob/ca5ef709661bfc7415638d1708a1e539d7a858aa/pnpm-lock.yaml#L7688-L7701

Dynamically importing the mermaid package will load these packages only when they're needed.