### PR TITLE
Configure CodeMirror editor for Web Handlers configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@antonz/runno": "^0.6.1",
     "@chakra-ui/react": "^2.8.2",
     "@codemirror/lang-javascript": "^6.2.1",
+    "@codemirror/lang-yaml": "^6.0.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@szhsin/react-menu": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@codemirror/lang-javascript':
     specifier: ^6.2.1
     version: 6.2.1
+  '@codemirror/lang-yaml':
+    specifier: ^6.0.0
+    version: 6.0.0(@codemirror/view@6.21.3)
   '@emotion/react':
     specifier: ^11.11.3
     version: 11.11.3(@types/react@18.2.55)(react@18.2.0)
@@ -2626,6 +2629,20 @@ packages:
       '@lezer/common': 1.1.0
     dev: false
 
+  /@codemirror/autocomplete@6.10.2(@codemirror/language@6.9.1)(@codemirror/state@6.3.1)(@codemirror/view@6.21.3)(@lezer/common@1.2.1):
+    resolution: {integrity: sha512-3dCL7b0j2GdtZzWN5j7HDpRAJ26ip07R4NGYz7QYthIYMiX8I4E4TNrYcdTayPJGeVQtd/xe7lWU4XL7THFb/w==}
+    peerDependencies:
+      '@codemirror/language': ^6.0.0
+      '@codemirror/state': ^6.0.0
+      '@codemirror/view': ^6.0.0
+      '@lezer/common': ^1.0.0
+    dependencies:
+      '@codemirror/language': 6.9.1
+      '@codemirror/state': 6.3.1
+      '@codemirror/view': 6.21.3
+      '@lezer/common': 1.2.1
+    dev: false
+
   /@codemirror/commands@6.3.0:
     resolution: {integrity: sha512-tFfcxRIlOWiQDFhjBSWJ10MxcvbCIsRr6V64SgrcaY0MwNk32cUOcCuNlWo8VjV4qRQCgNgUAnIeo0svkk4R5Q==}
     dependencies:
@@ -2647,13 +2664,25 @@ packages:
       '@lezer/javascript': 1.4.8
     dev: false
 
+  /@codemirror/lang-yaml@6.0.0(@codemirror/view@6.21.3):
+    resolution: {integrity: sha512-fVPapdX1oYr5HMC5bou1MHscGnNCvOHuhUW6C+V2gfIeIRcughvVfznV0OuUyHy0AdXoBCjOehjzFcmLRumu2Q==}
+    dependencies:
+      '@codemirror/autocomplete': 6.10.2(@codemirror/language@6.9.1)(@codemirror/state@6.3.1)(@codemirror/view@6.21.3)(@lezer/common@1.2.1)
+      '@codemirror/language': 6.9.1
+      '@codemirror/state': 6.3.1
+      '@lezer/common': 1.2.1
+      '@lezer/yaml': 1.0.2
+    transitivePeerDependencies:
+      - '@codemirror/view'
+    dev: false
+
   /@codemirror/language@6.9.1:
     resolution: {integrity: sha512-lWRP3Y9IUdOms6DXuBpoWwjkR7yRmnS0hKYCbSfPz9v6Em1A1UCRujAkDiCrdYfs1Z0Eu4dGtwovNPStIfkgNA==}
     dependencies:
       '@codemirror/state': 6.3.1
       '@codemirror/view': 6.21.3
-      '@lezer/common': 1.1.0
-      '@lezer/highlight': 1.1.6
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
       '@lezer/lr': 1.3.13
       style-mod: 4.1.0
     dev: false
@@ -2684,7 +2713,7 @@ packages:
       '@codemirror/language': 6.9.1
       '@codemirror/state': 6.3.1
       '@codemirror/view': 6.21.3
-      '@lezer/highlight': 1.1.6
+      '@lezer/highlight': 1.2.0
     dev: false
 
   /@codemirror/view@6.21.3:
@@ -3385,10 +3414,20 @@ packages:
     resolution: {integrity: sha512-XPIN3cYDXsoJI/oDWoR2tD++juVrhgIago9xyKhZ7IhGlzdDM9QgC8D8saKNCz5pindGcznFr2HBSsEQSWnSjw==}
     dev: false
 
