### PR TITLE
Logo bg color fix for all models that don't have logo

### DIFF
--- a/src/components/ModelAvatar.tsx
+++ b/src/components/ModelAvatar.tsx
@@ -8,8 +8,7 @@ export default function ModelAvatar({ model, size }: { model: ChatCraftModel; si
   // Differentiate OpenAI models by colour
   if (id.includes("gpt-4")) {
     return <Avatar size={size} bg="#A96CF9" src={logoUrl} title={prettyModel} />;
-  }
-  if (id.includes("gpt-3.5-turbo")) {
+  } else if (id.includes("gpt-3.5-turbo")) {
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
 

--- a/src/components/ModelAvatar.tsx
+++ b/src/components/ModelAvatar.tsx
@@ -12,14 +12,12 @@ export default function ModelAvatar({ model, size }: { model: ChatCraftModel; si
   if (id.includes("gpt-3.5-turbo")) {
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
-  if (id.includes("free") || id === "auto") {
-    return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
-  }
 
   // For now, all the rest use the same colour, or just the logo's background
   return (
     <Avatar
       size={size}
+      bg="#75AB9C"
       showBorder
       borderColor="gray.100"
       _dark={{ borderColor: "gray.600" }}


### PR DESCRIPTION
**Bug:**

Currently some logos in OpenRouter and custom providers appear as white, since they have a default white logo on a white bg.

**Fix:**

Set the default Avatar to have green bg color.

---
code change:

![image](https://github.com/tarasglek/chatcraft.org/assets/98062538/4e3bef96-a4f4-4300-8f2c-c405d5ea4889)

