### PR TITLE
User's Shared Chats directly accessibly from UI again

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -34,6 +34,7 @@ import { SharedChatCraftChat } from "../../lib/SharedChatCraftChat";
 import { useUser } from "../../hooks/use-user";
 import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
 import { useAlert } from "../../hooks/use-alert";
+import { convertToShareUrl } from "../../lib/share";
 
 /**
  * Chat Sidebar Items
@@ -411,7 +412,7 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
                 <ChatSidebarItem
                   key={shared.id}
                   chat={shared.chat}
-                  url={shared.url}
+                  url={convertToShareUrl(shared.url)}
                   isSelected={selectedChat?.id === shared.id}
                   onDelete={() => handleDeleteSharedChat(shared.id)}
                 />

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -12,7 +12,7 @@ import {
 import db, { type ChatCraftChatTable, type ChatCraftMessageTable } from "./db";
 import summarize from "./summarize";
 import { createSystemMessage } from "./system-prompt";
-import { createDataShareUrl, createShare } from "./share";
+import { createDataShareUrl, createShare, createShareUrl } from "./share";
 import { SharedChatCraftChat } from "./SharedChatCraftChat";
 import { countTokensInMessages } from "./ai";
 import { parseFunctionNames, loadFunctions } from "./ChatCraftFunction";
@@ -338,7 +338,7 @@ export class ChatCraftChat {
     }
 
     // Generate a public share URL
-    const shareUrl = createDataShareUrl(cloned, user);
+    const shareUrl = createShareUrl(cloned, user);
     await createShare(cloned, user);
 
     const shared = new SharedChatCraftChat({
@@ -370,7 +370,7 @@ export class ChatCraftChat {
     });
 
     // Use the existing sharing logic to share the cloned chat
-    const shareUrl = createDataShareUrl(clonedChatWithSingleMessage, user);
+    const shareUrl = createShareUrl(clonedChatWithSingleMessage, user);
     await createShare(clonedChatWithSingleMessage, user);
 
     const shared = new SharedChatCraftChat({

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -12,7 +12,7 @@ import {
 import db, { type ChatCraftChatTable, type ChatCraftMessageTable } from "./db";
 import summarize from "./summarize";
 import { createSystemMessage } from "./system-prompt";
-import { createShare, createShareUrl } from "./share";
+import { createDataShareUrl, createShare } from "./share";
 import { SharedChatCraftChat } from "./SharedChatCraftChat";
 import { countTokensInMessages } from "./ai";
 import { parseFunctionNames, loadFunctions } from "./ChatCraftFunction";
@@ -338,7 +338,7 @@ export class ChatCraftChat {
     }
 
     // Generate a public share URL
-    const shareUrl = createShareUrl(cloned, user);
+    const shareUrl = createDataShareUrl(cloned, user);
     await createShare(cloned, user);
 
     const shared = new SharedChatCraftChat({
@@ -370,7 +370,7 @@ export class ChatCraftChat {
     });
 
     // Use the existing sharing logic to share the cloned chat
-    const shareUrl = createShareUrl(clonedChatWithSingleMessage, user);
+    const shareUrl = createDataShareUrl(clonedChatWithSingleMessage, user);
     await createShare(clonedChatWithSingleMessage, user);
 
     const shared = new SharedChatCraftChat({

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -12,7 +12,7 @@ import {
 import db, { type ChatCraftChatTable, type ChatCraftMessageTable } from "./db";
 import summarize from "./summarize";
 import { createSystemMessage } from "./system-prompt";
-import { createDataShareUrl, createShare, createShareUrl } from "./share";
+import { createShare, createShareUrl } from "./share";
 import { SharedChatCraftChat } from "./SharedChatCraftChat";
 import { countTokensInMessages } from "./ai";
 import { parseFunctionNames, loadFunctions } from "./ChatCraftFunction";

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -16,16 +16,21 @@ export function createDataShareUrl(chat: ChatCraftChat, user: User) {
  * @param prefix
  * @returns url
  */
-
-export function convertToShareUrl(url: string) {
-  return url.includes("/api/share") ? url.replace("/api/share", "/c") : url;
-}
-
 export function createShareUrl(chat: ChatCraftChat, user: User, prefix = "/c") {
   const { origin } = new URL(location.href);
   const shareUrl = new URL(`${prefix}/${user.username}/${chat.id}`, origin);
 
   return shareUrl.href;
+}
+
+/**
+ * Converts "/api/share"-style URLs before passing it to UI
+ * This is done to avoid react-router-dom issue involving "/api/share"-style URLs
+ * @param url
+ * @returns url
+ */
+export function convertToShareUrl(url: string) {
+  return url.includes("/api/share") ? url.replace("/api/share", "/c") : url;
 }
 
 /**

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -16,6 +16,19 @@ export function createDataShareUrl(chat: ChatCraftChat, user: User) {
  * @param prefix
  * @returns url
  */
