### PR TITLE
Cap submenu maxHeight to 50vh to prevent weird autoscroll

### DIFF
--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -1,18 +1,11 @@
-import { Box } from "@chakra-ui/react";
 import { SubMenu as ReactMenuSubMenu, type SubMenuProps } from "@szhsin/react-menu";
 import React from "react";
 
 const SubMenu: React.FC<SubMenuProps> = (props) => {
   return (
-    <Box>
-      <ReactMenuSubMenu
-        menuStyle={{ maxHeight: "50vw", overflow: "auto" }}
-        align="center"
-        {...props}
-      >
-        {props.children}
-      </ReactMenuSubMenu>
-    </Box>
+    <ReactMenuSubMenu menuStyle={{ maxHeight: "50vh", overflow: "auto" }} align="center" {...props}>
+      {props.children}
+    </ReactMenuSubMenu>
   );
 };
 


### PR DESCRIPTION
This has been an issue for a long time. When we have a lot of items in a submenu, we get a weird autoscroll that tried to focus the first element of the list (which was not able to fit in the available viewport height).

I tried to fix this in #487, but it had a subtle mistake where I set `maxHeight` to `50vw` instead of `50vh` due to which the bug wasn't fixed properly.

I have corrected that mistake and the results are much better now.
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/36fca586-b3b7-42ae-ba66-ff736a12d491)

This fixes #454 