### PR TITLE
Add the Providers selection Menu Group to easy switch between providers

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,7 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll": "explicit"
+    "source.fixAll": true
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -38,7 +38,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
 
   return (
     <ButtonGroup variant="outline" isAttached>
-      <Menu placement="top" strategy="fixed" offset={[-90, 0]}>
+      <Menu placement="top" strategy="fixed" closeOnSelect={false} offset={[-90, 0]}>
         <IconButton
           type="submit"
           size="lg"
@@ -102,7 +102,11 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
             {models
               .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
               .map((model) => (
-                <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                <MenuItem
+                  closeOnSelect={true}
+                  key={model.id}
+                  onClick={() => setSettings({ ...settings, model })}
+                >
                   {model.prettyModel}
                 </MenuItem>
               ))}
@@ -185,7 +189,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </Button>
         </Tooltip>
       )}
-      <Menu placement="top" strategy="fixed">
+      <Menu placement="top" strategy="fixed" closeOnSelect={false}>
         <MenuButton
           as={IconButton}
           size="sm"
@@ -198,7 +202,11 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
             {models
               .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
               .map((model) => (
-                <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                <MenuItem
+                  closeOnSelect={true}
+                  key={model.id}
+                  onClick={() => setSettings({ ...settings, model })}
+                >
                   {model.prettyModel}
                 </MenuItem>
               ))}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -11,7 +11,6 @@ import {
   MenuGroup,
 } from "@chakra-ui/react";
 import { TbChevronUp, TbSend } from "react-icons/tb";
-import { FREEMODELPROVIDER_API_URL } from "../../lib/ChatCraftProvider";
 import { FreeModelProvider } from "../../lib/providers/DefaultProvider/FreeModelProvider";
 
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
@@ -21,7 +20,7 @@ import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { useMemo } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
-import { providerFromJSON, usingOfficialOpenAI } from "../../lib/providers";
+import { usingOfficialOpenAI } from "../../lib/providers";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -108,25 +107,26 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
                 </MenuItem>
               ))}
           </MenuGroup>
+          <MenuDivider />
           <MenuGroup title="Providers">
