### PR TITLE
Hotfix for bug introduced in pr 537

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -79,17 +79,19 @@ export const deserializer = (value: string): Settings => {
   }
 
   // Handle migration of deprecated apiKey, apiUrl
-  if (settings.apiKey && settings.apiUrl) {
-    const newProvider = providerFromUrl(settings.apiUrl, settings.apiKey);
-    settings.currentProvider = newProvider;
-    settings.providers = { ...settings.providers, [newProvider.name]: newProvider };
-    delete settings.apiKey;
-    delete settings.apiUrl;
-    console.warn("Migrated deprecated apiKey, apiUrl");
+  if (settings.currentProvider) {
+    // Handle deserialization of currentProvider
+    settings.currentProvider = providerFromJSON(settings.currentProvider);
+  } else {
+    if (settings.apiKey && settings.apiUrl) {
+      const newProvider = providerFromUrl(settings.apiUrl, settings.apiKey);
+      settings.currentProvider = newProvider;
+      settings.providers = { ...settings.providers, [newProvider.name]: newProvider };
+      delete settings.apiKey;
+      delete settings.apiUrl;
+      console.warn("Migrated deprecated apiKey, apiUrl");
+    }
   }
-
-  // Handle deserialization of currentProvider
-  settings.currentProvider = providerFromJSON(settings.currentProvider);
 
   // Deserialize each provider in settings.providers
   // Also handles migration for past users who have a saved provider, settings.providers[key],

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -78,11 +78,11 @@ export const deserializer = (value: string): Settings => {
     settings.model = new ChatCraftModel(settings.model);
   }
 
-  // Handle migration of deprecated apiKey, apiUrl
   if (settings.currentProvider) {
     // Handle deserialization of currentProvider
     settings.currentProvider = providerFromJSON(settings.currentProvider);
   } else {
+    // Handle migration of deprecated apiKey, apiUrl
     if (settings.apiKey && settings.apiUrl) {
       const newProvider = providerFromUrl(settings.apiUrl, settings.apiKey);
       settings.currentProvider = newProvider;


### PR DESCRIPTION
Accidentally introduced a bug in this morning's merged PR #537 

Took a statement out of an if statement in `settings.ts`, which may cause some users to be unable to load ChatCraft.

The users that are affected are users who have not logged into ChatCraft since last month.
They have a `settings` JSON in their localStorage, but do not have `settings.currentProvider`. (Because the last time they logged in was last month, back before I introduced `settings.currentProvider`)

Also if a user went to localStorage and manually set settings to {}, they would also be affected.

**The code from PR 537 which caused the bug:**

![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/c110c974-83c9-47cb-83b3-19e31c33b8a4)

**Fix**

Restoring the if statement in this hotfix fixes the issue.

**How to test:**

1. Go to localStorage and remove the currentProvider part of the settings json, or just clear the entire settings json and put {}
2. Load ChatCraft
3. Result - (it should have an error in production, but not in this PR's preview)
