### PR TITLE
Add: Generate Image by DALL·E 3

### DIFF
--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -17,7 +17,9 @@ Some commands accept arguments as well.
 | /new          | Creates a new chat. |
 | /clear        | Erases all messages in the current chat. |
 | /summary&nbsp;[max-length] | Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500). |
-| /import&nbsp;<url> | Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command. |`;
+| /import&nbsp;<url> | Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command. |
+| /image&nbsp;<prompt> | Creates an image using the provided prompt.|
+`;
 
 const helpText = `## ChatCraft.org Help
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -401,6 +401,8 @@ type dalle3ImageSize = "1024x1024" | "1792x1024" | "1024x1792";
 
 export const generateImage = async (
   prompt: string,
+  //You can request 1 image at a time with DALL·E 3 (request more by making parallel requests) or up to 10 images at a time using DALL·E 2 with the n parameter.
+  //https://platform.openai.com/docs/guides/images/generations
   n: number = 1,
   size: dalle3ImageSize = "1024x1024"
 ): Promise<string[]> => {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -433,9 +433,9 @@ export const generateImage = async (
   try {
     const response = await openai.images.generate({
       model: "dall-e-3",
-      prompt: prompt,
-      n: n,
-      size: size,
+      prompt,
+      n,
+      size,
     });
 
     const imageUrls = response.data.map((img: any) => img.url);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -411,7 +411,7 @@ export const generateImage = async (
     throw new Error("Missing OpenAI API Key");
   }
 
-  const { openai } = createClient(currentProvider?.apiKey, currentProvider?.apiUrl);
+  const { openai } = currentProvider.createClient(currentProvider.apiKey);
 
   try {
     const response = await openai.images.generate({

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -419,7 +419,6 @@ export const generateImage = async (
       size: size,
     });
 
-    // Assuming the response structure has an array of generated images
     const imageUrls = response.data.map((img: any) => img.url);
     return imageUrls;
   } catch (error: any) {

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -396,3 +396,33 @@ export const textToSpeech = async (message: string): Promise<string> => {
 
   return objectUrl;
 };
+
+type dalle3ImageSize = "1024x1024" | "1792x1024" | "1024x1792";
+
+export const generateImage = async (
+  prompt: string,
+  n: number = 1,
+  size: dalle3ImageSize = "1024x1024"
+): Promise<string[]> => {
+  const { currentProvider } = getSettings();
+  if (!currentProvider?.apiKey) {
+    throw new Error("Missing OpenAI API Key");
+  }
+
+  const { openai } = createClient(currentProvider?.apiKey, currentProvider?.apiUrl);
+
+  try {
+    const response = await openai.images.generate({
+      model: "dall-e-3",
+      prompt: prompt,
+      n: n,
+      size: size,
+    });
+
+    // Assuming the response structure has an array of generated images
+    const imageUrls = response.data.map((img: any) => img.url);
+    return imageUrls;
+  } catch (error: any) {
+    throw new Error(`Failed to generate image: ${error.message}`);
+  }
+};

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -397,6 +397,23 @@ export const textToSpeech = async (message: string): Promise<string> => {
   return objectUrl;
 };
 
+/**
+ * Only meant to be used outside components or hooks
+ * where useModels cannot be used.
+ */
+export async function isGenerateImageSupported() {
+  const { currentProvider } = getSettings();
+  if (!currentProvider.apiKey) {
+    throw new Error("Missing API Key");
+  }
+
+  return (
+    (await currentProvider.queryModels(currentProvider.apiKey)).filter((model: string) =>
+      model.includes("dall-e-3")
+    )?.length > 0
+  );
+}
+
 type dalle3ImageSize = "1024x1024" | "1792x1024" | "1024x1792";
 
 export const generateImage = async (
@@ -407,7 +424,7 @@ export const generateImage = async (
   size: dalle3ImageSize = "1024x1024"
 ): Promise<string[]> => {
   const { currentProvider } = getSettings();
-  if (!currentProvider?.apiKey) {
+  if (!currentProvider.apiKey) {
     throw new Error("Missing OpenAI API Key");
   }
 
@@ -424,6 +441,6 @@ export const generateImage = async (
     const imageUrls = response.data.map((img: any) => img.url);
     return imageUrls;
   } catch (error: any) {
-    throw new Error(`Failed to generate image: ${error.message}`);
+    throw new Error(error);
   }
 };

--- a/src/lib/commands/DALLE3Command.ts
+++ b/src/lib/commands/DALLE3Command.ts
@@ -9,8 +9,6 @@ export class DALLE3Command extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {
-    // return chat.resetMessages();
-
     if (!(args && args[0])) {
       throw new Error("must include a prompt");
     }

--- a/src/lib/commands/DALLE3Command.ts
+++ b/src/lib/commands/DALLE3Command.ts
@@ -1,0 +1,29 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { ChatCraftHumanMessage } from "../ChatCraftMessage";
+import { generateImage } from "../../lib/ai";
+
+export class DALLE3Command extends ChatCraftCommand {
+  constructor() {
+    super("DALLE3");
+  }
+
+  async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {
+    // return chat.resetMessages();
+
+    if (!(args && args[0])) {
+      throw new Error("must include a prompt");
+    }
+    const prompt = args.join(" ");
+    let imageUrls: string[] = [];
+    const text = `(DALL·E 3 result of the prompt: ${prompt})`;
+
+    try {
+      imageUrls = await generateImage(prompt);
+    } catch (error: any) {
+      console.error("Failed to generate image:", error);
+      throw new Error("Failed to generate image ", error);
+    }
+    return chat.addMessage(new ChatCraftHumanMessage({ user, text, imageUrls }));
+  }
+}

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -3,9 +3,9 @@ import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
 import { generateImage } from "../../lib/ai";
 
-export class DALLE3Command extends ChatCraftCommand {
+export class ImageCommand extends ChatCraftCommand {
   constructor() {
-    super("DALLE3");
+    super("image");
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -1,7 +1,7 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
-import { generateImage } from "../../lib/ai";
+import { generateImage, isGenerateImageSupported } from "../../lib/ai";
 
 export class ImageCommand extends ChatCraftCommand {
   constructor() {
@@ -9,6 +9,9 @@ export class ImageCommand extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {
+    if (!(await isGenerateImageSupported())) {
+      throw new Error("Failed to generate image, no image generation models available");
+    }
     if (!(args && args[0])) {
       throw new Error("must include a prompt");
     }
@@ -19,8 +22,8 @@ export class ImageCommand extends ChatCraftCommand {
     try {
       imageUrls = await generateImage(prompt);
     } catch (error: any) {
-      console.error("Failed to generate image:", error);
-      throw new Error("Failed to generate image ", error);
+      console.error(`Failed to generate image: ${error.message}`);
+      throw new Error(`Failed to generate image: ${error.message}`);
     }
     return chat.addMessage(new ChatCraftHumanMessage({ user, text, imageUrls }));
   }

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -7,6 +7,7 @@ import { SummaryCommand } from "./SummaryCommand";
 import { HelpCommand } from "./HelpCommand";
 import { ImportCommand } from "./ImportCommand";
 import { CommandsHelpCommand } from "./CommandsHelpCommand";
+import { DALLE3Command } from "./DALLE3Command";
 
 // Register all our commands
 ChatCraftCommandRegistry.registerCommand(new NewCommand());
@@ -15,3 +16,4 @@ ChatCraftCommandRegistry.registerCommand(new SummaryCommand());
 ChatCraftCommandRegistry.registerCommand(new HelpCommand());
 ChatCraftCommandRegistry.registerCommand(new CommandsHelpCommand());
 ChatCraftCommandRegistry.registerCommand(new ImportCommand());
+ChatCraftCommandRegistry.registerCommand(new DALLE3Command());

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -7,7 +7,7 @@ import { SummaryCommand } from "./SummaryCommand";
 import { HelpCommand } from "./HelpCommand";
 import { ImportCommand } from "./ImportCommand";
 import { CommandsHelpCommand } from "./CommandsHelpCommand";
-import { DALLE3Command } from "./DALLE3Command";
+import { ImageCommand } from "./ImageCommand";
 
 // Register all our commands
 ChatCraftCommandRegistry.registerCommand(new NewCommand());
@@ -16,4 +16,4 @@ ChatCraftCommandRegistry.registerCommand(new SummaryCommand());
 ChatCraftCommandRegistry.registerCommand(new HelpCommand());
 ChatCraftCommandRegistry.registerCommand(new CommandsHelpCommand());
 ChatCraftCommandRegistry.registerCommand(new ImportCommand());
-ChatCraftCommandRegistry.registerCommand(new DALLE3Command());
+ChatCraftCommandRegistry.registerCommand(new ImageCommand());


### PR DESCRIPTION
## Description
The function `generateImage` calls the [`dall-e-3`](https://platform.openai.com/docs/guides/images/image-generation) model api to get results. Add a new command `image` on user side to display the image generated. 

## How to test
Enter `prompt` after command `image` in the input area: `/image ${prompt}`
Example: `/image Happy White Border Collie. Close up`

Fixes: #124