### PR TITLE
Set init provider for new users to free model, added info alert banner

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,7 +8,7 @@
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { ProviderData, ChatCraftProvider } from "../lib/ChatCraftProvider";
 import { providerFromJSON, providerFromUrl } from "./providers";
-import { OpenAiProvider } from "./providers/OpenAiProvider";
+import { FreeModelProvider } from "./providers/DefaultProvider/FreeModelProvider";
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
@@ -42,7 +42,7 @@ export type Settings = {
 };
 
 export const defaults: Settings = {
-  model: new ChatCraftModel("gpt-3.5-turbo"),
+  model: new ChatCraftModel("undi95/toppy-m-7b:free"),
   temperature: 0,
   enterBehaviour: "send",
   // Disabled by default, since token parsing requires downloading larger deps
@@ -55,7 +55,7 @@ export const defaults: Settings = {
     voice: TextToSpeechVoices.ALLOY,
   },
   providers: {},
-  currentProvider: new OpenAiProvider(),
+  currentProvider: new FreeModelProvider(),
 };
 
 export const key = "settings";


### PR DESCRIPTION
- Set initial provider for new users to `FreeModelProvider` (can test by clearing cache)
- New users will not see the Instructions page upon their first visit to chatcraft, they can start talking to FreeModelProvider right away
- Users currently using `FreeModelProvider` will see the following alert banner with link which opens user settings

![alert_banner](https://github.com/tarasglek/chatcraft.org/assets/98062538/c504c713-2931-4ff1-9031-6360465eddd9)

Closes #501

### Code changes:

Modifications to `settings.ts`:

- Made `FreeModelProvider` the **initial provider** for new users instead of `OpenAiProvider`
- Made the default model of `FreeModelProvider` the **initial model** instead of `OpenAiProvider`'s default model

Modifications to `ChatBase.tsx`:

- Modified `ChatBase.tsx` to show the alert banner to users using `FreeModelProvider` as their currentProvider
- Clicking the link in alert banner opens the User Settings

Modifications to `Instructions.tsx`:

- Made api key field not a required field for `FreeModelProvider`
- Modified form submission handler function so that it will skip key validation for `FreeModelProvider`
- Kept this change even though we are not currently using Instructions page, just in case we need that page in the future

### How to test:

- Either clear your cache (you will automatically be set to free provider) or manually change your provider to the free provider in settings
- Go to the chatcraft main url, you should not see the instructions page and should be able to talk to chatcraft right away
- You should also see the alert banner, which notifies you that you are using free provider
- Click the link in the banner
- The User Settings modal should now open