+  /@lezer/common@1.2.1:
+    resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
+    dev: false
+
   /@lezer/highlight@1.1.6:
     resolution: {integrity: sha512-cmSJYa2us+r3SePpRCjN5ymCqCPv+zyXmDl0ciWtVaNiORT/MxM7ZgOMQZADD0o51qOaOg24qc/zBViOIwAjJg==}
     dependencies:
-      '@lezer/common': 1.1.0
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@lezer/highlight@1.2.0:
+    resolution: {integrity: sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==}
+    dependencies:
+      '@lezer/common': 1.2.1
     dev: false
 
   /@lezer/javascript@1.4.8:
@@ -3401,7 +3440,21 @@ packages:
   /@lezer/lr@1.3.13:
     resolution: {integrity: sha512-RLAbau/4uSzKgIKj96mI5WUtG1qtiR0Frn0Ei9zhPj8YOkHM+1Bb8SgdVvmR/aWJCFIzjo2KFnDiRZ75Xf5NdQ==}
     dependencies:
-      '@lezer/common': 1.1.0
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@lezer/lr@1.4.0:
+    resolution: {integrity: sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==}
+    dependencies:
+      '@lezer/common': 1.2.1
+    dev: false
+
+  /@lezer/yaml@1.0.2:
+    resolution: {integrity: sha512-XCkwuxe+eumJ28nA9e1S6XKsXz9W7V/AG+WBiWOtiIuUpKcZ/bHuvN8bLxSDREIcybSRpEd/jvphh4vgm6Ed2g==}
+    dependencies:
+      '@lezer/common': 1.2.1
+      '@lezer/highlight': 1.2.0
+      '@lezer/lr': 1.4.0
     dev: false
 
   /@miniflare/cache@2.14.2:
@@ -10846,7 +10899,6 @@ packages:
 
   /workbox-google-analytics@7.0.0:
     resolution: {integrity: sha512-MEYM1JTn/qiC3DbpvP2BVhyIH+dV/5BjHk756u9VbwuAhu0QHyKscTnisQuz21lfRpOwiS9z4XdqeVAKol0bzg==}
