### PR TITLE
Add logo for non-OpenAI models

### DIFF
--- a/src/components/ModelAvatar.tsx
+++ b/src/components/ModelAvatar.tsx
@@ -3,7 +3,7 @@ import { Avatar } from "@chakra-ui/react";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 
 export default function ModelAvatar({ model, size }: { model: ChatCraftModel; size: "sm" | "xs" }) {
-  const { id, logoUrl, prettyModel } = model;
+  const { id, logoUrl, logoBg, prettyModel } = model;
 
   // Differentiate OpenAI models by colour
   if (id.includes("gpt-4")) {
@@ -12,15 +12,15 @@ export default function ModelAvatar({ model, size }: { model: ChatCraftModel; si
     return <Avatar size={size} bg="#75AB9C" src={logoUrl} title={prettyModel} />;
   }
 
-  // For now, all the rest use the same colour, or just the logo's background
   return (
     <Avatar
       size={size}
-      bg="#75AB9C"
+      bg={logoBg}
       showBorder
       borderColor="gray.100"
       _dark={{ borderColor: "gray.600" }}
       src={logoUrl}
+      name={prettyModel}
       title={prettyModel}
     />
   );

--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -38,8 +38,21 @@ export class ChatCraftModel {
       return "/hugging-face-logo.png";
     }
 
-    // If we don't know, use the OpenAI logo as a fallback
-    return "/openai-logo.png";
+    return undefined;
+  }
+
+  // Simple hash from name's characters to a 6-digit hexadecimal color code
+  get logoBg(): string {
+    let hash = 0;
+    for (let i = 0; i < this.name.length; i++) {
+      hash = this.name.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    let color = "#";
+    for (let i = 0; i < 3; i++) {
+      const value = (hash >> (i * 8)) & 0xff;
+      color += ("00" + value.toString(16)).substr(-2);
+    }
+    return color;
   }
 
   /**


### PR DESCRIPTION
## Description

Using the  [Avatar Fallbacks](https://chakra-ui.com/docs/components/avatar#avatar-fallbacks)  behaviour of `chakra-ui`to set the name with simple hash function to set the background colour for different models

## Result

![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/04f13fbc-dcc9-4bdc-afe8-7c6cdd703a5e)

Fixes #564 