### PR TITLE
Support size settings in the image command

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -419,7 +419,7 @@ export async function isGenerateImageSupported() {
   );
 }
 
-type dalle3ImageSize = "1024x1024" | "1792x1024" | "1024x1792";
+export type dalle3ImageSize = "1024x1024" | "1792x1024" | "1024x1792";
 
 export const generateImage = async (
   prompt: string,

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -2,6 +2,7 @@ import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
 import { generateImage, isGenerateImageSupported } from "../../lib/ai";
+import type { dalle3ImageSize } from "../../lib/ai";
 
 export class ImageCommand extends ChatCraftCommand {
   constructor() {
@@ -15,12 +16,26 @@ export class ImageCommand extends ChatCraftCommand {
     if (!(args && args[0])) {
       throw new Error("must include a prompt");
     }
-    const prompt = args.join(" ");
+
+    const regexLandscape = /@(landscape|1792x1024)/g;
+    const regexPortrait = /@(portrait|1024x1792)/g;
+
+    let prompt = args.join(" ");
+    let size: dalle3ImageSize = "1024x1024";
+    if (regexLandscape.test(prompt)) {
+      size = "1792x1024";
+    } else if (regexPortrait.test(prompt)) {
+      size = "1024x1792";
+    }
+
+    prompt = prompt.replace(regexLandscape, "").replace(regexPortrait, "");
+
     let imageUrls: string[] = [];
     const text = `(DALL·E 3 result of the prompt: ${prompt})`;
 
     try {
-      imageUrls = await generateImage(prompt);
+      //TODO, refactor to object calling like generateImage(prompt, {size});
+      imageUrls = await generateImage(prompt, 1, size);
     } catch (error: any) {
       console.error(`Failed to generate image: ${error.message}`);
       throw new Error(`Failed to generate image: ${error.message}`);


### PR DESCRIPTION
Using regex to find matched size options which staring with `@`
  
Examples:

`/image @landscape dog`
`/image dog @portrait`
`/image dog @1792x1024`
`/image @1024x1792 dog`

Fixes #499 