### PR TITLE
Fixed icons in the Menu

### DIFF
--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -1,18 +1,23 @@
-import React, { type ReactNode } from "react";
+import React, { ReactNode } from "react";
 import {
   MenuItem as ReactMenuItem,
   type MenuItemProps as ReactMenuItemProps,
 } from "@szhsin/react-menu";
+import { Box } from "@chakra-ui/react";
 
-export type MenuItemProps = ReactMenuItemProps & { label: ReactNode; icon?: ReactNode };
+export type MenuItemProps = ReactMenuItemProps & { icon?: ReactNode; iconSpacing?: number };
 
-const MenuItem: React.FC<MenuItemProps> = ({ label, icon, ...props }) => {
+const MenuItem: React.FC<MenuItemProps> = ({ icon, iconSpacing = 2, children, ...props }) => {
   return (
     <ReactMenuItem {...props}>
-      <div style={{ display: "flex", alignItems: "center" }}>
-        {icon && <span style={{ marginRight: "8px" }}>{icon}</span>}
-        {label}
-      </div>
+      <>
+        {icon && (
+          <Box marginRight={iconSpacing} as={"span"}>
+            {icon}
+          </Box>
+        )}
+        {children}
+      </>
     </ReactMenuItem>
   );
 };

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -6,11 +6,13 @@ import {
 
 export type MenuItemProps = ReactMenuItemProps & { label: ReactNode; icon?: ReactNode };
 
-const MenuItem: React.FC<MenuItemProps> = (props) => {
+const MenuItem: React.FC<MenuItemProps> = ({ label, icon, ...props }) => {
   return (
     <ReactMenuItem {...props}>
-      {props.label}
-      {props.icon}
+      <div style={{ display: "flex", alignItems: "center" }}>
+        {icon && <span style={{ marginRight: "8px" }}>{icon}</span>}
+        {label}
+      </div>
     </ReactMenuItem>
   );
 };

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -386,18 +386,7 @@ function MessageBase({
                 </ButtonGroup>
               )}
               <Menu isDisabled={isLoading}>
-                <MenuItem
-                  label="Copy"
-                  onClick={handleCopy}
-                  icon={
-                    <IconButton
-                      variant="ghost"
-                      icon={<MdContentCopy />}
-                      aria-label="Copy message to clipboard"
-                      title="Copy message to clipboard"
-                    />
-                  }
-                />
+                <MenuItem label="Copy" onClick={handleCopy} icon={<MdContentCopy />} />
                 <SubMenu label="Download">
                   <MenuItem label="Download as Markdown" onClick={handleDownloadMarkdown} />
                   <MenuItem label="Download as Text" onClick={handleDownloadPlainText} />
@@ -452,14 +441,7 @@ function MessageBase({
                   <MenuItem
                     label={editing ? "Cancel Editing" : "Edit"}
                     onClick={() => onEditingChange(!editing)}
-                    icon={
-                      <IconButton
-                        variant="ghost"
-                        icon={<AiOutlineEdit />}
-                        aria-label="Edit message"
-                        title="Edit message"
-                      />
-                    }
+                    icon={<AiOutlineEdit />}
                   />
                 )}
 
@@ -470,14 +452,7 @@ function MessageBase({
                         label="Delete Message"
                         onClick={onDeleteClick}
                         className="delete-button"
-                        icon={
-                          <IconButton
-                            variant="ghost"
-                            icon={<TbTrash color="red" />}
-                            aria-label="Delete message"
-                            title="Delete message"
-                          />
-                        }
+                        icon={<TbTrash color="red" />}
                       />
                     ) : (
                       <SubMenu label="Delete" className="delete-button">
@@ -493,14 +468,7 @@ function MessageBase({
                             label="Delete Message"
                             onClick={onDeleteClick}
                             className="delete-button"
-                            icon={
-                              <IconButton
-                                variant="ghost"
-                                icon={<TbTrash color="red" />}
-                                aria-label="Delete message"
-                                title="Delete message"
-                              />
-                            }
+                            icon={<TbTrash color="red" />}
                           />
                         )}
                         {onDeleteAfterClick && (

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -35,7 +35,7 @@ import {
 
 import { Menu, MenuItem, SubMenu, MenuDivider } from "../Menu";
 import ResizeTextarea from "react-textarea-autosize";
-import { TbTrash } from "react-icons/tb";
+import { TbTrash, TbShare2 } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
 import { Link as ReactRouterLink } from "react-router-dom";
@@ -427,14 +427,7 @@ function MessageBase({
                 <MenuItem
                   label="Share Message"
                   onClick={() => handleShareMessage()}
-                  icon={
-                    <IconButton
-                      variant="ghost"
-                      // icon={<YourShareIcon />} // Replace YourShareIcon with the actual icon you want to use for sharing
-                      aria-label="Share message"
-                      title="Share message"
-                    />
-                  }
+                  icon={<TbShare2 />}
                 />
                 {(!disableEdit || onDeleteClick) && <MenuDivider />}
                 {!disableEdit && (

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -38,7 +38,6 @@ import ResizeTextarea from "react-textarea-autosize";
 import { TbTrash, TbShare2 } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
-import { TbTrash } from "react-icons/tb";
 import { Link as ReactRouterLink } from "react-router-dom";
 import ResizeTextarea from "react-textarea-autosize";
 import { Menu, MenuDivider, MenuItem, SubMenu } from "../Menu";

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -503,7 +503,7 @@ function MessageBase({
                         label="Delete Message"
                         onClick={onDeleteClick}
                         className="delete-button"
-                        icon={<TbTrash color="red" />}
+                        icon={<TbTrash color="red.400" />}
                       />
                     ) : (
                       <SubMenu label="Delete" className="delete-button">

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -439,31 +439,32 @@ function MessageBase({
                 </ButtonGroup>
               )}
               <Menu isDisabled={isLoading}>
-                <MenuItem label="Copy" onClick={handleCopy} icon={<MdContentCopy />} />
+                <MenuItem onClick={handleCopy} icon={<MdContentCopy />}>
+                  Copy
+                </MenuItem>
                 <SubMenu label="Download">
-                  <MenuItem label="Download as Markdown" onClick={handleDownloadMarkdown} />
-                  <MenuItem label="Download as Text" onClick={handleDownloadPlainText} />
-                  <MenuItem label="Download as Audio" onClick={handleDownloadAudio}></MenuItem>
+                  <MenuItem onClick={handleDownloadMarkdown}>Download as Markdown</MenuItem>
+                  <MenuItem onClick={handleDownloadPlainText}>Download as Text</MenuItem>
+                  <MenuItem onClick={handleDownloadAudio}>Download as Audio</MenuItem>
                   <MenuItem
-                    label="Download as Image"
                     onClick={handleDownloadImage}
-                    // If we're editing, or showing only a summary, don't enable download as image
-                    // since we need the whole element to exist in order to render into the canvas.
                     disabled={displaySummaryText !== false || editing}
-                  />
+                  >
+                    Download as Image
+                  </MenuItem>
                 </SubMenu>
                 <MenuItem
-                  label="Speak"
                   onClick={() => handleSpeakMessage(messageContent.current?.textContent ?? "")}
-                />
+                >
+                  Speak
+                </MenuItem>
+
                 {!disableFork && (
-                  <MenuItem
-                    label={
-                      <Link as={ReactRouterLink} to={`./fork/${id}`} target="_blank">
-                        Duplicate Chat until Message...
-                      </Link>
-                    }
-                  />
+                  <MenuItem>
+                    <Link as={ReactRouterLink} to={`./fork/${id}`} target="_blank">
+                      Duplicate Chat until Message...
+                    </Link>
+                  </MenuItem>
                 )}
                 {onRetryClick && (
                   <>
@@ -472,62 +473,54 @@ function MessageBase({
                       {models
                         .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
                         .map((model) => (
-                          <MenuItem
-                            key={model.id}
-                            label={model.prettyModel}
-                            onClick={() => onRetryClick(model)}
-                          />
+                          <MenuItem key={model.id} onClick={() => onRetryClick(model)}>
+                            {model.prettyModel}
+                          </MenuItem>
                         ))}
                     </SubMenu>
                   </>
                 )}
                 <MenuDivider />
-                <MenuItem
-                  label="Share Message"
-                  onClick={() => handleShareMessage()}
-                  icon={<TbShare2 />}
-                />
+                <MenuItem onClick={() => handleShareMessage()} icon={<TbShare2 />}>
+                  Share Message
+                </MenuItem>
                 {(!disableEdit || onDeleteClick) && <MenuDivider />}
                 {!disableEdit && (
-                  <MenuItem
-                    label={editing ? "Cancel Editing" : "Edit"}
-                    onClick={() => onEditingChange(!editing)}
-                    icon={<AiOutlineEdit />}
-                  />
+                  <MenuItem onClick={() => onEditingChange(!editing)} icon={<AiOutlineEdit />}>
+                    {editing ? "Cancel Editing" : "Edit"}
+                  </MenuItem>
                 )}
 
                 {shouldShowDeleteMenu && (
                   <>
                     {onDeleteClick && !onDeleteBeforeClick && !onDeleteAfterClick ? (
                       <MenuItem
-                        label="Delete Message"
                         onClick={onDeleteClick}
                         className="delete-button"
                         icon={<TbTrash color="red.400" />}
-                      />
+                      >
+                        Delete Message
+                      </MenuItem>
                     ) : (
                       <SubMenu label="Delete" className="delete-button">
                         {onDeleteBeforeClick && (
-                          <MenuItem
-                            label="Delete Messages Before"
-                            onClick={onDeleteBeforeClick}
-                            className="delete-button"
-                          />
+                          <MenuItem onClick={onDeleteBeforeClick} className="delete-button">
+                            Delete Messages Before
+                          </MenuItem>
                         )}
                         {onDeleteClick && (
                           <MenuItem
-                            label="Delete Message"
                             onClick={onDeleteClick}
                             className="delete-button"
                             icon={<TbTrash color="red.400" />}
-                          />
+                          >
+                            Delete Message
+                          </MenuItem>
                         )}
                         {onDeleteAfterClick && (
-                          <MenuItem
-                            label="Delete Messages After"
-                            onClick={onDeleteAfterClick}
-                            className="delete-button"
-                          />
+                          <MenuItem onClick={onDeleteAfterClick} className="delete-button">
+                            Delete Messages After
+                          </MenuItem>
                         )}
                       </SubMenu>
                     )}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -448,7 +448,9 @@ function MessageBase({
                 <SubMenu label="Download">
                   <MenuItem onClick={handleDownloadMarkdown}>Download as Markdown</MenuItem>
                   <MenuItem onClick={handleDownloadPlainText}>Download as Text</MenuItem>
-                  {isTtsSupported && (<MenuItem onClick={handleDownloadAudio}>Download as Audio</MenuItem>)}
+                  {isTtsSupported && (
+                    <MenuItem onClick={handleDownloadAudio}>Download as Audio</MenuItem>
+                  )}
                   <MenuItem
                     onClick={handleDownloadImage}
                     disabled={displaySummaryText !== false || editing}
@@ -457,11 +459,11 @@ function MessageBase({
                   </MenuItem>
                 </SubMenu>
                 {isTtsSupported && (
-                <MenuItem
-                  onClick={() => handleSpeakMessage(messageContent.current?.textContent ?? "")}
-                >
-                  Speak
-                </MenuItem>
+                  <MenuItem
+                    onClick={() => handleSpeakMessage(messageContent.current?.textContent ?? "")}
+                  >
+                    Speak
+                  </MenuItem>
                 )}
                 {!disableFork && (
                   <MenuItem>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -39,8 +39,6 @@ import { TbTrash, TbShare2 } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
 import { Link as ReactRouterLink } from "react-router-dom";
-import ResizeTextarea from "react-textarea-autosize";
-import { Menu, MenuDivider, MenuItem, SubMenu } from "../Menu";
 
 import { useCopyToClipboard } from "react-use";
 import { useAlert } from "../../hooks/use-alert";

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -461,7 +461,7 @@ function MessageBase({
                             label="Delete Message"
                             onClick={onDeleteClick}
                             className="delete-button"
-                            icon={<TbTrash color="red" />}
+                            icon={<TbTrash color="red.400" />}
                           />
                         )}
                         {onDeleteAfterClick && (


### PR DESCRIPTION
Closes #443 

Based on the issue, Icons should be:
- [x] On the left
- [x] Same colour as the font for the menu item
- [x] Smaller/ same size as the text
- [x] Not a button you click (the whole menu item should be clickable)

Steps Taken to resolve:
- Updated MessageBase component with icon prop to have icons and not IconButtons
- Updated MenuItem component to be in a div aligned to centre and flex for proper alignment and sizing
- Updated color of delete button icon to be similar to the ChakraUI red.400 text

Screenshots:
![image](https://github.com/tarasglek/chatcraft.org/assets/58596563/ce48a01c-0126-4451-91b3-21a05d6361b3)
