### PR TITLE
Vite Config: Explicitly provide null navigateFallback url

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -75,6 +75,9 @@ export default defineConfig({
           "**/assets/*.{js,json,css,ico,png,svg}",
           ...buildLanguageGlobPatterns("**/assets/"),
         ],
+        // Don't fallback on document based (e.g. `/some-page`) requests
+        // Even though this says `null` by default, I had to set this specifically to `null` to make it work
+        navigateFallback: null,
       },
     }),
   ],


### PR DESCRIPTION
This fixes #528 

I copied the code for this fix from this [comment](https://github.com/vite-pwa/vite-plugin-pwa/issues/120#issuecomment-1202579983) which gets rid of the non-precached-url error.

I don't think this will have any unforeseen consequences, as the `navigateFallback` parameter [was ostensibly already null](https://github.com/vite-pwa/vite-plugin-pwa/blob/4abcd5462f7ce030c7418303ba5bc6d5dd5b2634/docs/guide/development.md?plain=1#L69-L75):

![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/fe5ea780-08a6-426a-aba7-8b52ea47d3bd)

But I'd like additional opinions.