### PR TITLE
Open preview images in a new tab on click

### DIFF
--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -7,6 +7,7 @@ import {
   ModalBody,
   Image,
   Flex,
+  Link,
 } from "@chakra-ui/react";
 
 interface ImageModalProps {
@@ -22,15 +23,17 @@ const ImageModal: React.FC<ImageModalProps> = ({ isOpen, onClose, imageSrc }) =>
       <ModalCloseButton />
       <ModalBody>
         <Flex height={"100%"} justifyContent={"center"} alignItems={"center"}>
-          <Image
-            maxWidth="100%"
-            maxHeight="70vh"
-            overflow={"auto"}
-            src={imageSrc}
-            alt="Selected Image"
-            m="auto"
-            objectFit="contain"
-          />
+          <Link href={imageSrc} isExternal>
+            <Image
+              maxWidth="100%"
+              maxHeight="70vh"
+              overflow={"auto"}
+              src={imageSrc}
+              alt="Selected Image"
+              m="auto"
+              objectFit="contain"
+            />
+          </Link>
         </Flex>
       </ModalBody>
     </ModalContent>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -616,6 +616,7 @@ function MessageBase({
                         alt={`Images# ${index}`}
                         margin={"auto"}
                         maxWidth={"100%"}
+                        cursor={"pointer"}
                         onClick={() => openModalWithImage(imageUrl)}
                       />
                     </Box>


### PR DESCRIPTION
This is a follow up to @mingming-ma's PR #493 where he added support for Dalle image generation

I have:

1. Changed the hover cursor to **pointer** for images in `MessageBase`.
2. Wrapped image in preview modal in a link so they are opened in a new tab on click for better preview

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/4ceed531-2334-47ab-b93d-476437e7e908)

**On Click:**
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/fc4806e1-4018-4a46-8d09-01de54a5148d)


This fixes #505 