### PR TITLE
Create an index of shared chatcraft chats in R2

### DIFF
--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -14,7 +14,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
   const { CHATCRAFT_ORG_BUCKET } = env;
   const prefix: string = `${user}/`;
   const { objects } = await CHATCRAFT_ORG_BUCKET.list({ prefix });
-  const xsltUrl = "../../rss-style.xsl";
+  // const xsltUrl = "../../rss-style.xsl";
 
   const feed = new Feed({
     title: `User Feed for ${user}`,
@@ -23,12 +23,12 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     link: `https://chatcraft.org/api/share/${user}/feed.atom`,
     updated: new Date(),
     feedLinks: {
-      atom: `https://chatcraft.org/api/share/feed/${user}/feed.atom`,
+      atom: `https://chatcraft.org/api/share/${user}/feed.atom`,
     },
     author: {
       name: user,
     },
-    copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
+    copyright: `Copyright©${new Date().getFullYear()} by ${user}`,
   });
 
   const sortedObjects = objects.sort((a, b) => b.uploaded.getTime() - a.uploaded.getTime());
@@ -39,8 +39,8 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
       const chatContent: string = await chatData.text();
       const $ = load(chatContent);
 
-      const title = $('meta[property="og:title"]').text() || "No Title";
-      const summary = $('meta[name="description"]').attr("content") || "No Summary";
+      const title = $('meta[property="og:title"]').attr("content") || "No Title";
+      const summary = $('meta[property="og:description"]').attr("content") || "No Summary";
       const url = $('meta[property="og:url"]').attr("content") || "No URL";
       const id = url.split("/").pop() || "No ID";
       const preContent = $("pre").text();
@@ -58,6 +58,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     }
   }
 
