### PR TITLE
Add FreeModelProvider and more provider refactoring

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -154,7 +154,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                       {title}
                     </Link>
                   </Text>
-                  {settings.currentProvider?.apiKey && (
+                  {settings.currentProvider.apiKey && (
                     <IconButton
                       variant="ghost"
                       size="sm"
@@ -179,7 +179,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                 <MenuItem onClick={() => handleCopyChatClick()}>Copy</MenuItem>
                 <MenuItem onClick={() => handleDownloadClick()}>Download</MenuItem>
 
-                {!chat.readonly && settings.currentProvider?.apiKey && (
+                {!chat.readonly && settings.currentProvider.apiKey && (
                   <>
                     <MenuDivider />
                     <MenuItem onClick={onOpen}>Share Chat...</MenuItem>

--- a/src/components/Message/AiMessage.tsx
+++ b/src/components/Message/AiMessage.tsx
@@ -96,7 +96,7 @@ function AiMessage(props: AiMessageProps) {
 
   const handleRetryClick = useCallback(
     async (model: ChatCraftModel) => {
-      if (!settings.currentProvider?.apiKey) {
+      if (!settings.currentProvider.apiKey) {
         return;
       }
 
@@ -130,7 +130,7 @@ function AiMessage(props: AiMessageProps) {
         setRetrying(false);
       }
     },
-    [props.chatId, settings.currentProvider?.apiKey, message, callChatApi]
+    [props.chatId, settings.currentProvider.apiKey, message, callChatApi]
   );
 
   // While we're streaming in a new version, use a different display

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -60,10 +60,10 @@ import { useCopyToClipboard } from "react-use";
 // Styles for the message text are defined in CSS vs. Chakra-UI
 import "./Message.css";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
-import { usingOfficialOpenAI } from "../../lib/ai";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { useLiveQuery } from "dexie-react-hooks";
 import { useUser } from "../../hooks/use-user";
+import { usingOfficialOpenAI } from "../../lib/providers";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -80,7 +80,7 @@ function MessagesView({
     if (
       messages.length === 1 &&
       messages[0] instanceof ChatCraftSystemMessage &&
-      !settings.currentProvider?.apiKey
+      !settings.currentProvider.apiKey
     ) {
       return;
     }
@@ -115,7 +115,7 @@ function MessagesView({
     });
   }, [
     messages,
-    settings.currentProvider?.apiKey,
+    settings.currentProvider.apiKey,
     chatId,
     onPrompt,
     isLoading,
@@ -125,7 +125,7 @@ function MessagesView({
 
   const instructions = useMemo(() => {
     // If there's no API key in storage, show instructions so we get one
-    if (!settings.currentProvider?.apiKey) {
+    if (!settings.currentProvider.apiKey) {
       const message = ChatCraftAppMessage.instructions();
       return (
         <Message
@@ -138,7 +138,7 @@ function MessagesView({
         />
       );
     }
-  }, [settings.currentProvider?.apiKey, chatId, onPrompt, isLoading]);
+  }, [settings.currentProvider.apiKey, chatId, onPrompt, isLoading]);
 
   return (
     <Box minHeight="100%" scrollBehavior="smooth">

--- a/src/components/ModelAvatar.tsx
+++ b/src/components/ModelAvatar.tsx
@@ -12,6 +12,9 @@ export default function ModelAvatar({ model, size }: { model: ChatCraftModel; si
   if (id.includes("gpt-3.5-turbo")) {
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
+  if (id.includes("free")) {
+    return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
+  }
 
   // For now, all the rest use the same colour, or just the logo's background
   return (

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -15,9 +15,9 @@ import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
-import { usingOfficialOpenAI } from "../../lib/ai";
 import { useMemo } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
+import { usingOfficialOpenAI } from "../../lib/providers";
 
 type PromptSendButtonProps = {
   isLoading: boolean;

--- a/src/components/PromptForm/index.tsx
+++ b/src/components/PromptForm/index.tsx
@@ -20,7 +20,7 @@ export default function PromptForm(props: PromptFormProps) {
   const isMobile = useMobileBreakpoint();
 
   // Skip showing anything if we don't have an API Key to use
-  if (!settings.currentProvider?.apiKey) {
+  if (!settings.currentProvider.apiKey) {
     return null;
   }
 

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -85,7 +85,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
   );
 
   const handleSummarizeClick = useCallback(async () => {
-    if (!settings.currentProvider?.apiKey) {
+    if (!settings.currentProvider.apiKey) {
       return;
     }
     try {
@@ -98,7 +98,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
     } finally {
       setIsSummarizing(false);
     }
-  }, [settings.currentProvider?.apiKey, chat, setIsSummarizing, summarizeChat]);
+  }, [settings.currentProvider.apiKey, chat, setIsSummarizing, summarizeChat]);
 
   const handleCopyClick = useCallback(() => {
     copyToClipboard(url);
@@ -120,7 +120,7 @@ function AuthenticatedForm({ chat, user }: AuthenticatedForm) {
           <Button
             variant="outline"
             onClick={() => handleSummarizeClick()}
-            isDisabled={!settings.currentProvider?.apiKey}
+            isDisabled={!settings.currentProvider.apiKey}
             isLoading={isSummarizing}
             loadingText="Summarizing..."
           >

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -8,10 +8,10 @@ import {
   type FC,
 } from "react";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import { queryModels, defaultModelForProvider } from "../lib/ai";
+import { getSettings } from "../lib/settings";
 import { useSettings } from "./use-settings";
 
-const defaultModels = [defaultModelForProvider()];
+const defaultModels = [getSettings().currentProvider.defaultModelForProvider()];
 
 type ModelsContextType = {
   models: ChatCraftModel[];
@@ -35,7 +35,7 @@ const pickDefaultModel = (currentModel: ChatCraftModel, models: ChatCraftModel[]
     return currentModel;
   }
 
-  return defaultModelForProvider();
+  return getSettings().currentProvider.defaultModelForProvider();
 };
 
 export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
@@ -45,7 +45,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const { settings, setSettings } = useSettings();
 
   useEffect(() => {
-    const apiKey = settings.currentProvider?.apiKey;
+    const apiKey = settings.currentProvider.apiKey;
     if (!apiKey || isFetching.current) {
       return;
     }
@@ -53,7 +53,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const fetchModels = async () => {
       isFetching.current = true;
       try {
-        const models = await queryModels(apiKey).then((models) => {
+        const models = await settings.currentProvider.queryModels(apiKey).then((models) => {
           return models.map((modelName) => new ChatCraftModel(modelName));
         });
         models.sort((a, b) => a.prettyModel.localeCompare(b.prettyModel));

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -1,9 +1,10 @@
 import { nanoid } from "nanoid";
 import db, { type ChatCraftMessageTable } from "./db";
 import { ChatCraftModel } from "./ChatCraftModel";
-import { countTokens, defaultModelForProvider } from "./ai";
+import { countTokens } from "./ai";
 import { loadFunctions, parseFunctionNames } from "./ChatCraftFunction";
 import OpenAI from "openai";
+import { getSettings } from "./settings";
 
 export class ChatCraftAiMessageVersion {
   id: string;
@@ -302,7 +303,9 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
     return new ChatCraftAiMessage({
       id: message.id,
       date: new Date(message.date),
-      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
+      model: message.model
+        ? new ChatCraftModel(message.model)
+        : getSettings().currentProvider.defaultModelForProvider(),
       text: message.text,
       versions: message.versions?.map(
         (version) =>
@@ -320,7 +323,9 @@ export class ChatCraftAiMessage extends ChatCraftMessage {
     return new ChatCraftAiMessage({
       id: message.id,
       date: message.date,
-      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
+      model: message.model
+        ? new ChatCraftModel(message.model)
+        : getSettings().currentProvider.defaultModelForProvider(),
       text: message.text,
       versions: message.versions?.map(
         (version) =>
@@ -600,7 +605,9 @@ export class ChatCraftFunctionCallMessage extends ChatCraftMessage {
       id: message.id,
       date: new Date(message.date),
       func: message.func,
-      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
+      model: message.model
+        ? new ChatCraftModel(message.model)
+        : getSettings().currentProvider.defaultModelForProvider(),
       text: message.text,
       readonly: true,
     });
@@ -619,7 +626,9 @@ export class ChatCraftFunctionCallMessage extends ChatCraftMessage {
       id: message.id,
       date: message.date,
       func: message.func,
-      model: message.model ? new ChatCraftModel(message.model) : defaultModelForProvider(),
+      model: message.model
+        ? new ChatCraftModel(message.model)
+        : getSettings().currentProvider.defaultModelForProvider(),
       text: message.text,
     });
   }

--- a/src/lib/providers/DefaultProvider/FreeModelProvider.ts
+++ b/src/lib/providers/DefaultProvider/FreeModelProvider.ts
@@ -1,0 +1,35 @@
+import { ChatCraftModel } from "../../ChatCraftModel";
+import { ChatCraftProvider, FREEMODELPROVIDER_API_URL } from "../../ChatCraftProvider";
+
+export class FreeModelProvider extends ChatCraftProvider {
+  constructor() {
+    super(FREEMODELPROVIDER_API_URL, "mock_key");
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async queryModels(key: string) {
+    const res = await fetch(`${FREEMODELPROVIDER_API_URL}/models`, {
+      method: "GET",
+    });
+
+    if (!res.ok) {
+      throw new Error(`${res.status} ${await res.text()}`);
+    }
+
+    try {
+      const result = await res.json();
+      return result.data.map((model: { id: string }) => model.id) as string[];
+    } catch (err: any) {
+      throw new Error(`error querying models API: ${err.message}`);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async validateApiKey(key: string) {
+    return true;
+  }
+
+  defaultModelForProvider() {
+    return new ChatCraftModel("openchat/openchat-7b:free");
+  }
+}

--- a/src/lib/providers/OpenAiProvider.ts
+++ b/src/lib/providers/OpenAiProvider.ts
@@ -1,4 +1,4 @@
-import { queryModels } from "../ai";
+import { ChatCraftModel } from "../ChatCraftModel";
 import {
   ChatCraftProvider,
   SerializedChatCraftProvider,
@@ -18,20 +18,20 @@ export class OpenAiProvider extends ChatCraftProvider {
     super(OPENAI_API_URL, key);
   }
 
+  get logoUrl() {
+    return "/openai-logo.png";
+  }
+
   // Parse from serialized JSON
   static fromJSON({ apiKey }: SerializedChatCraftProvider): OpenAiProvider {
     return new OpenAiProvider(apiKey);
   }
 
-  static async validateApiKey(apiKey: string) {
-    return !!(await queryModels(apiKey));
+  async validateApiKey(key: string) {
+    return !!(await this.queryModels(key));
   }
 
-  static logoUrl() {
-    return "/openai-logo.png";
-  }
-
-  static defaultModel() {
-    return "gpt-3.5-turbo";
+  defaultModelForProvider() {
+    return new ChatCraftModel("gpt-3.5-turbo");
   }
 }

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -2,11 +2,18 @@ import {
   ChatCraftProvider,
   OPENAI_API_URL,
   OPENROUTER_API_URL,
+  FREEMODELPROVIDER_API_URL,
   ProviderData,
   SerializedChatCraftProvider,
 } from "../ChatCraftProvider";
+import { getSettings } from "../settings";
 import { OpenAiProvider } from "./OpenAiProvider";
 import { OpenRouterProvider } from "./OpenRouterProvider";
+import { FreeModelProvider } from "./DefaultProvider/FreeModelProvider";
+
+export const usingOfficialOpenAI = () => getSettings().currentProvider.apiUrl === OPENAI_API_URL;
+export const usingOfficialOpenRouter = () =>
+  getSettings().currentProvider.apiUrl === OPENROUTER_API_URL;
 
 // Parses url into instance of ChatCraftProvider
 export function providerFromUrl(url: string, key?: string) {
@@ -16,6 +23,10 @@ export function providerFromUrl(url: string, key?: string) {
 
   if (url === OPENROUTER_API_URL) {
     return new OpenRouterProvider(key);
+  }
+
+  if (url === FREEMODELPROVIDER_API_URL) {
+    return new FreeModelProvider();
   }
 
   throw new Error(`Error parsing provider from url, unsupported url: ${url}`);
@@ -36,6 +47,10 @@ export function providerFromJSON({
     return OpenRouterProvider.fromJSON({ id, name, apiUrl, apiKey });
   }
 
+  if (apiUrl === FREEMODELPROVIDER_API_URL) {
+    return new FreeModelProvider();
+  }
+
   throw new Error(`Error parsing provider from JSON, unsupported url: ${apiUrl}`);
 }
 
@@ -43,9 +58,11 @@ export function providerFromJSON({
 export const getSupportedProviders = (): ProviderData => {
   const openAi = new OpenAiProvider();
   const openRouter = new OpenRouterProvider();
+  const freeModel = new FreeModelProvider();
 
   return {
     [openAi.apiUrl]: openAi,
     [openRouter.apiUrl]: openRouter,
+    [freeModel.apiUrl]: freeModel,
   };
 };

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,4 +1,5 @@
-import { transcribe, usingOfficialOpenAI } from "./ai";
+import { transcribe } from "./ai";
+import { usingOfficialOpenAI } from "./providers";
 
 // Audio Recording and Transcribing depends on a bunch of technologies
 export function isTranscriptionSupported() {


### PR DESCRIPTION
Added new provider (free provider for new users to try)
Further providers refactoring

Closes #401

### Code changes:

- Moved `validateApiKey`, `queryModels`, `createClient` out of `ais.ts` and into `ChatCraftProvider.ts`
- Moved `usingOfficialOpenAI`, `usingOfficialOpenRouter` out of `ai.ts` and into `providers/index.ts`
- Added new free provider `providers/DefaultProvider/FreeModelProvider.ts`
- Configured `ModelAvatar.tsx` for `DefaultProvider` so logo will display with the green bg

### Potential future follow up items:

- Make FreeModelProvider the default provider for new users (this will make the Instructions page obsolete so we need to design a new way to instruct new users about ChatCraft)
- Query the first available free provider in the list of providers instead of hardcoding (currently not sure how since requires making `defaultModelForProvider()` async and affecting alot of other files)