### PR TITLE
Add Nomnoml Renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lodash-es": "^4.17.21",
     "mermaid": "^10.8.0",
     "nanoid": "^5.0.5",
+    "nomnoml": "^1.6.2",
     "openai": "^4.26.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ dependencies:
   nanoid:
     specifier: ^5.0.5
     version: 5.0.5
+  nomnoml:
+    specifier: ^1.6.2
+    version: 1.6.2
   openai:
     specifier: ^4.26.1
     version: 4.26.1
@@ -6564,6 +6567,10 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
+  /graphre@0.1.3:
+    resolution: {integrity: sha512-F4OO/+BQj3R2UB3PQOGLgdAUy+SQuwy2A5cVGELAQDJlloSyyHqRe60ESFouRf8W0K+sm6gtWKotOwZoX3BL8w==}
+    dev: false
+
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: true
@@ -8377,6 +8384,13 @@ packages:
       util: 0.12.5
       vm-browserify: 1.1.2
     dev: true
+
+  /nomnoml@1.6.2:
+    resolution: {integrity: sha512-R3dA3FS8txilobpd2ZdnCuEwmXYYljxza2wR41YE/cIHMbt0eXsjlXHlAsD+F/fVe536f0WkAQ+VQFRC3hPZCA==}
+    hasBin: true
+    dependencies:
+      graphre: 0.1.3
+    dev: false
 
   /non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
@@ -10723,6 +10737,7 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
+    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0

--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -17,6 +17,7 @@ import oneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-lig
 import CodeHeader from "./CodeHeader";
 import HtmlPreview from "./HtmlPreview";
 import MermaidPreview from "./MermaidPreview";
+import NomnomlPreview from "./NomnomlPreview";
 
 const fixLanguageName = (language: string | null) => {
   if (!language) {
@@ -107,6 +108,10 @@ function Markdown({
             } else if (language === "mermaid") {
               preview = (
                 <MermaidPreview children={Array.isArray(children) ? children : [children]} />
+              );
+            } else if (language === "nomnoml") {
+              preview = (
+                <NomnomlPreview children={Array.isArray(children) ? children : [children]} />
               );
             }
           }

--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -29,7 +29,7 @@ We think ChatCraft is the best platform for learning, experimenting, and getting
 | ------------------------------------- |:---------:|:-------:|:-------:|
 | Optimized for conversations about code | ✅        | ❌      | ❌      |
 | Work with models from multiple AI vendors | ✅         |❌       | ❌      |
-| Previews for Mermaid Diagrams, HTML   | ✅        | ❌      | ❌      |
+| Previews for Mermaid/Nomnoml Diagrams, HTML   | ✅        | ❌      | ❌      |
 | Edit Generated AI Replies             | ✅        | ❌      | ✅      |
 | Use Custom System Prompts             | ✅        | ✅      | ❌      |
 | Easy to retry with different AI models| ✅        | ❌      | ❌      |

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -1,8 +1,9 @@
-import { useRef, type ReactNode, useCallback, useEffect } from "react";
+import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
+import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
 import nomnoml from "nomnoml";
-import { useClipboard } from "@chakra-ui/react";
-import { useAlert } from "../hooks/use-alert";
+import { TbCopy } from "react-icons/tb";
 import { nanoid } from "nanoid";
+import { useAlert } from "../hooks/use-alert";
 
 type NomnomlPreviewProps = {
   children: ReactNode & ReactNode[];

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -28,8 +28,8 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
       return;
     }
 
-    try {
-      const fetchNomnoml = async () => {
+    const fetchNomnoml = async () => {
+      try {
         const nomnoml = await import("nomnoml");
         const svg = await nomnoml.renderSvg(code);
 
@@ -41,12 +41,13 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
         if (svgElement) {
           svgElement.style.width = "100%";
         }
-      };
-      fetchNomnoml();
-    } catch (err: any) {
-      setValue(err);
-      console.warn(`Error rendering nomnoml diagram`, err);
-    }
+      } catch (err: any) {
+        // If diagram fails, use error vs. diagram for copying (to debug)
+        setValue(err);
+        console.warn(`Error rendering nomnoml diagram`, err);
+      }
+    };
+    fetchNomnoml();
   }, [diagramRef, code, setValue]);
 
   return (

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -1,0 +1,13 @@
+import { type ReactNode } from "react";
+import nomnoml from "nomnoml";
+
+type NomnomlPreviewProps = {
+  children: ReactNode & ReactNode[];
+};
+
+const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
+  const code = String(children);
+};
+
+// Memoize to reduce re-renders/flickering when content hasn't changed
+export default memo(NomnomlPreview);

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -1,12 +1,34 @@
-import { type ReactNode } from "react";
+import { useRef, type ReactNode, useCallback, useEffect } from "react";
 import nomnoml from "nomnoml";
