### PR TITLE
Fix image generated not available after some time

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -449,9 +449,13 @@ export const generateImage = async ({
       prompt,
       n,
       size,
+      response_format: "b64_json",
     });
 
-    const imageUrls = response.data.map((img: any) => img.url);
+    const imageUrls = response.data.map((item) => {
+      const base64ImageData = item.b64_json;
+      return `data:image/jpeg;base64,${base64ImageData}`;
+    });
     return imageUrls;
   } catch (error: any) {
     throw new Error(error);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -452,10 +452,7 @@ export const generateImage = async ({
       response_format: "b64_json",
     });
 
-    const imageUrls = response.data.map((item) => {
-      const base64ImageData = item.b64_json;
-      return `data:image/jpeg;base64,${base64ImageData}`;
-    });
+    const imageUrls = response.data.map(({ b64_json }) => `data:image/jpeg;base64,${b64_json}`);
     return imageUrls;
   } catch (error: any) {
     throw new Error(error);


### PR DESCRIPTION
## Description
In the DALL·E 3 generations, if response returned as URL, it will expire after [an hour](https://platform.openai.com/docs/guides/images/example-dall-e-3-generations)

This update change the response format to `b64_json` so we can keep the image's Data

Fixes #496 