### PR TITLE
Implement initial version of web handlers

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -211,9 +211,9 @@ function ChatBase({ chat }: ChatBaseProps) {
       }
 
       // If we have a web handler registered for this url
-      if (prompt && WebHandler.getMatchingHandler(prompt)) {
-        const handler = WebHandler.getMatchingHandler(prompt);
+      const handler = WebHandler.getMatchingHandler(prompt ?? "");
 
+      if (prompt && handler) {
         try {
           const result = await handler!.executeHandler(prompt); // We know handler is always there
 

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -215,7 +215,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
       if (prompt && handler) {
         try {
-          const result = await handler!.executeHandler(prompt); // We know handler is always there
+          const result = await handler.executeHandler(prompt);
 
           chat.addMessage(new ChatCraftHumanMessage({ user, text: result }));
           forceScroll();

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -35,6 +35,7 @@ import {
   ChatCraftFunctionResultMessage,
   ChatCraftHumanMessage,
 } from "../lib/ChatCraftMessage";
+import { WebHandler } from "../lib/WebHandler";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import ChatHeader from "./ChatHeader";
 import { FreeModelProvider } from "../lib/providers/DefaultProvider/FreeModelProvider";
@@ -207,6 +208,26 @@ function ChatBase({ chat }: ChatBaseProps) {
       // Special-case for "help", to invoke /help command
       if (prompt?.toLowerCase() === "help") {
         prompt = "/help";
+      }
+
+      // If we have a web handler registered for this url
+      if (prompt && WebHandler.getMatchingHandler(prompt)) {
+        const handler = WebHandler.getMatchingHandler(prompt);
+
+        try {
+          const result = await handler!.executeHandler(prompt); // We know handler is always there
+
+          chat.addMessage(new ChatCraftHumanMessage({ user, text: result }));
+          forceScroll();
+        } catch (err: any) {
+          error({
+            title: "Error running Web Handler",
+            message: err.message,
+          });
+        }
+
+        setLoading(false);
+        return;
       }
 
       // If this is a slash command, execute that instead of prompting LLM

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,6 +28,7 @@ import PreferencesModal from "./PreferencesModal";
 import DefaultSystemPromptModal from "./DefaultSystemPromptModal";
 import { useUser } from "../hooks/use-user";
 import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
+import WebHandlersConfigModal from "./WebHandlersConfigModal";
 
 type HeaderProps = {
   chatId?: string;
@@ -42,6 +43,11 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
     isOpen: isPrefModalOpen,
     onOpen: onPrefModalOpen,
     onClose: onPrefModalClose,
+  } = useDisclosure();
+  const {
+    isOpen: isWebHandlersModalOpen,
+    onOpen: onWebHandlersModalOpen,
+    onClose: onWebHandlersModalClose,
   } = useDisclosure();
   const {
     isOpen: isSysPromptModalOpen,
@@ -141,6 +147,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
             />
             <MenuList>
               <MenuItem onClick={onPrefModalOpen}>Settings...</MenuItem>
+              <MenuItem onClick={onWebHandlersModalOpen}>Web Handlers</MenuItem>
               <MenuItem onClick={onSysPromptModalOpen}>Default System Prompt...</MenuItem>
               {user ? (
                 <MenuItem
@@ -189,6 +196,11 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
       <PreferencesModal
         isOpen={isPrefModalOpen}
         onClose={onPrefModalClose}
+        finalFocusRef={inputPromptRef}
+      />
+      <WebHandlersConfigModal
+        isOpen={isWebHandlersModalOpen}
+        onClose={onWebHandlersModalClose}
         finalFocusRef={inputPromptRef}
       />
       <DefaultSystemPromptModal

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -1,0 +1,118 @@
+import {
+  Button,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Textarea,
+  VStack,
+} from "@chakra-ui/react";
+import { ChangeEvent, RefObject, useCallback, useState } from "react";
+
+import { MdSave } from "react-icons/md";
+import YAML from "yaml";
+import { useWebHandlers } from "../hooks/use-web-handlers";
+import { WebHandler, WebHandlers } from "../lib/WebHandler";
+import { useAlert } from "../hooks/use-alert";
+
+type WebHandlersConfigModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  finalFocusRef?: RefObject<HTMLTextAreaElement>;
+};
+
+function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersConfigModalProps) {
+  const { webHandlers, registerHandlers } = useWebHandlers();
+  const { info, error } = useAlert();
+
+  const getWebHandlersYaml = (webHandlers: WebHandlers) => {
+    return YAML.stringify(
+      webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))
+    );
+  };
+
+  const [webHandlerConfig, setWebHandlerConfig] = useState(getWebHandlersYaml(webHandlers));
+
+  const handleConfigValueChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const updatedConfig = event.target.value;
+
+      setWebHandlerConfig(updatedConfig);
+    },
+    [setWebHandlerConfig]
+  );
+
+  const onModalClose = useCallback(() => {
+    // Reset any unsaved changes
+    setWebHandlerConfig(getWebHandlersYaml(webHandlers));
+
+    // Close the modal
+    onClose();
+  }, [onClose, webHandlers]);
+
+  const onSaveConfig = useCallback(() => {
+    try {
+      const updatedWebHandlers: WebHandlers = YAML.parse(webHandlerConfig).map(
+        (handlerConfig: WebHandler) => new WebHandler(handlerConfig)
+      );
+
+      if (updatedWebHandlers.some((handler) => !handler.isValidHandler())) {
+        throw new Error("Invalid Handler Configuration");
+      }
+
+      // Persist handlers to local storage
+      registerHandlers(updatedWebHandlers);
+
+      info({
+        title: "Saved",
+        message: "Successfully updated Web Handlers configuration",
+      });
+    } catch (err: any) {
+      error({
+        title: "Failed to save Handler Config",
+        message: "Please enter valid YAML configuration",
+      });
+    }
+  }, [error, info, registerHandlers, webHandlerConfig]);
+
+  return (
+    <Modal isOpen={isOpen} onClose={onModalClose} size="lg" finalFocusRef={finalFocusRef}>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Web Handlers</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <VStack gap={4}>
+            <FormControl>
+              <FormLabel>Register Handlers</FormLabel>
+              <Textarea
+                value={webHandlerConfig}
+                onChange={handleConfigValueChange}
+                height={200}
+                placeholder="Please enter the configurations of your handlers in YAML"
+              />
+
+              <FormHelperText>
+                The first handler with a successful match pattern is executed
+              </FormHelperText>
+            </FormControl>
+          </VStack>
+        </ModalBody>
+
+        <ModalFooter>
+          <Button size="sm" rightIcon={<MdSave />} onClick={onSaveConfig}>
+            Save
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}
+
+export default WebHandlersConfigModal;

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -92,6 +92,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
             <FormControl>
               <FormLabel>Register Handlers</FormLabel>
               <Textarea
+                fontFamily={"monospace"}
                 value={webHandlerConfig}
                 onChange={handleConfigValueChange}
                 height={200}

--- a/src/hooks/use-web-handlers.tsx
+++ b/src/hooks/use-web-handlers.tsx
@@ -1,0 +1,78 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type FC,
+  type ReactNode,
+} from "react";
+import { useLocalStorage } from "react-use";
+
+import {
+  defaultWebHandlers,
+  WebHandler,
+  WebHandlers,
+  webHandlersLocalStorageKey,
+} from "../lib/WebHandler";
+
+type WebHandlersContextType = {
+  webHandlers: WebHandlers;
+  registerHandlers: (newWebHandlers: WebHandlers) => void;
+};
+
+const WebHandlersContext = createContext<WebHandlersContextType>({
+  webHandlers: defaultWebHandlers,
+  registerHandlers: () => {
+    /* do nothing */
+  },
+});
+
+export const useWebHandlers = () => useContext(WebHandlersContext);
+
+const serializer = (value: WebHandlers) => {
+  const serializableHandlers = value.map((handler) => ({
+    ...handler,
+    matchPattern: handler.matchPattern.source,
+  }));
+
+  return JSON.stringify(serializableHandlers);
+};
+
+const deserializer = (value: string) => {
+  // Get back the prototype methods
+  const webHandlers = JSON.parse(value).map((handler: WebHandler) => new WebHandler(handler));
+
+  return webHandlers;
+};
+
+export const WebHandlersProvider: FC<{ children: ReactNode }> = ({ children }) => {
+  const [webHandlers, registerHandlers] = useLocalStorage<WebHandlers>(
+    webHandlersLocalStorageKey,
+    defaultWebHandlers,
+    {
+      raw: false,
+      serializer,
+      deserializer,
+    }
+  );
+
+  const [state, setState] = useState<WebHandlers>(webHandlers || defaultWebHandlers);
+
+  useEffect(() => {
+    setState(webHandlers || defaultWebHandlers);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const updateWebHandlers = useCallback(
+    (newWebHandlers: WebHandlers) => {
+      setState(newWebHandlers);
+      registerHandlers(newWebHandlers);
+    },
+    [registerHandlers]
+  );
+
+  const value = { webHandlers: state, registerHandlers: updateWebHandlers };
+
+  return <WebHandlersContext.Provider value={value}>{children}</WebHandlersContext.Provider>;
+};

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -17,15 +17,15 @@ export class WebHandler {
     this.matchPattern = matchPattern;
   }
 
-  isMatchingHandler(url: string) {
-    return this.matchPattern.test(url);
+  isMatchingHandler(message: string) {
+    return this.matchPattern.test(message);
   }
 
-  async executeHandler(url: string): Promise<string> {
+  async executeHandler(message: string): Promise<string> {
     const requestUrl = new URL(this.handlerUrl);
 
     const params = new URLSearchParams();
-    params.append("url", url);
+    params.append("url", message);
 
     requestUrl.search = params.toString();
 
@@ -36,14 +36,16 @@ export class WebHandler {
     // const type = guessType(response.headers.get("Content-Type"));
     const content = (await response.text()).trim();
 
-    const messageHeader = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${url}](${url})`;
-    const text = `${messageHeader}\n\n` + content;
+    const resultHeader = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${message}](${message})`;
+    const text = `${resultHeader}\n\n` + content;
 
     return text;
   }
 
-  static getMatchingHandler(url: string): WebHandler | null {
-    return this.getRegisteredHandlers().find((handler) => handler.isMatchingHandler(url)) ?? null;
+  static getMatchingHandler(message: string): WebHandler | null {
+    return (
+      this.getRegisteredHandlers().find((handler) => handler.isMatchingHandler(message)) ?? null
+    );
   }
 
   static getRegisteredHandlers(): WebHandler[] {

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -10,11 +10,11 @@ export class WebHandler {
   }: {
     handlerUrl: string;
     method: HttpMethod;
-    matchPattern: RegExp;
+    matchPattern: RegExp | string;
   }) {
     this.handlerUrl = handlerUrl;
     this.method = method;
-    this.matchPattern = matchPattern;
+    this.matchPattern = matchPattern instanceof RegExp ? matchPattern : new RegExp(matchPattern);
   }
 
   isMatchingHandler(message: string) {
@@ -48,17 +48,15 @@ export class WebHandler {
   }
 
   static getRegisteredHandlers(): WebHandler[] {
-    // TODO: Fetch from localStorage
-
-    const supportedHandlers = [
-      new WebHandler({
-        handlerUrl: "https://taras-scrape2md.web.val.run/",
-        method: HttpMethod.GET,
-        matchPattern: /^https:\/\/\S+$/,
-      }),
-    ];
+    const supportedHandlers = JSON.parse(
+      localStorage.getItem(webHandlersLocalStorageKey) ?? ""
+    ).map((handler: WebHandler) => new WebHandler(handler));
 
     return supportedHandlers;
+  }
+
+  isValidHandler(): boolean {
+    return !!this.handlerUrl && !!this.method && !!this.matchPattern;
   }
 }
 
@@ -73,3 +71,15 @@ export enum HttpMethod {
   PUT = "PUT",
   TRACE = "TRACE",
 }
+
+export const defaultWebHandlers: WebHandlers = [
+  new WebHandler({
+    handlerUrl: "https://taras-scrape2md.web.val.run/",
+    method: HttpMethod.GET,
+    matchPattern: /^https:\/\/\S+$/,
+  }),
+];
+
+export const webHandlersLocalStorageKey = "webHandlers";
+
+export type WebHandlers = WebHandler[];

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -1,5 +1,3 @@
-import { guessType } from "./commands/ImportCommand";
-
 export class WebHandler {
   handlerUrl: string;
   method: HttpMethod;
@@ -24,33 +22,22 @@ export class WebHandler {
   }
 
   async executeHandler(url: string): Promise<string> {
-    url = extractFirstUrl(url) ?? ""; // When the input is not a url itself
+    const requestUrl = new URL(this.handlerUrl);
 
     const params = new URLSearchParams();
     params.append("url", url);
 
-    let requestUrl: string | URL = "";
-    if (URL.canParse(this.handlerUrl)) {
-      requestUrl = new URL(this.handlerUrl);
-
-      requestUrl.search = params.toString();
-    } else {
-      requestUrl = `${this.handlerUrl}?${params.toString()}`;
-    }
+    requestUrl.search = params.toString();
 
     const response = await fetch(requestUrl, {
       method: this.method,
     });
 
-    const type = guessType(response.headers.get("Content-Type"));
+    // const type = guessType(response.headers.get("Content-Type"));
     const content = (await response.text()).trim();
 
-    const command = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${url}](${url})`;
-    const text =
-      `${command}\n\n` +
-      // If it's already markdown, dump it into the message as is;
-      // otherwise, wrap it in a code block with appropriate type
-      (type === "markdown" ? content : `\`\`\`${type}\n${content}` + `\n\`\`\``);
+    const messageHeader = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${url}](${url})`;
+    const text = `${messageHeader}\n\n` + content;
 
     return text;
   }
@@ -84,15 +71,4 @@ export enum HttpMethod {
   POST = "POST",
   PUT = "PUT",
   TRACE = "TRACE",
-}
-
-function extractFirstUrl(text: string) {
-  // Regular expression to match URLs
-  const urlRegex = /(https?:\/\/[^\s]+)/;
-
-  // Match the first URL found in the text
-  const match = text.match(urlRegex);
-
-  // If a URL is found, return it, otherwise return null
-  return match ? match[0] : null;
 }

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -1,0 +1,103 @@
+import { guessType } from "./commands/ImportCommand";
+
+export class WebHandler {
+  handlerUrl: string;
+  method: HttpMethod;
+  matchPattern: RegExp;
+
+  constructor({
+    handlerUrl,
+    method,
+    matchPattern,
+  }: {
+    handlerUrl: string;
+    method: HttpMethod;
+    matchPattern: RegExp;
+  }) {
+    this.handlerUrl = handlerUrl;
+    this.method = method;
+    this.matchPattern = matchPattern;
+  }
+
+  isMatchingHandler(url: string) {
+    return this.matchPattern.test(url);
+  }
+
+  async executeHandler(url: string): Promise<string> {
+    url = extractFirstUrl(url) ?? ""; // When the input is not a url itself
+
+    const params = new URLSearchParams();
+    params.append("url", url);
+
+    let requestUrl: string | URL = "";
+    if (URL.canParse(this.handlerUrl)) {
+      requestUrl = new URL(this.handlerUrl);
+
+      requestUrl.search = params.toString();
+    } else {
+      requestUrl = `${this.handlerUrl}?${params.toString()}`;
+    }
+
+    const response = await fetch(requestUrl, {
+      method: this.method,
+    });
+
+    const type = guessType(response.headers.get("Content-Type"));
+    const content = (await response.text()).trim();
+
+    const command = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${url}](${url})`;
+    const text =
+      `${command}\n\n` +
+      // If it's already markdown, dump it into the message as is;
+      // otherwise, wrap it in a code block with appropriate type
+      (type === "markdown" ? content : `\`\`\`${type}\n${content}` + `\n\`\`\``);
+
+    return text;
+  }
+
+  static getMatchingHandler(url: string): WebHandler | null {
+    return this.getRegisteredHandlers().find((handler) => handler.isMatchingHandler(url)) ?? null;
+  }
+
+  static getRegisteredHandlers(): WebHandler[] {
+    // TODO: Fetch from localStorage
+
+    const supportedHandlers = [
+      new WebHandler({
+        handlerUrl: "/api/proxy",
+        method: HttpMethod.GET,
+        matchPattern: /^\/import https?:\/\/\S+/,
+      }),
+      new WebHandler({
+        handlerUrl: "https://taras-scrape2md.web.val.run/",
+        method: HttpMethod.GET,
+        matchPattern: /^https:\/\/\S+/,
+      }),
+    ];
+
+    return supportedHandlers;
+  }
+}
+
+export enum HttpMethod {
+  CONNECT = "CONNECT",
+  DELETE = "DELETE",
+  GET = "GET",
+  HEAD = "HEAD",
+  OPTIONS = "OPTIONS",
+  PATCH = "PATCH",
+  POST = "POST",
+  PUT = "PUT",
+  TRACE = "TRACE",
+}
+
+function extractFirstUrl(text: string) {
+  // Regular expression to match URLs
+  const urlRegex = /(https?:\/\/[^\s]+)/;
+
+  // Match the first URL found in the text
+  const match = text.match(urlRegex);
+
+  // If a URL is found, return it, otherwise return null
+  return match ? match[0] : null;
+}

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -64,14 +64,9 @@ export class WebHandler {
 
     const supportedHandlers = [
       new WebHandler({
-        handlerUrl: "/api/proxy",
-        method: HttpMethod.GET,
-        matchPattern: /^\/import https?:\/\/\S+/,
-      }),
-      new WebHandler({
         handlerUrl: "https://taras-scrape2md.web.val.run/",
         method: HttpMethod.GET,
-        matchPattern: /^https:\/\/\S+/,
+        matchPattern: /^https:\/\/\S+$/,
       }),
     ];
 

--- a/src/lib/WebHandler.ts
+++ b/src/lib/WebHandler.ts
@@ -33,7 +33,6 @@ export class WebHandler {
       method: this.method,
     });
 
-    // const type = guessType(response.headers.get("Content-Type"));
     const content = (await response.text()).trim();
 
     const resultHeader = `**Web Handler**: [${this.handlerUrl}](${this.handlerUrl})?url=[${message}](${message})`;

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -3,7 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
 
 // To keep this small, just deal with some common cases vs doing proper parser/list
-const guessType = (contentType: string | null) => {
+export const guessType = (contentType: string | null) => {
   if (!contentType) {
     return "text";
   }

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -3,7 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
 
 // To keep this small, just deal with some common cases vs doing proper parser/list
-export const guessType = (contentType: string | null) => {
+const guessType = (contentType: string | null) => {
   if (!contentType) {
     return "text";
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,22 +10,25 @@ import { UserProvider } from "./hooks/use-user";
 import { ModelsProvider } from "./hooks/use-models";
 import { CostProvider } from "./hooks/use-cost";
 import { AudioPlayerProvider } from "./hooks/use-audio-player";
+import { WebHandlersProvider } from "./hooks/use-web-handlers";
 
 ReactDOM.createRoot(document.querySelector("main") as HTMLElement).render(
   <React.StrictMode>
     <ChakraProvider theme={theme}>
-      <AudioPlayerProvider>
-        <SettingsProvider>
-          <CostProvider>
-            <ModelsProvider>
-              <UserProvider>
-                <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-                <RouterProvider router={router} />
-              </UserProvider>
-            </ModelsProvider>
-          </CostProvider>
-        </SettingsProvider>
-      </AudioPlayerProvider>
+      <WebHandlersProvider>
+        <AudioPlayerProvider>
+          <SettingsProvider>
+            <CostProvider>
+              <ModelsProvider>
+                <UserProvider>
+                  <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+                  <RouterProvider router={router} />
+                </UserProvider>
+              </ModelsProvider>
+            </CostProvider>
+          </SettingsProvider>
+        </AudioPlayerProvider>
+      </WebHandlersProvider>
     </ChakraProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
This is my initial attempt in implementing the idea of what we can call web handlers as discussed in #507 .

I have:
1. Written a `WebHandler` class registering/searching web handlers and executing their logic i.e. sending request to `handler url` based on request config (so far request method)
2. Added logic to check if the prompt matches with **match pattern** of one of the registered Web Handlers. The search is sequential as mentioned in the issue, and the first matched web handler processes the prompt url. If there is no match, the prompt is released to the regular control flow (slash command or sent to AI).
3. Currently, I have hard coded 2 Web Handlers as mentioned in issue, but we can later create UI to configure as many as user wants in `localStorage`.

**Demo:**

Prompt: `https://github.com/tarasglek/chatcraft.org/pull/519`

<img width="960" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/78865303/54a8904a-8dd0-41c6-b291-0013146fb11e">

What I don't like is how we are currently allowing prompt like `import <url>` to be registered as match patterns. This causes ambiguity and I had to write specialized logic to handle edge cases like
```ts
url = extractFirstUrl(url) ?? ""; // When the input is not a url itself
```
as an example.

I feel like we should restrict web handler match patterns to just urls, and let import command serve its own purpose.

 Maybe I am wrong and don't understand fully where we are going with this.

@humphd @tarasglek Please let me know what you think.