### PR TITLE
Remove workaround hardcode in the vision model

### DIFF
--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -259,14 +259,6 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
           ? { name: functionToCall.name }
           : "auto"
         : undefined,
-
-    /*
-     Got this value from error message of OpenAI's gpt-4-vision-preview max_tokens
-     by setting a very large number,
-     After setting this value, seems no cutoff
-     Tested on version openai@4.24.7, without max_tokens response still cutoff
-     */
-    max_tokens: model.supportsImages ? 4096 : undefined,
   };
 
   const chatCompletionReqOptions = {


### PR DESCRIPTION
## Description 

In PR #286, I set the `max_tokens` to 4096 to fix the [response cutoff](https://github.com/tarasglek/chatcraft.org/pull/286#issuecomment-1806583129) issue.

```
max_tokens: model.supportsImages ? 4096 : undefined,
```

I've recently using without this and it appears to be working well, so I think we can do away with this part. We can keep this branch for a well to get more tests before it is merged to `main` branch.

## How to test

Upload a picture and ask some question that would like give longer response, check the response is complete and doesn't cut off, such as:

<img width="502" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/875401f6-ee81-4a7a-868b-f0acd54c8f13">