+import { useClipboard } from "@chakra-ui/react";
+import { useAlert } from "../hooks/use-alert";
+import { nanoid } from "nanoid";
 
 type NomnomlPreviewProps = {
   children: ReactNode & ReactNode[];
 };
 
 const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
+  const { onCopy, value, setValue } = useClipboard("");
+  const { info } = useAlert();
+  const diagramRef = useRef<HTMLDivElement | null>(null);
   const code = String(children);
+
+  const handleCopy = useCallback(() => {
+    onCopy();
+    info({
+      title: "Copied to Clipboard",
+      message: "Nomnoml SVG diagram was copied to your clipboard.",
+    });
+  }, [onCopy, info]);
+
+  // Render the diagram as an SVG into our card's body
+  useEffect(() => {
+    const diagramDiv = diagramRef.current;
+    if (!diagramDiv) {
+      return;
+    }
+  });
 };
 
 // Memoize to reduce re-renders/flickering when content hasn't changed

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -1,6 +1,5 @@
 import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
-import nomnoml from "nomnoml";
 import { TbCopy } from "react-icons/tb";
 import { nanoid } from "nanoid";
 import { useAlert } from "../hooks/use-alert";
@@ -29,7 +28,51 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
     if (!diagramDiv) {
       return;
     }
-  });
+
+    // console.log(code);
+    // const nomnomlDiagramId = `nomnoml-diagram-${nanoid().toLowerCase()}`;
+    // console.log(nomnoml.renderSvg(code));
+    try {
+      const fetchNomnoml = async () => {
+        const nomnoml = await import("nomnoml");
+        console.log("code", code);
+        console.log("type of code", typeof code);
+        const svg = await nomnoml.renderSvg(code);
+        console.log(svg);
+        console.log("type of svg", typeof svg);
+
+        setValue(svg);
+        diagramDiv.innerHTML = svg;
+      };
+      fetchNomnoml();
+    } catch (err) {
+      // setValue(err);
+      console.warn(`Error rendering nomnoml diagram`, err);
+    }
+  }, [diagramRef, code, setValue]);
+
+  return (
+    <Card variant="outline" position="relative" mt={2} minHeight="12em" resize="vertical">
+      <IconButton
+        position="absolute"
+        right={1}
+        top={1}
+        zIndex={50}
+        aria-label="Copy Diagram to Clipboard"
+        title="Copy Diagram to Clipboard"
+        icon={<TbCopy />}
+        color="gray.600"
+        _dark={{ color: "gray.300" }}
+        variant="ghost"
+        onClick={() => handleCopy()}
+        isDisabled={!value}
+      />
+
+      <CardBody p={2}>
+        <div ref={diagramRef} />
+      </CardBody>
+    </Card>
+  );
 };
 
 // Memoize to reduce re-renders/flickering when content hasn't changed

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -45,8 +45,8 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
         diagramDiv.innerHTML = svg;
       };
       fetchNomnoml();