-            {Object.values({
+            {Object.entries({
               ...settings.providers,
-              [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
-            }).map((provider) => (
+              "Free AI Models": "Free AI Models",
+            }).map(([providerName]) => (
               <MenuItem
-                key={provider.apiUrl}
+                key={providerName}
                 onClick={() => {
-                  const newProvider = providerFromJSON({
-                    id: provider.id,
-                    name: provider.name,
-                    apiUrl: provider.apiUrl,
-                    apiKey: provider.apiKey,
-                  });
+                  const isFreeModel = providerName === "Free AI Models";
+                  const newProvider = isFreeModel
+                    ? new FreeModelProvider()
+                    : settings.providers[providerName];
                   setSettings({ ...settings, currentProvider: newProvider });
                 }}
               >
-                {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️ " : ""}
-                {provider.name}
+                <span style={{ width: "1em", display: "inline-block", textAlign: "center" }}>
+                  {settings.currentProvider.name === providerName ? "✔️" : ""}
+                </span>
+                {providerName}
               </MenuItem>
             ))}
           </MenuGroup>
@@ -203,26 +203,24 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuDivider />
           <MenuGroup title="Providers">
-            {Object.values({
+            {Object.entries({
               ...settings.providers,
-              [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
-            }).map((provider) => (
+              "Free AI Models": "Free AI Models",
+            }).map(([providerName]) => (
               <MenuItem
-                key={provider.apiUrl}
+                key={providerName}
                 onClick={() => {
-                  const newProvider = providerFromJSON({
-                    id: provider.id,
-                    name: provider.name,
-                    apiUrl: provider.apiUrl,
-                    apiKey: provider.apiKey,
-                  });
+                  const isFreeModel = providerName === "Free AI Models";
+                  const newProvider = isFreeModel
+                    ? new FreeModelProvider()
+                    : settings.providers[providerName];
                   setSettings({ ...settings, currentProvider: newProvider });
                 }}
               >
                 <span style={{ width: "1em", display: "inline-block", textAlign: "center" }}>
-                  {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️" : ""}
+                  {settings.currentProvider.name === providerName ? "✔️" : ""}
                 </span>
-                {provider.name}
+                {providerName}
               </MenuItem>
             ))}
           </MenuGroup>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -7,6 +7,8 @@ import {
   MenuList,
   MenuItem,
   Tooltip,
+  MenuDivider,
+  MenuGroup,
 } from "@chakra-ui/react";
 import { TbChevronUp, TbSend } from "react-icons/tb";
 
@@ -17,7 +19,7 @@ import theme from "../../theme";
 import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
 import { useMemo } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
-import { usingOfficialOpenAI } from "../../lib/providers";
+import { providerFromJSON, usingOfficialOpenAI } from "../../lib/providers";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -111,7 +113,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
 function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
-
+  const supportedProviders = settings.providers;
   const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
   }, [models]);
@@ -165,13 +167,35 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
-          {models
-            .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
-            .map((model) => (
-              <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
-                {model.prettyModel}
+          <MenuGroup title="Models">
+            {models
+              .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+              .map((model) => (
+                <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                  {model.prettyModel}
+                </MenuItem>
+              ))}
+          </MenuGroup>
+          <MenuDivider />
+          <MenuGroup title="Providers">
+            {Object.values(supportedProviders).map((provider) => (
+              <MenuItem
+                key={provider.apiUrl}
+                onClick={() => {
+                  const newProvider = providerFromJSON({
+                    id: provider.id,
+                    name: provider.name,
+                    apiUrl: provider.apiUrl,
+                    apiKey: provider.apiKey,
+                  });
+                  setSettings({ ...settings, currentProvider: newProvider });
+                }}
+              >
+                {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️ " : ""}
+                {provider.name}
               </MenuItem>
             ))}
+          </MenuGroup>
         </MenuList>
       </Menu>
     </ButtonGroup>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -30,6 +30,7 @@ type PromptSendButtonProps = {
 function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
+  const supportedProviders = settings.providers;
 
   const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
@@ -99,13 +100,37 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
-          {models
-            .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
-            .map((model) => (
-              <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
-                {model.prettyModel}
+          <MenuGroup title="Models">
+            {models
+              .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+              .map((model) => (
+                <MenuItem key={model.id} onClick={() => setSettings({ ...settings, model })}>
+                  {model.prettyModel}
+                </MenuItem>
+              ))}
+          </MenuGroup>
+          <MenuGroup title="Providers">
+            {Object.values({
+              ...supportedProviders,
+              [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
+            }).map((provider) => (
+              <MenuItem
+                key={provider.apiUrl}
+                onClick={() => {
+                  const newProvider = providerFromJSON({
+                    id: provider.id,
+                    name: provider.name,
+                    apiUrl: provider.apiUrl,
+                    apiKey: provider.apiKey,
+                  });
+                  setSettings({ ...settings, currentProvider: newProvider });
+                }}
+              >
+                {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️ " : ""}
+                {provider.name}
               </MenuItem>
             ))}
+          </MenuGroup>
         </MenuList>
       </Menu>
     </ButtonGroup>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -17,7 +17,7 @@ import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
-import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
+import { MdVolumeUp, MdVolumeOff, MdOutlineChevronRight } from "react-icons/md";
 import { useMemo } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import { usingOfficialOpenAI } from "../../lib/providers";
@@ -123,9 +123,11 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
                   setSettings({ ...settings, currentProvider: newProvider });
                 }}
               >
-                <span style={{ width: "1em", display: "inline-block", textAlign: "center" }}>
-                  {settings.currentProvider.name === providerName ? "✔️" : ""}
-                </span>
+                {settings.currentProvider.name === providerName ? (
+                  <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                ) : (
+                  <span style={{ width: "24px", display: "inline-block" }} />
+                )}
                 {providerName}
               </MenuItem>
             ))}
@@ -217,9 +219,11 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
                   setSettings({ ...settings, currentProvider: newProvider });
                 }}
               >
-                <span style={{ width: "1em", display: "inline-block", textAlign: "center" }}>
-                  {settings.currentProvider.name === providerName ? "✔️" : ""}
-                </span>
+                {settings.currentProvider.name === providerName ? (
+                  <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                ) : (
+                  <span style={{ width: "24px", display: "inline-block" }} />
+                )}
                 {providerName}
               </MenuItem>
             ))}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -36,6 +36,11 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
 
   const { clearAudioQueue } = useAudioPlayer();
 
+  const providersList = {
+    ...settings.providers,
+    "Free AI Models": new FreeModelProvider(),
+  };
+
   return (
     <ButtonGroup variant="outline" isAttached>
       <Menu placement="top" strategy="fixed" closeOnSelect={false} offset={[-90, 0]}>
@@ -113,18 +118,11 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuDivider />
           <MenuGroup title="Providers">
-            {Object.entries({
-              ...settings.providers,
-              "Free AI Models": "Free AI Models",
-            }).map(([providerName]) => (
+            {Object.entries(providersList).map(([providerName, providerObject]) => (
               <MenuItem
                 key={providerName}
                 onClick={() => {
-                  const isFreeModel = providerName === "Free AI Models";
-                  const newProvider = isFreeModel
-                    ? new FreeModelProvider()
-                    : settings.providers[providerName];
-                  setSettings({ ...settings, currentProvider: newProvider });
+                  setSettings({ ...settings, currentProvider: providerObject });
                 }}
               >
                 {settings.currentProvider.name === providerName ? (
@@ -150,6 +148,11 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   }, [models]);
 
   const { clearAudioQueue } = useAudioPlayer();
+
+  const providersList = {
+    ...settings.providers,
+    "Free AI Models": new FreeModelProvider(),
+  };
 
   return (
     <ButtonGroup isAttached>
@@ -213,18 +216,11 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuDivider />
           <MenuGroup title="Providers">
-            {Object.entries({
-              ...settings.providers,
-              "Free AI Models": "Free AI Models",
-            }).map(([providerName]) => (
+            {Object.entries(providersList).map(([providerName, providerObject]) => (
               <MenuItem
                 key={providerName}
                 onClick={() => {
-                  const isFreeModel = providerName === "Free AI Models";
-                  const newProvider = isFreeModel
-                    ? new FreeModelProvider()
-                    : settings.providers[providerName];
-                  setSettings({ ...settings, currentProvider: newProvider });
+                  setSettings({ ...settings, currentProvider: providerObject });
                 }}
               >
                 {settings.currentProvider.name === providerName ? (

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -30,7 +30,6 @@ type PromptSendButtonProps = {
 function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
-  const supportedProviders = settings.providers;
 
   const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
@@ -111,7 +110,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuGroup title="Providers">
             {Object.values({
-              ...supportedProviders,
+              ...settings.providers,
               [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
             }).map((provider) => (
               <MenuItem
@@ -140,7 +139,6 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
 function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const { settings, setSettings } = useSettings();
   const { models } = useModels();
-  const supportedProviders = settings.providers;
   const isTtsSupported = useMemo(() => {
     return !!models.filter((model) => model.id.includes("tts"))?.length;
   }, [models]);
@@ -206,7 +204,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           <MenuDivider />
           <MenuGroup title="Providers">
             {Object.values({
-              ...supportedProviders,
+              ...settings.providers,
               [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
             }).map((provider) => (
               <MenuItem

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -221,7 +221,9 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
                   setSettings({ ...settings, currentProvider: newProvider });
                 }}
               >
-                {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️ " : ""}
+                <span style={{ width: "1em", display: "inline-block", textAlign: "center" }}>
+                  {settings.currentProvider.apiUrl === provider.apiUrl ? "✔️" : ""}
+                </span>
                 {provider.name}
               </MenuItem>
             ))}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -11,6 +11,8 @@ import {
   MenuGroup,
 } from "@chakra-ui/react";
 import { TbChevronUp, TbSend } from "react-icons/tb";
+import { FREEMODELPROVIDER_API_URL } from "../../lib/ChatCraftProvider";
+import { FreeModelProvider } from "../../lib/providers/DefaultProvider/FreeModelProvider";
 
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
@@ -178,7 +180,10 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuDivider />
           <MenuGroup title="Providers">
-            {Object.values(supportedProviders).map((provider) => (
+            {Object.values({
+              ...supportedProviders,
+              [FREEMODELPROVIDER_API_URL]: new FreeModelProvider(),
+            }).map((provider) => (
               <MenuItem
                 key={provider.apiUrl}
                 onClick={() => {


### PR DESCRIPTION
Closes #510 

Tasks Completed:
- [x] Enable switching between providers from the ask menu for Desktop Prompt
- [x] Enable switching between providers from the ask menu for Mobile Prompt
- [x] Use MenuGroup from Chakra UI to group models and providers distinctly

Files Changed:
PromptForm.tsx

Screenshots:
<img width="809" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/58596563/1f4a411b-1876-4df5-8c98-a9daee82bbbe">