-    deprecated: It is not compatible with newer versions of GA starting with v4, as long as you are using GAv3 it should be ok, but the package is not longer being maintained
     dependencies:
       workbox-background-sync: 7.0.0
       workbox-core: 7.0.0

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -1,9 +1,6 @@
 import {
   Box,
   Button,
-  Flex,
-  FormControl,
-  FormLabel,
   Heading,
   Modal,
   ModalBody,
@@ -12,7 +9,6 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
-  Switch,
   Text,
   VStack,
   useColorMode,
@@ -29,7 +25,6 @@ import CodeHeader from "./CodeHeader";
 
 import { yaml } from "@codemirror/lang-yaml";
 import { MdSignalCellularAlt } from "react-icons/md";
-import { useSettings } from "../hooks/use-settings";
 import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 
 type WebHandlersConfigModalProps = {
@@ -41,11 +36,9 @@ type WebHandlersConfigModalProps = {
 function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersConfigModalProps) {
   const { webHandlers, registerHandlers } = useWebHandlers();
   const { success, error } = useAlert();
-  const { settings, setSettings } = useSettings();
 
-  const getWebHandlersYaml = useCallback(
-    (webHandlers: WebHandlers) => {
-      const onBoardingInstructions = `##############################################################################
+  const getWebHandlersYaml = useCallback((webHandlers: WebHandlers) => {
+    const onBoardingInstructions = `##############################################################################
 ## You can configure "match patterns" for certain types
 ## of URLs, that send an HTTP request to your
 ## configured "handler url".
@@ -65,12 +58,10 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
 ##                 of your Web Handler definitions.
 ##############################################################################`;
 
-      return `${settings.showWebHandlersInstructions ? `${onBoardingInstructions}\n\n` : ""}${YAML.stringify(
-        webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))
-      )}`;
-    },
-    [settings.showWebHandlersInstructions]
-  );
+    return `${onBoardingInstructions}\n\n${YAML.stringify(
+      webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))
+    )}`;
+  }, []);
 
   const [webHandlerConfig, setWebHandlerConfig] = useState(getWebHandlersYaml(webHandlers));
 
@@ -139,33 +130,10 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
               services, you are at the right place 😎
             </Text>
 
-            <Flex
-              width={"100%"}
-              justifyContent={"space-between"}
-              alignItems={"center"}
-              wrap={"wrap"}
-              gap={2}
-            >
-              <Heading size={"md"} alignSelf={"start"} fontWeight={"normal"} flexGrow={1}>
-                Register Handlers
-              </Heading>
+            <Heading size={"md"} width={"100%"} fontWeight={"normal"}>
+              Register Handlers
+            </Heading>
 
-              <FormControl display="flex" alignItems="center" width={"auto"}>
-                <FormLabel htmlFor="show-instructions-switch" mb="0">
-                  Show Instructions?
-                </FormLabel>
-                <Switch
-                  id="show-instructions-switch"
-                  isChecked={settings.showWebHandlersInstructions}
-                  onChange={() =>
-                    setSettings({
-                      ...settings,
-                      showWebHandlersInstructions: !settings.showWebHandlersInstructions,
-                    })
-                  }
-                />
-              </FormControl>
-            </Flex>
             <Box
               w={"100%"}
               border="1px"

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -29,6 +29,7 @@ import CodeHeader from "./CodeHeader";
 
 import { yaml } from "@codemirror/lang-yaml";
 import { MdSignalCellularAlt } from "react-icons/md";
+import { useSettings } from "../hooks/use-settings";
 
 type WebHandlersConfigModalProps = {
   isOpen: boolean;
@@ -39,7 +40,7 @@ type WebHandlersConfigModalProps = {
 function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersConfigModalProps) {
   const { webHandlers, registerHandlers } = useWebHandlers();
   const { success, error } = useAlert();
-  const [showInstructions, setShowInstructions] = useState(true);
+  const { settings, setSettings } = useSettings();
 
   const getWebHandlersYaml = useCallback(
     (webHandlers: WebHandlers) => {
@@ -63,11 +64,11 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
 ##                 of your Web Handler definitions.
 ##############################################################################`;
 
-      return `${showInstructions ? `${onBoardingInstructions}\n\n` : ""}${YAML.stringify(
+      return `${settings.showWebHandlersInstructions ? `${onBoardingInstructions}\n\n` : ""}${YAML.stringify(
         webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))
       )}`;
     },
-    [showInstructions]
+    [settings.showWebHandlersInstructions]
   );
 
   const [webHandlerConfig, setWebHandlerConfig] = useState(getWebHandlersYaml(webHandlers));
@@ -153,8 +154,13 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
                 </FormLabel>
                 <Switch
                   id="show-instructions-switch"
-                  isChecked={showInstructions}
-                  onChange={() => setShowInstructions((prevValue) => !prevValue)}
+                  isChecked={settings.showWebHandlersInstructions}
+                  onChange={() =>
+                    setSettings({
+                      ...settings,
+                      showWebHandlersInstructions: !settings.showWebHandlersInstructions,
+                    })
+                  }
                 />
               </FormControl>
             </Flex>

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -30,6 +30,7 @@ import CodeHeader from "./CodeHeader";
 import { yaml } from "@codemirror/lang-yaml";
 import { MdSignalCellularAlt } from "react-icons/md";
 import { useSettings } from "../hooks/use-settings";
+import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 
 type WebHandlersConfigModalProps = {
   isOpen: boolean;
@@ -120,6 +121,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
   const configDownloadFilename = "WebHandlersConfig.yaml";
   const { colorMode } = useColorMode();
   const editorHeight = "350px";
+  const isMobile = useMobileBreakpoint();
 
   return (
     <Modal isOpen={isOpen} onClose={onModalClose} size="2xl" finalFocusRef={finalFocusRef}>
@@ -131,7 +133,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
         <ModalCloseButton />
         <ModalBody>
           <VStack gap={4}>
-            <Text>
+            <Text textAlign={isMobile ? "justify" : "start"}>
               {/* eslint-disable-next-line react/no-unescaped-entities */}
               If you want to extend ChatCraft's functionality by plugging external services your own
               services, you are at the right place 😎

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -126,7 +126,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
           <VStack gap={4}>
             <Text textAlign={isMobile ? "justify" : "start"}>
               {/* eslint-disable-next-line react/no-unescaped-entities */}
-              If you want to extend ChatCraft's functionality by plugging external services your own
+              If you want to extend ChatCraft's default URL handling by adding your own external
               services, you are at the right place 😎
             </Text>
 

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -58,9 +58,14 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
 ##                 of your Web Handler definitions.
 #######################################################################`;
 
+    const sampleWebHandlers = `## Example:
+# - handlerUrl: https://taras-scrape2md.web.val.run/
+#   method: GET
+#   matchPattern: ^https:\\/\\/\\S*$\n`;
+
     return `${onBoardingInstructions}\n\n${YAML.stringify(
       webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))
-    )}`;
+    )}\n${sampleWebHandlers}`;
   }, []);
 
   const [webHandlerConfig, setWebHandlerConfig] = useState(getWebHandlersYaml(webHandlers));

--- a/src/components/WebHandlersConfigModal.tsx
+++ b/src/components/WebHandlersConfigModal.tsx
@@ -38,7 +38,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
   const { success, error } = useAlert();
 
   const getWebHandlersYaml = useCallback((webHandlers: WebHandlers) => {
-    const onBoardingInstructions = `##############################################################################
+    const onBoardingInstructions = `#######################################################################
 ## You can configure "match patterns" for certain types
 ## of URLs, that send an HTTP request to your
 ## configured "handler url".
@@ -56,7 +56,7 @@ function WebHandlersConfigModal({ isOpen, onClose, finalFocusRef }: WebHandlersC
 ##                 if the your prompt text is a match.
 ##                 The match patterns are evaluated in the order
 ##                 of your Web Handler definitions.
-##############################################################################`;
+#######################################################################`;
 
     return `${onBoardingInstructions}\n\n${YAML.stringify(
       webHandlers.map((handler) => ({ ...handler, matchPattern: handler.matchPattern.source }))

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -42,6 +42,7 @@ export type Settings = {
   compressionFactor: number;
   maxCompressedFileSizeMB: number;
   maxImageDimension: number;
+  showWebHandlersInstructions: boolean;
 };
 
 export const defaults: Settings = {
@@ -62,6 +63,7 @@ export const defaults: Settings = {
   compressionFactor: 1,
   maxCompressedFileSizeMB: 20,
   maxImageDimension: 2048,
+  showWebHandlersInstructions: true,
 };
 
 export const key = "settings";

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -42,7 +42,6 @@ export type Settings = {
   compressionFactor: number;
   maxCompressedFileSizeMB: number;
   maxImageDimension: number;
-  showWebHandlersInstructions: boolean;
 };
 
 export const defaults: Settings = {
@@ -63,7 +62,6 @@ export const defaults: Settings = {
   compressionFactor: 1,
   maxCompressedFileSizeMB: 20,
   maxImageDimension: 2048,
-  showWebHandlersInstructions: true,
 };
 
 export const key = "settings";


### PR DESCRIPTION
In this PR, I have:

1. Replaced the [TextArea](https://chakra-ui.com/docs/components/textarea/usage) that was being used to configure **Web Handlers** with [CodeMirror](https://github.com/uiwjs/react-codemirror) code editor to ensure a good developer experience.

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/9c0234b9-ce33-48c0-8352-6997ed284833)

2. Also added some onboarding instructions so users can easily understand how this feature works.
This instructions can be hidden/shown with a switch I've added right above the editor.

![image](https://github.com/tarasglek/chatcraft.org/assets/78865303/445da8a3-bf96-4f50-9e40-faf298f5dece)


3. We, of course, also get all the functionalities `CodeHeader` component implements - including **copying**, **downloading** and opening the code in a new browser tab.

This closes #540 