### PR TITLE
Replace "Cancel Adding Provider" SVG with an IconButton

### DIFF
--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -695,7 +695,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         return (
                           <Tr key={provider.name}>
                             <Td>
-                              <Flex justifyContent={"center"}>
+                              <Flex width={6} justifyContent={"center"}>
                                 <Checkbox
                                   onChange={() => handleSelectedProviderChange(provider)}
                                   isChecked={selectedProvider?.name === provider.name}

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -572,34 +572,36 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                     {newCustomProvider && (
                       <Tr>
                         <Td sx={{ textAlign: "center" }}>
-                          <Box
-                            as={MdCancel}
+                          <IconButton
+                            aria-label="Cancel adding new provider"
+                            icon={<MdCancel />}
+                            size={"xs"}
                             onClick={() => setNewCustomProvider(null)}
                             onKeyDown={(e) => {
                               if (e.key === "Enter" || e.key === " ") {
                                 setNewCustomProvider(null);
                               }
                             }}
+                            variant="outline"
                             tabIndex={0}
-                            sx={{
-                              cursor: "pointer",
-                              color: "gray",
-                              fontSize: "16px",
-                              display: "inline-flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                              borderColor: "gray.200",
-                              borderRadius: "50%",
-
-                              _hover: {
-                                borderColor: "gray.400",
-                                color: "gray.400",
-                              },
+                            color={"grey"}
+                            border={"none"}
+                            p={0}
+                            fontSize={16}
+                            borderRadius={"50%"}
+                            _hover={{
+                              borderColor: "gray.400",
+                              color: "gray.400",
+                            }}
+                            _focus={{
                               _focus: {
                                 outline: "none",
                                 boxShadow: "0 0 0 3px rgba(66, 153, 225, 0.6)",
                                 borderColor: "blue.300",
                               },
+                            }}
+                            _active={{
+                              backgroundColor: "none",
                             }}
                           />
                         </Td>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -571,7 +571,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                   <Tbody>
                     {newCustomProvider && (
                       <Tr>
-                        <Td sx={{ textAlign: "center" }}>
+                        <Td>
                           <IconButton
                             aria-label="Cancel adding new provider"
                             icon={<MdCancel />}
@@ -695,10 +695,12 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         return (
                           <Tr key={provider.name}>
                             <Td>
-                              <Checkbox
-                                onChange={() => handleSelectedProviderChange(provider)}
-                                isChecked={selectedProvider?.name === provider.name}
-                              />
+                              <Flex justifyContent={"center"}>
+                                <Checkbox
+                                  onChange={() => handleSelectedProviderChange(provider)}
+                                  isChecked={selectedProvider?.name === provider.name}
+                                />
+                              </Flex>
                             </Td>
                             <Td fontSize="xs">{provider.name}</Td>
                             <Td fontSize="xs">


### PR DESCRIPTION
As discussed in https://github.com/tarasglek/chatcraft.org/pull/530#discussion_r1545481317, we should not use Svg's directly as an alternative of a button since it is semantically incorrect.

https://www.reddit.com/r/webdev/comments/r72zq6/comment/hmwvobm/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button

I tried preserving the look of the button, and was successful for the most part.

**Normal:**
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/8f0b36b5-501d-415b-be13-ed7ceffaab5c)

**Active:**
![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/d4cf2d69-eb47-47c0-8cc1-5d028ab7ef66)


This fixes #551 