+  const xsltUrl = "https://daverupert.com/pretty-feed-v3.xsl";
   let feedXml = feed.atom1();
   feedXml =
     `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}"?>\n` +

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -17,10 +17,9 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
 
   const feed = new Feed({
     title: `User Feed for ${user}`,
-    description: `This is ${user}'s share chats`,
+    description: `This is ${user}'s shared chats`,
     id: `https://chatcraft.org/api/feed/${user}/feed.atom`,
     link: `https://chatcraft.org/api/feed/${user}/feed.atom`,
-    language: "en",
     updated: new Date(),
     feedLinks: {
       atom: `https://chatcraft.org/api/feed/${user}/feed.atom`,

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -10,60 +10,116 @@ interface Env {
   JWT_SECRET: string;
 }
 
-async function generateUserFeed(env: Env, user: string): Promise<void> {
+interface ChatItem {
+  title: string;
+  id: string;
+  link: string;
+  description: string;
+  date: Date;
+  author: { name: string }[];
+}
+
+async function getNewItem(env: Env, newObject, user: string): Promise<ChatItem | null> {
   const { CHATCRAFT_ORG_BUCKET } = env;
-  const prefix: string = `${user}/`;
-  const { objects } = await CHATCRAFT_ORG_BUCKET.list({ prefix });
+  try {
+    const chatData = await CHATCRAFT_ORG_BUCKET.get(newObject.key);
+    if (!chatData) {
+      console.error(`No chat data found for key: ${newObject.key}`);
+      return null;
+    }
+    const chatContent: string = await chatData.text();
+    const $ = load(chatContent);
+
+    const title = $('meta[property="og:title"]').text() || "No Title";
+    const summary = $('meta[name="description"]').attr("content") || "No Summary";
+    const url = $('meta[property="og:url"]').attr("content") || "No URL";
+    const id = url.split("/").pop() || "No ID";
+    const preContent = $("pre").text();
+    const dateMatch = preContent.match(/date:\s*(.+)/i);
+    const date = dateMatch ? new Date(dateMatch[1]) : new Date();
+
+    return {
+      title: title,
+      id: id,
+      link: url,
+      description: summary,
+      date: date,
+      author: [{ name: user }],
+    };
+  } catch (err) {
+    console.error(`Error processing new item: ${err}`);
+    return null;
+  }
+}
+
+function chatItemToXml(item: ChatItem): string {
+  return `
+    <entry>
+      <title>${item.title}</title>
+      <id>${item.id}</id>
+      <link href="${item.link}" />
+      <updated>${item.date.toISOString()}</updated>
+      <summary>${item.description}</summary>
+      <author>
+        <name>${item.author[0].name}</name>
+      </author>
+    </entry>
+  `.trim();
+}
+
+async function generateUserFeed(env: Env, user_id: any[]): Promise<void> {
+  const { CHATCRAFT_ORG_BUCKET } = env;
+  const [user, id] = user_id;
+  const newPrefix: string = `${user}/${id}`;
+  const { objects } = await CHATCRAFT_ORG_BUCKET.list({ newPrefix });
+  const newObject = objects.length > 0 ? objects[0] : null;
   const xsltUrl = "../../rss-style.xsl";
+  const feedKey = `${user}/feed/feed.atom`;
 
-  const feed = new Feed({
-    title: `User Feed for ${user}`,
-    description: `This is ${user}'s shared chats`,
-    id: `https://chatcraft.org/api/feed/${user}/feed.atom`,
-    link: `https://chatcraft.org/api/feed/${user}/feed.atom`,
-    updated: new Date(),
-    feedLinks: {
-      atom: `https://chatcraft.org/api/feed/${user}/feed.atom`,
-    },
-    author: {
-      name: user,
-    },
-    copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
-  });
+  let existingFeedXml: string | null = null;
+  try {
+    const existingFeedData = await CHATCRAFT_ORG_BUCKET.get(feedKey);
+    if (existingFeedData) {
+      existingFeedXml = await existingFeedData.text();
+    }
+  } catch (err) {
+    console.error(`Error fetching existing feed: ${err.message}`);
+  }
 
-  const recentObjects = objects.slice(0, 50);
-  for (const object of recentObjects) {
-    const chatData = await CHATCRAFT_ORG_BUCKET.get(object.key);
-    if (chatData) {
-      const chatContent: string = await chatData.text();
-      const $ = load(chatContent);
-
-      const title = $('meta[property="og:title"]').text() || "No Title";
-      const summary = $('meta[name="description"]').attr("content") || "No Summary";
-      const url = $('meta[property="og:url"]').attr("content") || "No URL";
-      const id = url.split("/").pop() || "No ID";
-      const preContent = $("pre").text();
-      const dateMatch = preContent.match(/date:\s*(.+)/i);
-      const date = dateMatch ? new Date(dateMatch[1]) : new Date();
-
-      feed.addItem({
-        title: title,
-        id: id,
-        link: url,
-        description: summary,
-        date: date,
-        author: [{ name: user }],
+  let feedXml: string = "";
+  const newEntry: ChatItem | null = await getNewItem(env, newObject, user);
+  if (newEntry !== null) {
+    let feed: Feed;
+    if (existingFeedXml) {
+      const $ = load(existingFeedXml, { xmlMode: true });
+      const newEntryXml = chatItemToXml(newEntry);
+      $("feed").prepend(newEntryXml);
+      feedXml = $.xml();
+    } else {
+      feed = new Feed({
+        title: `User Feed for ${user}`,
+        description: `This is ${user}'s shared chats`,
+        id: `https://chatcraft.org/api/feed/${user}/feed.atom`,
+        link: `https://chatcraft.org/api/feed/${user}/feed.atom`,
+        updated: new Date(),
+        feedLinks: {
+          atom: `https://chatcraft.org/api/feed/${user}/feed.atom`,
+        },
+        author: {
+          name: user,
+        },
+        copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
       });
+
+      feed.addItem(newEntry);
+      feedXml = feed.atom1();
+      feedXml =
+        `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}"?>\n` +
+        feedXml;
     }
   }
 
-  let feedXml = feed.atom1();
-  feedXml =
-    `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}"?>\n` +
-    feedXml;
-
   try {
-    const feedKey = `${user}/feed/feed.atom`;
     await CHATCRAFT_ORG_BUCKET.put(feedKey, new TextEncoder().encode(feedXml), {
       httpMetadata: {
         contentType: "application/atom+xml",
@@ -148,8 +204,7 @@ export const onRequestPut: PagesFunction<Env> = async ({ request, env, params })
       },
     });
 
-    const [user] = user_id;
-    await generateUserFeed(env, user);
+    await generateUserFeed(env, user_id);
 
     return new Response(
       JSON.stringify({

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -19,11 +19,11 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
   const feed = new Feed({
     title: `User Feed for ${user}`,
     description: `This is ${user}'s shared chats`,
-    id: `https://chatcraft.org/api/feed/${user}/feed.atom`,
-    link: `https://chatcraft.org/api/feed/${user}/feed.atom`,
+    id: `https://chatcraft.org/api/share/${user}/feed.atom`,
+    link: `https://chatcraft.org/api/share/${user}/feed.atom`,
     updated: new Date(),
     feedLinks: {
-      atom: `https://chatcraft.org/api/feed/${user}/feed.atom`,
+      atom: `https://chatcraft.org/api/share/feed/${user}/feed.atom`,
     },
     author: {
       name: user,
@@ -31,7 +31,8 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
   });
 
-  const recentObjects = objects.slice(0, 20);
+  const sortedObjects = objects.sort((a, b) => b.uploaded.getTime() - a.uploaded.getTime());
+  const recentObjects = sortedObjects.slice(0, 20);
   for (const object of recentObjects) {
     const chatData = await CHATCRAFT_ORG_BUCKET.get(object.key);
     if (chatData) {
@@ -63,7 +64,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     feedXml;
 
   try {
-    const feedKey = `${user}/feed/feed.atom`;
+    const feedKey = `${user}/feed.atom`;
     await CHATCRAFT_ORG_BUCKET.put(feedKey, new TextEncoder().encode(feedXml), {
       httpMetadata: {
         contentType: "application/atom+xml",

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -14,7 +14,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
   const { CHATCRAFT_ORG_BUCKET } = env;
   const prefix: string = `${user}/`;
   const { objects } = await CHATCRAFT_ORG_BUCKET.list({ prefix });
-  // const xsltUrl = "../../rss-style.xsl";
+  const xsltUrl = "/rss-style.xsl";
 
   const feed = new Feed({
     title: `User Feed for ${user}`,
@@ -58,10 +58,17 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     }
   }
 
-  const xsltUrl = "https://daverupert.com/pretty-feed-v3.xsl";
   let feedXml = feed.atom1();
+
+  // Remove the first line (second XML declaration) if it exists
+  const lines = feedXml.split("\n");
+  if (lines[0].startsWith("<?xml")) {
+    lines.shift();
+    feedXml = lines.join("\n");
+  }
+
   feedXml =
-    `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}"?>\n` +
+    `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}?">\n` +
     feedXml;
 
   try {

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -68,7 +68,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
   }
 
   feedXml =
-    `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}?">\n` +
+    `<?xml version="1.0" encoding="UTF-8"?>\n<?xml-stylesheet type="text/xsl" href="${xsltUrl}"?>\n` +
     feedXml;
 
   try {

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -28,7 +28,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     author: {
       name: user,
     },
-    copyright: `Copyright©${new Date().getFullYear()} by ${user}`,
+    copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
   });
 
   const sortedObjects = objects.sort((a, b) => b.uploaded.getTime() - a.uploaded.getTime());

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -74,7 +74,7 @@ async function generateUserFeed(env: Env, user_id: any[]): Promise<void> {
   const { objects } = await CHATCRAFT_ORG_BUCKET.list({ newPrefix });
   const newObject = objects.length > 0 ? objects[0] : null;
   const xsltUrl = "../../rss-style.xsl";
-  const feedKey = `/feed/${user}/feed.atom`;
+  const feedKey = `${user}/feed.atom`;
 
   let existingFeedXml: string | null = null;
   try {

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -31,7 +31,8 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
   });
 
-  for (const object of objects) {
+  const recentObjects = objects.slice(0, 10);
+  for (const object of recentObjects) {
     const chatData = await CHATCRAFT_ORG_BUCKET.get(object.key);
     if (chatData) {
       const chatContent: string = await chatData.text();

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -31,7 +31,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
     copyright: `Copyright © ${new Date().getFullYear()} by ${user}`,
   });
 
-  const recentObjects = objects.slice(0, 10);
+  const recentObjects = objects.slice(0, 50);
   for (const object of recentObjects) {
     const chatData = await CHATCRAFT_ORG_BUCKET.get(object.key);
     if (chatData) {

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -74,7 +74,7 @@ async function generateUserFeed(env: Env, user_id: any[]): Promise<void> {
   const { objects } = await CHATCRAFT_ORG_BUCKET.list({ newPrefix });
   const newObject = objects.length > 0 ? objects[0] : null;
   const xsltUrl = "../../rss-style.xsl";
-  const feedKey = `${user}/feed/feed.atom`;
+  const feedKey = `/feed/${user}/feed.atom`;
 
   let existingFeedXml: string | null = null;
   try {

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -12,7 +12,7 @@ interface Env {
 
 async function generateUserFeed(env: Env, user: string): Promise<void> {
   const { CHATCRAFT_ORG_BUCKET } = env;
-  const prefix: string = `${user}/`;
+  const prefix = `${user}/`;
   const { objects } = await CHATCRAFT_ORG_BUCKET.list({ prefix });
   const xsltUrl = "/rss-style.xsl";
 
@@ -36,7 +36,7 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
   for (const object of recentObjects) {
     const chatData = await CHATCRAFT_ORG_BUCKET.get(object.key);
     if (chatData) {
-      const chatContent: string = await chatData.text();
+      const chatContent = await chatData.text();
       const $ = load(chatContent);
 
       const title = $('meta[property="og:title"]').attr("content") || "No Title";

--- a/functions/api/share/[[user_id]].ts
+++ b/functions/api/share/[[user_id]].ts
@@ -47,14 +47,15 @@ async function generateUserFeed(env: Env, user: string): Promise<void> {
       const dateMatch = preContent.match(/date:\s*(.+)/i);
       const date = dateMatch ? new Date(dateMatch[1]) : new Date();
 
-      feed.addItem({
-        title: title,
-        id: id,
-        link: url,
-        description: summary,
-        date: date,
-        author: [{ name: user }],
-      });
+      if (title !== "No Title" && url !== "No URL")
+        feed.addItem({
+          title: title,
+          id: id,
+          link: url,
+          description: summary,
+          date: date,
+          author: [{ name: user }],
+        });
     }
   }
 

--- a/functions/rss-style.xsl
+++ b/functions/rss-style.xsl
@@ -15,39 +15,72 @@
       </head>
       <body>
         <main class="layout-content">
-          <div class="alert-box">
-            <strong>This is an Atom feed</strong>. Subscribe by copying
-            the URL from the address bar into your feed reader. Visit <a
-            href="https://aboutfeeds.com">About Feeds</a> to learn more and get started. It’s free.
-          </div>
+          <dk-alert-box type="info">
+            <strong>This is an RSS feed</strong>. Subscribe by copying
+            the URL from the address bar into your newsreader. Visit <a
+            href="https://aboutfeeds.com">About Feeds
+          </a> to learn more and get started. It’s free.
+          </dk-alert-box>
           <div class="py-7">
-            <h1>Atom Feed Preview</h1>
-            <h2><xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/></h2>
-            <p>
-              <xsl:value-of select="/atom:feed/atom:subtitle"/>
-            </p>
-            <a href="{/atom:feed/atom:link[@rel='alternate']/@href}">Visit Website &#x2192;</a>
+                        <h1 class="flex items-start">
+              <svg xmlns="http://www.w3.org/2000/svg" version="1.1"
+                   class="mr-5"
+                   style="flex-shrink: 0; width: 1em; height: 1em;"
+                   viewBox="0 0 256 256">
+                <defs>
+                  <linearGradient x1="0.085" y1="0.085" x2="0.915" y2="0.915"
+                                  id="RSSg">
+                    <stop offset="0.0" stop-color="#E3702D"/>
+                    <stop offset="0.1071" stop-color="#EA7D31"/>
+                    <stop offset="0.3503" stop-color="#F69537"/>
+                    <stop offset="0.5" stop-color="#FB9E3A"/>
+                    <stop offset="0.7016" stop-color="#EA7C31"/>
+                    <stop offset="0.8866" stop-color="#DE642B"/>
+                    <stop offset="1.0" stop-color="#D95B29"/>
+                  </linearGradient>
+                </defs>
+                <rect width="256" height="256" rx="55" ry="55" x="0" y="0"
+                      fill="#CC5D15"/>
+                <rect width="246" height="246" rx="50" ry="50" x="5" y="5"
+                      fill="#F49C52"/>
+                <rect width="236" height="236" rx="47" ry="47" x="10" y="10"
+                      fill="url(#RSSg)"/>
+                <circle cx="68" cy="189" r="24" fill="#FFF"/>
+                <path
+                  d="M160 213h-34a82 82 0 0 0 -82 -82v-34a116 116 0 0 1 116 116z"
+                  fill="#FFF"/>
+                <path
+                  d="M184 213A140 140 0 0 0 44 73 V 38a175 175 0 0 1 175 175z"
+                  fill="#FFF"/>
+              </svg>
+              RSS Feed Preview
+            </h1>
+            <h2>ChatCraft</h2>
+            <a>
+              <xsl:attribute name="href">
+                <xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/>
+              </xsl:attribute>
+              Visit Website &#x2192;
+            </a>
 
             <h2>Recent Shared Chats</h2>
             <xsl:for-each select="/atom:feed/atom:entry">
               <div class="pb-7">
                 <div class="text-2 text-offset">
                   Shared on
-                  <xsl:value-of select="substring(atom:date, 1, 10)" />
+                  <xsl:value-of select="substring(atom:updated, 0 11)"/>
                 </div>
 
                 <div class="text-4 font-bold">
                   <a>
                     <xsl:attribute name="href">
-                      <xsl:value-of select="atom:title"/>
+                      <xsl:value-of select="atom:link/@href"/>
                     </xsl:attribute>
                     <xsl:value-of select="atom:title"/>
                   </a>
                 </div>
 
-                <div class="text-3">
-                  <xsl:value-of select="atom:description"/>
-                </div>
+                <div class="text-3"><xsl:value-of select="atom:summary"/></div>
               </div>
             </xsl:for-each>
           </div>

--- a/functions/rss-style.xsl
+++ b/functions/rss-style.xsl
@@ -28,11 +28,11 @@
             </p>
             <a href="{/atom:feed/atom:link[@rel='alternate']/@href}">Visit Website &#x2192;</a>
 
-            <h2>Recent Posts</h2>
+            <h2>Recent Shared Chats</h2>
             <xsl:for-each select="/atom:feed/atom:entry">
               <div class="pb-7">
                 <div class="text-2 text-offset">
-                  Published on
+                  Shared on
                   <xsl:value-of select="substring(atom:date, 1, 10)" />
                 </div>
 

--- a/functions/rss-style.xsl
+++ b/functions/rss-style.xsl
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsl:stylesheet version="3.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:atom="http://www.w3.org/2005/Atom">
+  <xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+  <xsl:template match="/">
+    <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
+      <head>
+        <title>
+          Atom Feed | <xsl:value-of select="/atom:feed/atom:title"/>
+        </title>
+        <meta charset="utf-8"/>
+        <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1"/>
+        <link rel="stylesheet" href="/assets/styles.css"/>
+      </head>
+      <body>
+        <main class="layout-content">
+          <div class="alert-box">
+            <strong>This is an Atom feed</strong>. Subscribe by copying
+            the URL from the address bar into your feed reader. Visit <a
+            href="https://aboutfeeds.com">About Feeds</a> to learn more and get started. It’s free.
+          </div>
+          <div class="py-7">
+            <h1>Atom Feed Preview</h1>
+            <h2><xsl:value-of select="/atom:feed/atom:link[@rel='alternate']/@href"/></h2>
+            <p>
+              <xsl:value-of select="/atom:feed/atom:subtitle"/>
+            </p>
+            <a href="{/atom:feed/atom:link[@rel='alternate']/@href}">Visit Website &#x2192;</a>
+
+            <h2>Recent Posts</h2>
+            <xsl:for-each select="/atom:feed/atom:entry">
+              <div class="pb-7">
+                <div class="text-2 text-offset">
+                  Published on
+                  <xsl:value-of select="substring(atom:date, 1, 10)" />
+                </div>
+
+                <div class="text-4 font-bold">
+                  <a>
+                    <xsl:attribute name="href">
+                      <xsl:value-of select="atom:title"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="atom:title"/>
+                  </a>
+                </div>
+
+                <div class="text-3">
+                  <xsl:value-of select="atom:description"/>
+                </div>
+              </div>
+            </xsl:for-each>
+          </div>
+        </main>
+      </body>
+    </html>
+  </xsl:template>
+</xsl:stylesheet>

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dexie-export-import": "^4.1.1",
     "dexie-react-hooks": "^1.1.7",
     "esbuild-wasm": "^0.20.0",
+    "feed": "^4.2.2",
     "framer-motion": "^11.0.3",
     "get-video-id": "^3.6.5",
     "html2canvas": "^1.4.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@szhsin/react-menu": "^4.1.0",
     "@uiw/react-codemirror": "^4.21.21",
     "browser-image-compression": "^2.0.2",
+    "cheerio": "1.0.0-rc.12",
     "compromise": "^14.11.2",
     "cookie": "^0.6.0",
     "dexie": "^3.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   esbuild-wasm:
     specifier: ^0.20.0
     version: 0.20.0
+  feed:
+    specifier: ^4.2.2
+    version: 4.2.2
   framer-motion:
     specifier: ^11.0.3
     version: 11.0.3(react-dom@18.2.0)(react@18.2.0)
@@ -6261,6 +6264,13 @@ packages:
       format: 0.2.2
     dev: false
 
+  /feed@4.2.2:
+    resolution: {integrity: sha512-u5/sxGfiMfZNtJ3OvQpXcvotFpYkL0n9u9mM2vkui2nGo8b4wvDkJ8gAkYqbA8QpGyFCv3RK0Z+Iv+9veCS9bQ==}
+    engines: {node: '>=0.4.0'}
+    dependencies:
+      xml-js: 1.6.11
+    dev: false
+
   /file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -9432,6 +9442,10 @@ packages:
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  /sax@1.3.0:
+    resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+    dev: false
+
   /scheduler@0.23.0:
     resolution: {integrity: sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==}
     dependencies:
@@ -10865,6 +10879,13 @@ packages:
       utf-8-validate:
         optional: true
     dev: true
+
+  /xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
+    dependencies:
+      sax: 1.3.0
+    dev: false
 
   /xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   browser-image-compression:
     specifier: ^2.0.2
     version: 2.0.2
+  cheerio:
+    specifier: 1.0.0-rc.12
+    version: 1.0.0-rc.12
   compromise:
     specifier: ^14.11.2
     version: 14.11.2
@@ -4624,6 +4627,10 @@ packages:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
     dev: true
 
+  /boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+    dev: false
+
   /brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -4856,6 +4863,30 @@ packages:
     dependencies:
       get-func-name: 2.0.2
     dev: true
+
+  /cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.1.0
+      css-what: 6.1.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+    dev: false
+
+  /cheerio@1.0.0-rc.12:
+    resolution: {integrity: sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==}
+    engines: {node: '>= 6'}
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      htmlparser2: 8.0.2
+      parse5: 7.1.2
+      parse5-htmlparser2-tree-adapter: 7.0.0
+    dev: false
 
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
@@ -5143,12 +5174,27 @@ packages:
       utrie: 1.0.2
     dev: false
 
+  /css-select@5.1.0:
+    resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.1.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      nth-check: 2.1.1
+    dev: false
+
   /css-tree@1.1.3:
     resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==}
     engines: {node: '>=8.0.0'}
     dependencies:
       mdn-data: 2.0.14
       source-map: 0.6.1
+    dev: false
+
+  /css-what@6.1.0:
+    resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
+    engines: {node: '>= 6'}
     dev: false
 
   /csstype@3.1.2:
@@ -5631,13 +5677,40 @@ packages:
       esutils: 2.0.3
     dev: true
 
+  /dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+    dev: false
+
   /domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
     engines: {node: '>=10'}
     dev: true
 
+  /domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+    dev: false
+
+  /domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+    dependencies:
+      domelementtype: 2.3.0
+    dev: false
+
   /dompurify@3.0.6:
     resolution: {integrity: sha512-ilkD8YEnnGh1zJ240uJsW7AzE+2qpbOUYjacomn3AvJ6J4JhKGSZ2nh4wUIXPZrEPppaCLx5jFe8T89Rk8tQ7w==}
+    dev: false
+
+  /domutils@3.1.0:
+    resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
     dev: false
 
   /dotenv@10.0.0:
@@ -6779,6 +6852,15 @@ packages:
     dependencies:
       css-line-break: 2.1.0
       text-segmentation: 1.0.3
+    dev: false
+
+  /htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.1.0
+      entities: 4.5.0
     dev: false
 
   /http-cache-semantics@4.1.1:
@@ -8413,6 +8495,12 @@ packages:
       validate-npm-package-name: 4.0.0
     dev: true
 
+  /nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+    dependencies:
+      boolbase: 1.0.0
+    dev: false
+
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8614,6 +8702,13 @@ packages:
   /parse-package-name@1.0.0:
     resolution: {integrity: sha512-kBeTUtcj+SkyfaW4+KBe0HtsloBJ/mKTPoxpVdA57GZiPerREsUWJOhVj9anXweFiJkm5y8FG1sxFZkZ0SN6wg==}
     dev: true
+
+  /parse5-htmlparser2-tree-adapter@7.0.0:
+    resolution: {integrity: sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==}
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.1.2
+    dev: false
 
   /parse5@7.1.2:
     resolution: {integrity: sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==}


### PR DESCRIPTION
###  After user sharing a chat, the generateAndSaveUserFeed() will automatically get the latest 20 share chats from cloudflare and generated feed file with rss-style in path `${user}/feed.atom`

<img width="1019" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/8db914b4-6079-4240-82f9-9fb21e6593fa">



### The generated feed.atom file can be automatically rendered by my chrome RSS Feed Reader:

<img width="1361" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/aa38d426-859c-4a36-92da-18c9970695ab">


closes #425 

