### PR TITLE
/ - Keyboard shortcut to focus on current chat prompt input

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { CgArrowDownO } from "react-icons/cg";
 import { ScrollRestoration } from "react-router-dom";
 
@@ -39,6 +39,7 @@ import { ChatCraftCommandRegistry } from "../lib/commands";
 import ChatHeader from "./ChatHeader";
 import { FreeModelProvider } from "../lib/providers/DefaultProvider/FreeModelProvider";
 import PreferencesModal from "../components/PreferencesModal";
+import { useKeyDownHandler } from "../hooks/use-key-down-handler";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -66,6 +67,26 @@ function ChatBase({ chat }: ChatBaseProps) {
     onOpen: onPrefModalOpen,
     onClose: onPrefModalClose,
   } = useDisclosure();
+
+  // Handle prompt form submission
+  const handleChatInputFocus = (e: FormEvent) => {
+    e.preventDefault();
+  };
+  const handleForwardSlash = useKeyDownHandler<HTMLDivElement>({
+    onForwardSlash: handleChatInputFocus,
+  });
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      // Allow the user to cursor-up to repeat last prompt
+      case "/":
+        console.log(e.key);
+        handleForwardSlash(e);
+        break;
+      default:
+        return;
+    }
+  };
 
   // If we can't load models, it's a bad sign for API connectivity.
   // Show an error so the user is aware.
@@ -361,6 +382,7 @@ function ChatBase({ chat }: ChatBaseProps) {
       transition={"150ms"}
       bgGradient="linear(to-b, white, gray.100)"
       _dark={{ bgGradient: "linear(to-b, gray.600, gray.700)" }}
+      onKeyDown={handleKeyDown}
     >
       <GridItem colSpan={2}>
         {/* Default Provider Alert Banner*/}

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -67,7 +67,7 @@ function ChatBase({ chat }: ChatBaseProps) {
     onClose: onPrefModalClose,
   } = useDisclosure();
 
-  // Handle prompt form submission
+  // Set focus on Prompt Input text area
   const handleChatInputFocus = useCallback((e: KeyboardEvent) => {
     e.preventDefault();
     inputPromptRef.current?.focus();
@@ -84,9 +84,8 @@ function ChatBase({ chat }: ChatBaseProps) {
         return;
       }
       switch (e.key) {
-        // '/' Shortcut to focus on Prompt Input
+        // '/' Shortcut to focus on Prompt Input text area
         case "/":
-          console.log(e.key);
           handleChatInputFocus(e);
           break;
         default:

--- a/src/hooks/use-key-down-handler.ts
+++ b/src/hooks/use-key-down-handler.ts
@@ -4,14 +4,9 @@ import { isMac, isWindows } from "../lib/utils";
 type KeyboardEventHandlers<T> = {
   onMetaEnter?: (e: KeyboardEvent<T>) => void;
   onEscape?: (e: KeyboardEvent<T>) => void;
-  onForwardSlash?: (e: KeyboardEvent<T>) => void;
 };
 
-export function useKeyDownHandler<T>({
-  onMetaEnter,
-  onEscape,
-  onForwardSlash,
-}: KeyboardEventHandlers<T>) {
+export function useKeyDownHandler<T>({ onMetaEnter, onEscape }: KeyboardEventHandlers<T>) {
   return useCallback(
     (e: KeyboardEvent<T>) => {
       if (
@@ -24,10 +19,7 @@ export function useKeyDownHandler<T>({
       if (onEscape && e.key === "Escape") {
         onEscape(e);
       }
-      if (onForwardSlash && e.key === "/") {
-        onForwardSlash(e);
-      }
     },
-    [onMetaEnter, onEscape, onForwardSlash]
+    [onMetaEnter, onEscape]
   );
 }

--- a/src/hooks/use-key-down-handler.ts
+++ b/src/hooks/use-key-down-handler.ts
@@ -4,9 +4,14 @@ import { isMac, isWindows } from "../lib/utils";
 type KeyboardEventHandlers<T> = {
   onMetaEnter?: (e: KeyboardEvent<T>) => void;
   onEscape?: (e: KeyboardEvent<T>) => void;
+  onForwardSlash?: (e: KeyboardEvent<T>) => void;
 };
 
-export function useKeyDownHandler<T>({ onMetaEnter, onEscape }: KeyboardEventHandlers<T>) {
+export function useKeyDownHandler<T>({
+  onMetaEnter,
+  onEscape,
+  onForwardSlash,
+}: KeyboardEventHandlers<T>) {
   return useCallback(
     (e: KeyboardEvent<T>) => {
       if (
@@ -19,7 +24,10 @@ export function useKeyDownHandler<T>({ onMetaEnter, onEscape }: KeyboardEventHan
       if (onEscape && e.key === "Escape") {
         onEscape(e);
       }
+      if (onForwardSlash && e.key === "/") {
+        onForwardSlash(e);
+      }
     },
-    [onMetaEnter, onEscape]
+    [onMetaEnter, onEscape, onForwardSlash]
   );
 }


### PR DESCRIPTION
This fixes #511 

Summary of Changes
---
This adds a `/` shortcut that sets focus on the current Chat prompt entry.
This adds two methods to the ChatBase component:
`handleChatInputFocus()` - sets focus on Chat prompt entry
`handleForwardSlash` - useEffect that listens for '/' key entry when user is not focused on a text input box

I initially tried to do this by extending [useKeyDownHandler](https://github.com/tarasglek/chatcraft.org/blob/9208edb962839a3cce0524efc4e36beb6fedf652/src/hooks/use-key-down-handler.ts) with a method to handle forward slashes and adding a **useKeyDownHandler** instance to the ChatBase component, but the listener would only trigger when inside a text area (like the search bar or chat prompt entry).

If there's a better way to implement this please let me know.