-    } catch (err) {
-      // setValue(err);
+    } catch (err: any) {
+      setValue(err);
       console.warn(`Error rendering nomnoml diagram`, err);
     }
   }, [diagramRef, code, setValue]);

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useRef, type ReactNode } from "react";
 import { Card, CardBody, IconButton, useClipboard } from "@chakra-ui/react";
 import { TbCopy } from "react-icons/tb";
-import { nanoid } from "nanoid";
 import { useAlert } from "../hooks/use-alert";
 
 type NomnomlPreviewProps = {
@@ -29,17 +28,10 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
       return;
     }
 
-    // console.log(code);
-    // const nomnomlDiagramId = `nomnoml-diagram-${nanoid().toLowerCase()}`;
-    // console.log(nomnoml.renderSvg(code));
     try {
       const fetchNomnoml = async () => {
         const nomnoml = await import("nomnoml");
-        console.log("code", code);
-        console.log("type of code", typeof code);
         const svg = await nomnoml.renderSvg(code);
-        console.log(svg);
-        console.log("type of svg", typeof svg);
 
         setValue(svg);
         diagramDiv.innerHTML = svg;

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -42,7 +42,7 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
           svgElement.style.width = "100%";
         }
       } catch (err: any) {
-        // If diagram fails, use error vs. diagram for copying (to debug)
+        // When the diagram fails, use the error vs. diagram for copying (to debug)
         setValue(err);
         console.warn(`Error rendering nomnoml diagram`, err);
       }

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -43,6 +43,12 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
 
         setValue(svg);
         diagramDiv.innerHTML = svg;
