### PR TITLE
Fixed logo of FreeModelProvider auto

### DIFF
--- a/src/components/ModelAvatar.tsx
+++ b/src/components/ModelAvatar.tsx
@@ -12,7 +12,8 @@ export default function ModelAvatar({ model, size }: { model: ChatCraftModel; si
   if (id.includes("gpt-3.5-turbo")) {
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
-  if (id.includes("free")) {
+  // FreeModelProvider models
+  if (id.includes("free") || id === "auto") {
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
 


### PR DESCRIPTION
This PR fixes a logo bug.
![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/a187e797-f058-442b-8bdf-101fce4fd4b6)

**Bug:** FreeModelProvider's model, "auto", shows white logo

**Reason for bug:** In `ModelAvatar.tsx`, I was setting all models with the word "free" in them with the default green bg colour, but this misses the model that is called "auto" which does not have the word free in it. The logo itself is white which means white on a white bg shows us a white logo.

**Fix:** 

In `ModelAvatar.tsx`, add the check for the "auto" model and and give it the green bg.

**Testing:**

No longer showing the white logo.
![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/c20c64b1-faf6-4f14-8450-ac0393178469)