+
+export function convertToShareUrl(url: string) {
+  console.log("url is here", url);
+  if (url.includes("/api/share")) {
+    console.log("using old URL link");
+    const newUrl = url.replace("/api/share", "/c");
+    return newUrl;
+  } else {
+    console.log("using same URL link");
+    return url;
+  }
+}
+
 export function createShareUrl(chat: ChatCraftChat, user: User, prefix = "/c") {
   const { origin } = new URL(location.href);
   const shareUrl = new URL(`${prefix}/${user.username}/${chat.id}`, origin);

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -18,15 +18,7 @@ export function createDataShareUrl(chat: ChatCraftChat, user: User) {
  */
 
 export function convertToShareUrl(url: string) {
-  console.log("url is here", url);
-  if (url.includes("/api/share")) {
-    console.log("using old URL link");
-    const newUrl = url.replace("/api/share", "/c");
-    return newUrl;
-  } else {
-    console.log("using same URL link");
-    return url;
-  }
+  return url.includes("/api/share") ? url.replace("/api/share", "/c") : url;
 }
 
 export function createShareUrl(chat: ChatCraftChat, user: User, prefix = "/c") {


### PR DESCRIPTION
This quick and dirty PR fixes #480

## Current Shared Chat Access Flow on ChatCraft (3/15/2024)
We know that currently, a shared chat in the Shared Chats accordion redirects to a url via the /api/share prefix, e.g. `[website-url]/api/share/{user}/{id}`:
### Current Share URL format (/api/share) in Shared Chats Accordion
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/c8d9305e-3124-402a-93b8-114d01043f52)

### Current Error when Accessing Shared Chat from Sidebar Accordion redirect url
Clicking the Shared Chat to access this url fails and returns two 404 errors (likely a react-router-dom issue based on findings in this week's triage meeting):
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/3eafec18-3510-48fd-9173-d2d2ca02aa97)

### Successfully loading the Accordion redirect url in address bar
However, copy/pasting the this link into the address bar will redirect it to the **/c/** prefix equivalent, e.g `[website-url]/c/{user}/{id}` (keep an eye on the address bar in this gif):
![issue480newApiRoute](https://github.com/tarasglek/chatcraft.org/assets/78163326/f7d3c96b-78b5-4542-bd60-70cc448092c5)

## Previous Shared Chat Access Flow
After a couple days of comparing the main branch to past branches that didn't have this issue, clicking a shared chat from the Shared Chats accordion would **redirect to a shared chat _directly_ via the /c/ prefix**, e.g. `[website-url]/c/{user}/{id}`:
**Previous Share URL format (/c/**
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/25e2c15f-3160-4ba7-b5eb-0f34ecbba698).

Compare this to a current Shared Chat item url using the **/api/share/** route, which, while accessible by copy/pasting the link into a new tab, will crash ChatCraft when accessed through the Shared Chats accordion UI.

#417 added **createDataShareUrl()**, which uses **createShareUrl()** to create a Shared Chat with the shared chat url with the `/api/share/{user}/id` format instead of `/c/{user}/{id}`:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/5e396a50-88a2-4796-bdf1-cc8319126915)

This is why we had conflicting reports of this issue.
Those who reported the issue were accessing recently-created Shared Chats (and given given the /api/share/-style redirect URL in the UI), while those who didn't see the issue were accessing Shared Chats that were created before this change (and given the /c/-style redirect URL in the UI)

My Solution (not ideal)
---

**createDataShareUrl()** replaced **createShareUrl()** in `src/lib/ChatCraftChat.ts` when creating a Shared Chat:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/87cbc54e-7fbc-4da5-8f92-eec9140a3d08)

This PR fixes the shared-chat access issue by **replacing createDataShareUrl()** calls with **createShareUrl()** calls in `src/lib/ChatCraftChat.ts` to give Shared Chat items the `/c/{user}/{id}`-style redirect URLs instead of the `/api/share/{user}/{id}`-style redirect URLs.


I don't think this is a perfect solution and it's not my preferred solution.
For one, this change still doesn't allow users to access their own shared chats created in the last month (at least not through the UI)
I'd rather find a way to use the `/api/share/{user}/{id}`-style URLs directly from the UI, but this is all I can come up with for now