### PR TITLE
Add multiple image compression options

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -19,6 +19,7 @@ import { useCopyToClipboard } from "react-use";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { useUser } from "../hooks/use-user";
 import { useAlert } from "../hooks/use-alert";
+import { useSettings } from "../hooks/use-settings";
 import ShareModal from "./ShareModal";
 import { download, compressImageToBase64 } from "../lib/utils";
 import theme from "../theme";
@@ -91,6 +92,7 @@ function OptionsButton({
   const { info, error } = useAlert();
   const [, copyToClipboard] = useCopyToClipboard();
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const { settings } = useSettings();
 
   const handleFileChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -105,7 +107,11 @@ function OptionsButton({
           const file = files[i];
           if (file.type.startsWith("image/")) {
             onFileSelected("");
-            compressImageToBase64(file)
+            compressImageToBase64(
+              file,
+              settings.compressionFactor,
+              settings.maxCompressedFileSizeMb
+            )
               .then((base64) => onFileSelected(base64))
               .catch((err) => {
                 console.error(err);

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -107,12 +107,11 @@ function OptionsButton({
           const file = files[i];
           if (file.type.startsWith("image/")) {
             onFileSelected("");
-            compressImageToBase64(
-              file,
-              settings.compressionFactor,
-              settings.maxCompressedFileSizeMB,
-              settings.maxImageDimension
-            )
+            compressImageToBase64(file, {
+              compressionFactor: settings.compressionFactor,
+              maxSizeMB: settings.maxCompressedFileSizeMB,
+              maxWidthOrHeight: settings.maxImageDimension,
+            })
               .then((base64) => onFileSelected(base64))
               .catch((err) => {
                 console.error(err);

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -110,7 +110,8 @@ function OptionsButton({
             compressImageToBase64(
               file,
               settings.compressionFactor,
-              settings.maxCompressedFileSizeMb
+              settings.maxCompressedFileSizeMB,
+              settings.maxImageDimension
             )
               .then((base64) => onFileSelected(base64))
               .catch((err) => {

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -130,7 +130,13 @@ function OptionsButton({
         event.target.value = "";
       }
     },
-    [error, onFileSelected]
+    [
+      error,
+      onFileSelected,
+      settings.compressionFactor,
+      settings.maxCompressedFileSizeMB,
+      settings.maxImageDimension,
+    ]
   );
 
   const handleAttachFiles = useCallback(() => {

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -456,6 +456,60 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               </FormControl>
 
               <FormControl>
+                <FormLabel>Image Compression</FormLabel>
+                <Stack>
+                  <Box px="5">
+                    <FormLabel>
+                      Maximum file size after compression: {settings.maxCompressedFileSizeMb} (MB)
+                    </FormLabel>
+                    <Slider
+                      id="max-compressed-file-size"
+                      value={settings.maxCompressedFileSizeMb}
+                      onChange={(value) =>
+                        setSettings({ ...settings, maxCompressedFileSizeMb: value })
+                      }
+                      min={1}
+                      max={20}
+                      step={1}
+                    >
+                      <SliderTrack>
+                        <SliderFilledTrack />
+                      </SliderTrack>
+                      <SliderThumb />
+                    </Slider>
+                    <FormErrorMessage>
+                      Maximum file size must be between 1 and 20 MB.
+                    </FormErrorMessage>
+                  </Box>
+                  <Box px="5">
+                    <FormLabel>Compression factor: {settings.compressionFactor}</FormLabel>
+                    <Slider
+                      id="compression-factor"
+                      value={settings.compressionFactor}
+                      onChange={(value) => setSettings({ ...settings, compressionFactor: value })}
+                      min={0.1}
+                      max={1}
+                      step={0.1}
+                    >
+                      <SliderTrack>
+                        <SliderFilledTrack />
+                      </SliderTrack>
+                      <SliderThumb />
+                      <FormErrorMessage>
+                        Compression factor must be between 0.1 and 1.0
+                      </FormErrorMessage>
+                    </Slider>
+                  </Box>
+                </Stack>
+                <FormHelperText>
+                  Choose the best compression option for each attached image file based on your
+                  needs. You can either compress the image based on a maximum file size or a
+                  compression factor (i.e. original size x factor). The smaller the size or factor,
+                  the longer the compression time may be.
+                </FormHelperText>
+              </FormControl>
+
+              <FormControl>
                 <FormLabel>
                   When writing a prompt, press <Kbd>Enter</Kbd> to...
                 </FormLabel>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -460,13 +460,13 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                 <Stack>
                   <Box px="5">
                     <FormLabel>
-                      Maximum file size after compression: {settings.maxCompressedFileSizeMb} (MB)
+                      Maximum file size after compression: {settings.maxCompressedFileSizeMB} (MB)
                     </FormLabel>
                     <Slider
                       id="max-compressed-file-size"
-                      value={settings.maxCompressedFileSizeMb}
+                      value={settings.maxCompressedFileSizeMB}
                       onChange={(value) =>
-                        setSettings({ ...settings, maxCompressedFileSizeMb: value })
+                        setSettings({ ...settings, maxCompressedFileSizeMB: value })
                       }
                       min={1}
                       max={20}
@@ -480,6 +480,27 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                     <FormErrorMessage>
                       Maximum file size must be between 1 and 20 MB.
                     </FormErrorMessage>
+                  </Box>
+                  <Box px="5">
+                    <FormLabel>
+                      Maximum image dimension: {settings.maxImageDimension} (px)
+                    </FormLabel>
+                    <Slider
+                      id="max-image-dimension"
+                      value={settings.maxImageDimension}
+                      onChange={(value) => setSettings({ ...settings, maxImageDimension: value })}
+                      min={16}
+                      max={2048}
+                      step={16}
+                    >
+                      <SliderTrack>
+                        <SliderFilledTrack />
+                      </SliderTrack>
+                      <SliderThumb />
+                      <FormErrorMessage>
+                        Maximum Image dimension must be between 16 and 2048
+                      </FormErrorMessage>
+                    </Slider>
                   </Box>
                   <Box px="5">
                     <FormLabel>Compression factor: {settings.compressionFactor}</FormLabel>
@@ -503,9 +524,9 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                 </Stack>
                 <FormHelperText>
                   Choose the best compression option for each attached image file based on your
-                  needs. You can either compress the image based on a maximum file size or a
-                  compression factor (i.e. original size x factor). The smaller the size or factor,
-                  the longer the compression time may be.
+                  needs. You can choose from: maximum file size, maximum image dimension (width or
+                  height) or compression factor (i.e. original size x factor). The smaller the size,
+                  dimension or factor, the longer the compression time may be.
                 </FormHelperText>
               </FormControl>
 

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -482,7 +482,8 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         Maximum file size must be between 1 and 20 MB.
                       </FormErrorMessage>
                       <FormHelperText>
-                        The maximum file size for your compressed image (1 MB - 20 MB)
+                        After compression, each attached image will be under your chosen maximum
+                        file size (1-20 MB).
                       </FormHelperText>
                     </FormControl>
                   </Box>
@@ -508,8 +509,8 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         Maximum Image dimension must be between 16 and 2048
                       </FormErrorMessage>
                       <FormHelperText>
-                        The maximum image width or height for your compressed image (16 px - 2048
-                        px)
+                        Your compressed image&apos;s maximum width or height will be within the
+                        dimension you choose (16-2048 pixels).
                       </FormHelperText>
                     </FormControl>
                   </Box>
@@ -533,8 +534,8 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         Compression factor must be between 0.1 and 1.0
                       </FormErrorMessage>
                       <FormHelperText>
-                        The compression factor for your compressed image: the maximum compressed
-                        file size is set to original size x factor (0.1 - 1.0).
+                        Set the maximum file size based on the original size multiplied by the
+                        factor you choose (0.1-1.0).
                       </FormHelperText>
                     </FormControl>
                   </Box>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -459,75 +459,86 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                 <FormLabel as="legend">Image Compression</FormLabel>
                 <Stack>
                   <Box px="5">
-                    <FormLabel>
-                      Maximum file size after compression: {settings.maxCompressedFileSizeMB} (MB)
-                    </FormLabel>
-                    <Slider
-                      id="max-compressed-file-size"
-                      value={settings.maxCompressedFileSizeMB}
-                      onChange={(value) =>
-                        setSettings({ ...settings, maxCompressedFileSizeMB: value })
-                      }
-                      min={1}
-                      max={20}
-                      step={1}
-                    >
-                      <SliderTrack>
-                        <SliderFilledTrack />
-                      </SliderTrack>
-                      <SliderThumb />
-                    </Slider>
-                    <FormErrorMessage>
-                      Maximum file size must be between 1 and 20 MB.
-                    </FormErrorMessage>
+                    <FormControl>
+                      <FormLabel>
+                        Maximum file size after compression: {settings.maxCompressedFileSizeMB} (MB)
+                      </FormLabel>
+                      <Slider
+                        id="max-compressed-file-size"
+                        value={settings.maxCompressedFileSizeMB}
+                        onChange={(value) =>
+                          setSettings({ ...settings, maxCompressedFileSizeMB: value })
+                        }
+                        min={1}
+                        max={20}
+                        step={1}
+                      >
+                        <SliderTrack>
+                          <SliderFilledTrack />
+                        </SliderTrack>
+                        <SliderThumb />
+                      </Slider>
+                      <FormErrorMessage>
+                        Maximum file size must be between 1 and 20 MB.
+                      </FormErrorMessage>
+                      <FormHelperText>
+                        The maximum file size for your compressed image (1 MB - 20 MB)
+                      </FormHelperText>
+                    </FormControl>
                   </Box>
                   <Box px="5">
-                    <FormLabel>
-                      Maximum image dimension: {settings.maxImageDimension} (px)
-                    </FormLabel>
-                    <Slider
-                      id="max-image-dimension"
-                      value={settings.maxImageDimension}
-                      onChange={(value) => setSettings({ ...settings, maxImageDimension: value })}
-                      min={16}
-                      max={2048}
-                      step={16}
-                    >
-                      <SliderTrack>
-                        <SliderFilledTrack />
-                      </SliderTrack>
-                      <SliderThumb />
+                    <FormControl>
+                      <FormLabel>
+                        Maximum image dimension: {settings.maxImageDimension} (px)
+                      </FormLabel>
+                      <Slider
+                        id="max-image-dimension"
+                        value={settings.maxImageDimension}
+                        onChange={(value) => setSettings({ ...settings, maxImageDimension: value })}
+                        min={16}
+                        max={2048}
+                        step={16}
+                      >
+                        <SliderTrack>
+                          <SliderFilledTrack />
+                        </SliderTrack>
+                        <SliderThumb />
+                      </Slider>
                       <FormErrorMessage>
                         Maximum Image dimension must be between 16 and 2048
                       </FormErrorMessage>
-                    </Slider>
+                      <FormHelperText>
+                        The maximum image width or height for your compressed image (16 px - 2048
+                        px)
+                      </FormHelperText>
+                    </FormControl>
                   </Box>
                   <Box px="5">
-                    <FormLabel>Compression factor: {settings.compressionFactor}</FormLabel>
-                    <Slider
-                      id="compression-factor"
-                      value={settings.compressionFactor}
-                      onChange={(value) => setSettings({ ...settings, compressionFactor: value })}
-                      min={0.1}
-                      max={1}
-                      step={0.1}
-                    >
-                      <SliderTrack>
-                        <SliderFilledTrack />
-                      </SliderTrack>
-                      <SliderThumb />
+                    <FormControl>
+                      <FormLabel>Compression factor: {settings.compressionFactor}</FormLabel>
+                      <Slider
+                        id="compression-factor"
+                        value={settings.compressionFactor}
+                        onChange={(value) => setSettings({ ...settings, compressionFactor: value })}
+                        min={0.1}
+                        max={1}
+                        step={0.1}
+                      >
+                        <SliderTrack>
+                          <SliderFilledTrack />
+                        </SliderTrack>
+                        <SliderThumb />
+                      </Slider>
                       <FormErrorMessage>
                         Compression factor must be between 0.1 and 1.0
                       </FormErrorMessage>
-                    </Slider>
+                      <FormHelperText>
+                        The compression factor for your compressed image: the maximum compressed
+                        file size is set to original size x factor (0.1 - 1.0).
+                      </FormHelperText>
+                    </FormControl>
                   </Box>
                 </Stack>
-                <FormHelperText>
-                  Choose the best compression option for each attached image file based on your
-                  needs. You can choose from: maximum file size, maximum image dimension (width or
-                  height) or compression factor (i.e. original size x factor). The smaller the size,
-                  dimension or factor, the longer the compression time may be.
-                </FormHelperText>
               </FormControl>
 
               <FormControl>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -455,8 +455,8 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                 </FormHelperText>
               </FormControl>
 
-              <FormControl>
-                <FormLabel>Image Compression</FormLabel>
+              <FormControl as="fieldset">
+                <FormLabel as="legend">Image Compression</FormLabel>
                 <Stack>
                   <Box px="5">
                     <FormLabel>

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -227,8 +227,11 @@ function DesktopPromptForm({
 
   const processImages = (imageFiles: File[]) => {
     setInputImageUrls((prevImageUrls) => [...prevImageUrls, ...imageFiles.map(() => "")]);
-
-    Promise.all(imageFiles.map((file) => compressImageToBase64(file)))
+    Promise.all(
+      imageFiles.map((file) =>
+        compressImageToBase64(file, settings.compressionFactor, settings.maxCompressedFileSizeMb)
+      )
+    )
       .then((base64Strings) => {
         setInputImageUrls((prevImageUrls) => {
           const newImageUrls = [...prevImageUrls];

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -229,12 +229,11 @@ function DesktopPromptForm({
     setInputImageUrls((prevImageUrls) => [...prevImageUrls, ...imageFiles.map(() => "")]);
     Promise.all(
       imageFiles.map((file) =>
-        compressImageToBase64(
-          file,
-          settings.compressionFactor,
-          settings.maxCompressedFileSizeMB,
-          settings.maxImageDimension
-        )
+        compressImageToBase64(file, {
+          compressionFactor: settings.compressionFactor,
+          maxSizeMB: settings.maxCompressedFileSizeMB,
+          maxWidthOrHeight: settings.maxImageDimension,
+        })
       )
     )
       .then((base64Strings) => {

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -229,7 +229,12 @@ function DesktopPromptForm({
     setInputImageUrls((prevImageUrls) => [...prevImageUrls, ...imageFiles.map(() => "")]);
     Promise.all(
       imageFiles.map((file) =>
-        compressImageToBase64(file, settings.compressionFactor, settings.maxCompressedFileSizeMb)
+        compressImageToBase64(
+          file,
+          settings.compressionFactor,
+          settings.maxCompressedFileSizeMB,
+          settings.maxImageDimension
+        )
       )
     )
       .then((base64Strings) => {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -39,6 +39,8 @@ export type Settings = {
   textToSpeech: TextToSpeechSettings;
   providers: ProviderData;
   currentProvider: ChatCraftProvider;
+  compressionFactor: number;
+  maxCompressedFileSizeMb: number;
 };
 
 export const defaults: Settings = {
@@ -56,6 +58,8 @@ export const defaults: Settings = {
   },
   providers: {},
   currentProvider: new FreeModelProvider(),
+  compressionFactor: 1,
+  maxCompressedFileSizeMb: 20,
 };
 
 export const key = "settings";

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -40,7 +40,8 @@ export type Settings = {
   providers: ProviderData;
   currentProvider: ChatCraftProvider;
   compressionFactor: number;
-  maxCompressedFileSizeMb: number;
+  maxCompressedFileSizeMB: number;
+  maxImageDimension: number;
 };
 
 export const defaults: Settings = {
@@ -59,7 +60,8 @@ export const defaults: Settings = {
   providers: {},
   currentProvider: new FreeModelProvider(),
   compressionFactor: 1,
-  maxCompressedFileSizeMb: 20,
+  maxCompressedFileSizeMB: 20,
+  maxImageDimension: 2048,
 };
 
 export const key = "settings";

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -86,12 +86,17 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
 
 // Make sure image's size is within 20MB and 2048x2048 resolution
 // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
-export const compressImageToBase64 = (file: File): Promise<string> => {
+export const compressImageToBase64 = (
+  file: File,
+  compressionFactor: number = 1,
+  maxCompressedFileSizeMb: number = 20
+): Promise<string> => {
   const imageCompressionOptions = {
-    maxSizeMB: 20,
+    maxSizeMB: Math.min((file.size / 1024 / 1024) * compressionFactor, maxCompressedFileSizeMb, 20),
     maxWidthOrHeight: 2048,
   };
 
+  console.log(imageCompressionOptions);
   return import("browser-image-compression")
     .then((imageCompressionModule) => {
       const imageCompression = imageCompressionModule.default;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -84,15 +84,20 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
     );
 };
 
+interface ImageCompressionOptions {
+  compressionFactor?: number;
+  maxSizeMB?: number;
+  maxWidthOrHeight?: number;
+}
 // Make sure image's size is within 20MB and 2048x2048 resolution
 // https://platform.openai.com/docs/guides/vision/is-there-a-limit-to-the-size-of-the-image-i-can-upload
 export const compressImageToBase64 = (
   file: File,
-  compressionFactor: number = 1,
-  maxSizeMB: number = 20,
-  maxWidthOrHeight: number = 2048
+  options: ImageCompressionOptions = {}
 ): Promise<string> => {
-  const imageCompressionOptions = {
+  const { compressionFactor = 1, maxSizeMB = 20, maxWidthOrHeight = 2048 } = options;
+
+  const libOptions = {
     maxSizeMB: Math.min((file.size / 1024 / 1024) * compressionFactor, maxSizeMB, 20),
     maxWidthOrHeight: Math.min(maxWidthOrHeight, 2048),
   };
@@ -100,7 +105,7 @@ export const compressImageToBase64 = (
   return import("browser-image-compression")
     .then((imageCompressionModule) => {
       const imageCompression = imageCompressionModule.default;
-      return imageCompression(file, imageCompressionOptions);
+      return imageCompression(file, libOptions);
     })
     .then((compressedFile: File) => {
       return new Promise<string>((resolve, reject) => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -89,14 +89,14 @@ export const screenshotElement = (element: HTMLElement): Promise<Blob> => {
 export const compressImageToBase64 = (
   file: File,
   compressionFactor: number = 1,
-  maxCompressedFileSizeMb: number = 20
+  maxSizeMB: number = 20,
+  maxWidthOrHeight: number = 2048
 ): Promise<string> => {
   const imageCompressionOptions = {
-    maxSizeMB: Math.min((file.size / 1024 / 1024) * compressionFactor, maxCompressedFileSizeMb, 20),
-    maxWidthOrHeight: 2048,
+    maxSizeMB: Math.min((file.size / 1024 / 1024) * compressionFactor, maxSizeMB, 20),
+    maxWidthOrHeight: Math.min(maxWidthOrHeight, 2048),
   };
 
-  console.log(imageCompressionOptions);
   return import("browser-image-compression")
     .then((imageCompressionModule) => {
       const imageCompression = imageCompressionModule.default;


### PR DESCRIPTION
## Description

Allow user to set the preferred image compression options, the settings modal of this part looks like:

![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/8d4760fa-9b4d-4cfe-b279-a92a1a820c17)


Notes for the slider of `Maximum image dimension` option, I set the step to `16`, Therefore, users will not feel the tediousness of changing the numerical values, and I think the step makes sense in terms of image dimensions.

```
min={16}
max={2048}
step={16}
```

Fixes #464 