### PR TITLE
Migration fix for settings.providers

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -13,11 +13,12 @@ import {
 
 import MessageBase, { type MessageBaseProps } from "../MessageBase";
 import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
-import { providerFromUrl, providerFromJSON, getSupportedProviders } from "../../../lib/providers";
+import { providerFromUrl, getSupportedProviders } from "../../../lib/providers";
 import { OpenRouterProvider } from "../../../lib/providers/OpenRouterProvider";
 import RevealablePasswordInput from "../../RevealablePasswordInput";
 import { useSettings } from "../../../hooks/use-settings";
 import { FreeModelProvider } from "../../../lib/providers/DefaultProvider/FreeModelProvider";
+import { nameToUrlMap } from "../../../lib/ChatCraftProvider";
 
 const ApiKeyInstructionsText = `## Getting Started with ChatCraft
 
@@ -92,7 +93,7 @@ function Instructions(props: MessageBaseProps) {
               currentProvider: newProvider,
               providers: {
                 ...settings.providers,
-                [newProvider.apiUrl]: newProvider,
+                [newProvider.name]: newProvider,
               },
             });
           } else {
@@ -109,10 +110,12 @@ function Instructions(props: MessageBaseProps) {
 
   const handleProviderChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
+      const apiUrl = nameToUrlMap[e.target.value];
+
       // Get stored data from settings.providers array if exists
       const newProvider = settings.providers[e.target.value]
-        ? providerFromJSON(settings.providers[e.target.value])
-        : providerFromUrl(e.target.value);
+        ? settings.providers[e.target.value]
+        : providerFromUrl(apiUrl);
 
       if (newProvider instanceof FreeModelProvider) {
         // If user chooses the free provider, set the key automatically
@@ -141,9 +144,9 @@ function Instructions(props: MessageBaseProps) {
             <FormControl>
               <FormLabel>Provider API URL</FormLabel>
 
-              <Select value={settings.currentProvider.apiUrl} onChange={handleProviderChange}>
+              <Select value={settings.currentProvider.name} onChange={handleProviderChange}>
                 {Object.values(supportedProviders).map((provider) => (
-                  <option key={provider.apiUrl} value={provider.apiUrl}>
+                  <option key={provider.name} value={provider.name}>
                     {provider.name} ({provider.apiUrl})
                   </option>
                 ))}

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -15,7 +15,6 @@ import {
   isTtsSupported,
   textToSpeech,
 } from "../lib/ai";
-import { getSettings } from "../lib/settings";
 import { tokenize } from "../lib/summarize";
 import useAudioPlayer from "./use-audio-player";
 import { useAutoScroll } from "./use-autoscroll";
@@ -95,7 +94,7 @@ function useChatOpenAI() {
 
               const { sentences } = tokenize(ttsWordsBuffer);
 
-              if (ttsSupported && getSettings().textToSpeech.announceMessages) {
+              if (ttsSupported && settings.textToSpeech.announceMessages) {
                 if (
                   sentences.length > 1 // Has one full sentence
                 ) {
@@ -170,11 +169,7 @@ function useChatOpenAI() {
           resetScrollProgress();
           setShouldAutoScroll(false);
 
-          if (
-            ttsSupported &&
-            getSettings().textToSpeech.announceMessages &&
-            ttsWordsBuffer.length
-          ) {
+          if (ttsSupported && settings.textToSpeech.announceMessages && ttsWordsBuffer.length) {
             try {
               // Call TTS for any remaining words
               const audioClipUri = textToSpeech(ttsWordsBuffer, settings.textToSpeech.voice);
@@ -188,6 +183,7 @@ function useChatOpenAI() {
     },
     [
       settings.model,
+      settings.textToSpeech.announceMessages,
       settings.textToSpeech.voice,
       settings.countTokens,
       setShouldAutoScroll,

--- a/src/hooks/use-settings.tsx
+++ b/src/hooks/use-settings.tsx
@@ -59,7 +59,7 @@ export const SettingsProvider: FC<{ children: ReactNode }> = ({ children }) => {
               currentProvider: newProvider,
               providers: {
                 ...state.providers,
-                [newProvider.apiUrl]: newProvider,
+                [newProvider.name]: newProvider,
               },
             });
             // Strip out openRouter's code from the URL

--- a/src/lib/ChatCraftProvider.ts
+++ b/src/lib/ChatCraftProvider.ts
@@ -8,6 +8,12 @@ export const OPENAI_API_URL = "https://api.openai.com/v1";
 export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
 export const FREEMODELPROVIDER_API_URL = "https://free-chatcraft-ai.deno.dev/api/v1";
 
+export const nameToUrlMap: { [key: string]: string } = {
+  ["OpenAI"]: OPENAI_API_URL,
+  ["OpenRouter.ai"]: OPENROUTER_API_URL,
+  ["Free AI Models"]: FREEMODELPROVIDER_API_URL,
+};
+
 const urlToNameMap: { [key: string]: ProviderName } = {
   [OPENAI_API_URL]: "OpenAI",
   [OPENROUTER_API_URL]: "OpenRouter.ai",

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -89,14 +89,15 @@ export const transcribe = async (audio: File) => {
 };
 
 export const chatWithLLM = (messages: ChatCraftMessage[], options: ChatOptions = {}) => {
+  const settings = getSettings();
   const {
     onData,
     onFinish,
     onPause,
     onResume,
     onError,
-    temperature = getSettings().temperature,
-    model = getSettings().model,
+    temperature = settings.temperature,
+    model = settings.model,
     functions,
     functionToCall,
   } = options;
@@ -218,15 +219,16 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
     throw new Error(`OpenAI API Returned Error: ${error.message}`);
   };
 
-  const { currentProvider } = getSettings();
-  if (!currentProvider.apiKey) {
+  if (!settings.currentProvider.apiKey) {
     throw new Error("Missing API Key");
   }
 
-  const { openai, headers } = currentProvider.createClient(currentProvider.apiKey);
+  const { openai, headers } = settings.currentProvider.createClient(
+    settings.currentProvider.apiKey
+  );
 
   const chatCompletionParams: OpenAI.Chat.ChatCompletionCreateParams = {
-    model: model ? model.id : getSettings().model.id,
+    model: model ? model.id : settings.model.id,
     temperature: Math.min(Math.max(temperature ?? 0, 0.0), 2.0),
 
     /**

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -61,8 +61,8 @@ export const getSupportedProviders = (): ProviderData => {
   const freeModel = new FreeModelProvider();
 
   return {
-    [openAi.apiUrl]: openAi,
-    [openRouter.apiUrl]: openRouter,
-    [freeModel.apiUrl]: freeModel,
+    [openAi.name]: openAi,
+    [openRouter.name]: openRouter,
+    [freeModel.name]: freeModel,
   };
 };


### PR DESCRIPTION
Closes #536

### Code changes:

#### Part 1 - Changing settings.providers to use name as the key

Files:
[`src/components/Message/AppMessage/Instructions.tsx`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-9fcdb80f3814fd658a3bb7dcaf58478d27938a43cde9049d449210652e77434c)
[`src/components/PreferencesModal.tsx`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-1025748a16e04005898c20c05840616be48ca0eb4eb4c156248de41a2f3bdd7d)
[`src/lib/settings.ts`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-b5f5521c9795e314efdf6293ad3afda789a1402bbf5e2a304e20efa8134d2a15)

#### Part 2 - Deserializing settings.providers in [`settings.ts`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-b5f5521c9795e314efdf6293ad3afda789a1402bbf5e2a304e20efa8134d2a15)

To test this you can set your settings json to the following (replace YOUR_OPENAI_KEY with your key). Using my json you start with two openai providers and two openrouter providers and after navigating to or refreshing chatcraft the deserializer will change it to having two.

```
{"model":"openai/gpt-3.5-turbo","temperature":0,"enterBehaviour":"send","countTokens":false,"sidebarVisible":false,"alwaysSendFunctionResult":false,"textToSpeech":{"announceMessages":false,"voice":"alloy"},"providers":{"OpenAI":{"id":"Jnc3KkY4--dQm7KwMWy7Y","name":"OpenAI","apiUrl":"https://api.openai.com/v1","apiKey":"aaaaaaaa"},"OpenRouter.ai":{"id":"XG_lpq_xG-nMIbD1ZRCG-","name":"OpenRouter.ai","apiUrl":"https://openrouter.ai/api/v1","apiKey":"bbbbbbbb"},"https://api.openai.com/v1":{"id":"Jnc3KkY4--dQm7KwMWy7Y","name":"OpenAI","apiUrl":"https://api.openai.com/v1","apiKey":"YOUR_OPENAI_KEY"},"https://openrouter.ai/api/v1":{"id":"XG_lpq_xG-nMIbD1ZRCG-","name":"OpenRouter.ai","apiUrl":"https://openrouter.ai/api/v1","apiKey":"YOUR_OPENROUTER_KEY"}},"currentProvider":{"id":"XG_lpq_xG-nMIbD1ZRCG-","name":"OpenRouter.ai","apiUrl":"https://openrouter.ai/api/v1","apiKey":"YOUR_OPENROUTER_KEY"},"compressionFactor":1,"maxCompressedFileSizeMB":20,"maxImageDimension":2048}
```

#### Part 3 - Removing unnecessary calls to `getSettings()` in useEffects to decrease how many times our deserializer runs

As discussed with @Amnish04 already, there are some locations where we can call `getSettings()` a lesser amount of times.
Files: [`src/hooks/use-chat-openai.ts`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-6d071d338ac4fef38a1aff98d7885eb7dcdbfbd07984436fca89685520bd9225), [`src/lib/ai.ts`](https://github.com/tarasglek/chatcraft.org/pull/537/files#diff-1e3019f58d4740d97c73bcc9d005579ec23be1a4ec6d4c25ed3072d742831a95)

---

@Rachit1313 If this PR is merged to main before your [PR#535](https://github.com/tarasglek/chatcraft.org/pull/535), then I need you to merge the code from main into your branch and then modify your code to use the name as the key instead of the apiUrl as the key whenever you access `settings.providers`