+
+        // Adjust the width of the SVG to fit the content
+        const svgElement = diagramDiv.querySelector("svg");
+        if (svgElement) {
+          svgElement.style.width = "100%";
+        }
       };
       fetchNomnoml();
     } catch (err: any) {

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -49,7 +49,7 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
         setValue(err);
 
         // Render custom error message instead of error or blank content
-        const errMessage = `Syntax error in Nomnoml code`;
+        const errMessage = `Error rendering Nomnoml diagram`;
         diagramDiv.innerHTML = errMessage;
         console.warn(`Error rendering nomnoml diagram`, err);
       }

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -30,13 +30,14 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
 
     const fetchNomnoml = async () => {
       try {
+        // Load nomnoml dynamically at runtime if needed
         const nomnoml = await import("nomnoml");
         const svg = await nomnoml.renderSvg(code);
 
         setValue(svg);
         diagramDiv.innerHTML = svg;
 
-        // Adjust the width of the SVG to fit the content
+        // Adjust the width of the SVG to fit the content inside the CardBody
         const svgElement = diagramDiv.querySelector("svg");
         if (svgElement) {
           svgElement.style.width = "100%";

--- a/src/components/NomnomlPreview.tsx
+++ b/src/components/NomnomlPreview.tsx
@@ -35,6 +35,8 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
         const svg = await nomnoml.renderSvg(code);
 
         setValue(svg);
+
+        // Render nomnoml svg if successful
         diagramDiv.innerHTML = svg;
 
         // Adjust the width of the SVG to fit the content inside the CardBody
@@ -45,6 +47,10 @@ const NomnomlPreview = ({ children }: NomnomlPreviewProps) => {
       } catch (err: any) {
         // When the diagram fails, use the error vs. diagram for copying (to debug)
         setValue(err);
+
+        // Render custom error message instead of error or blank content
+        const errMessage = `Syntax error in Nomnoml code`;
+        diagramDiv.innerHTML = errMessage;
         console.warn(`Error rendering nomnoml diagram`, err);
       }
     };

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -8,7 +8,7 @@ I follow these rules when responding:
 - Use GitHub flavored Markdown
 - ALWAYS include the programming language name (js) or type of data (csv) at the start of Markdown code blocks
 - Format ALL lines of code to 80 characters or fewer
-- Use Mermaid diagrams when discussing visual topics
+- Use nomnoml or Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
 - If responding with math markdown, inline or otherwise, I use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 `;

--- a/src/lib/system-prompt.ts
+++ b/src/lib/system-prompt.ts
@@ -8,7 +8,7 @@ I follow these rules when responding:
 - Use GitHub flavored Markdown
 - ALWAYS include the programming language name (js) or type of data (csv) at the start of Markdown code blocks
 - Format ALL lines of code to 80 characters or fewer
-- Use nomnoml or Mermaid diagrams when discussing visual topics
+- Use Nomnoml or Mermaid diagrams when discussing visual topics
 - If using functions, only use the specific functions I have been provided with
 - If responding with math markdown, inline or otherwise, I use KaTeX syntax in math Markdown by enclosing EVERY mathematical expression, equation, variable, and formula with double-dollar signs \`($$)\`, for example: $$O(n\\log n)$$, $$1024 * 1024 = 1048576$$, $$1024^2$$, $$X$$
 `;


### PR DESCRIPTION
This fixes #466 

Summary of Changes
---
This adds Nomnoml rendering support to ChatCraft using [skanaar/nomnoml](https://github.com/skanaar/nomnoml).

This feature was heavily based on [Mermaid rendering support](https://github.com/tarasglek/chatcraft.org/pull/48/files) using [mermaid-js](https://github.com/mermaid-js/mermaid). For example, Nomnoml rendering is handled by [NomnomlPreview.tsx](https://github.com/tarasglek/chatcraft.org/blob/bb7c55737566be0231fdb525ec725bb8b8409680/src/components/NomnomlPreview.tsx) similar to how Mermaid rendering is handled by MermaidPreview.tsx, and similar to mermaid, the rendering is done in Markdown.tsx when a nomnoml code block is detected:
https://github.com/tarasglek/chatcraft.org/blob/bb7c55737566be0231fdb525ec725bb8b8409680/src/components/Markdown.tsx#L108-L115

Differences from Mermaid rendering
---
Although this feature is modelled off of Mermaid rendering, due to the differences between the nomnoml and mermaid-js libraries I had to implement Nomnoml rendering differently:
### No Error Message in the Nomnoml Preview
Whenever mermaidjs fails to render mermaid code, it renders an image in the preview, but
Nomnoml currently does not render an error image, so failed renders are rendered as a blank diagram instead:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/1910007a-fb36-4a8c-9bc1-253a412b7e4b)


### No SVG ID value support
Unlike the [mermaid-js render method](https://github.com/mermaid-js/mermaid/blob/8e95c4db55c10b152e262d6fb271415f86f616d6/packages/mermaid/src/mermaid.ts#L359-L406), nomnoml's [renderSvg method](https://github.com/skanaar/nomnoml/blob/89a1ac4470f27f5f042c156ec53e7a328f27e507/src/nomnoml.ts#L60-L71) does not support an ID parameter, so in NomnomlPreview.tsx an ID value is not generated or assigned to the rendered SVG.

### No config method/no way to directly modify default styling
Nomnoml currently (as of **1.6.2**) **does not** expose a config method like [mermaid.initialize](https://mermaid.js.org/config/usage.html#using-the-mermaidapi-initialize-mermaid-initialize-call).
This means there's currently no way to programatically modify the default styling of nomnoml diagrams.
However, nomnoml has [directives](https://github.com/skanaar/nomnoml?tab=readme-ov-file#directives) that modify styling

#### Alternative Styling Modification
In the future, I see two ways users can reliably indirectly modify the styling:
- The user can update the system prompt with instructions for nomnoml styling
- Within a ChatCraft conversation, the user iteratively ask the LLM to modify the styling

However, both of these methods are heavily dependent on the LLM.
Even GPT-4 seems to [hallucinate on nomnoml syntax](https://issue-466.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/AkWRUWWG5zYmNsg-Z2e9R) when asked to modify styling, unless a [directive example is provided](https://issue-466.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/UW08evlCIutmdi_v1poCZ)