### PR TITLE
Update ChatCraftCommand::isCommand() criteria for slash function

### DIFF
--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -18,6 +18,8 @@ export abstract class ChatCraftCommand {
 
   // Checks if a string is a command.
   static isCommand(input: string): boolean {
-    return input.startsWith("/");
+    // Check if there's something resembling a command (no non-word characters in the portion after forward slash)
+    const match = input.match(/^\/(\w+)(?:\s+(.*))?$/);
+    return !!match;
   }
 }

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -19,7 +19,6 @@ export abstract class ChatCraftCommand {
   // Checks if a string is a command.
   static isCommand(input: string): boolean {
     // Check if there's something resembling a command (no non-word characters in the portion after forward slash)
-    const match = input.match(/^\/(\w+)(?:\s+(.*))?$/);
-    return !!match;
+    return /^\/(\w+)(?:\s+(.*))?$/.test(input);
   }
 }


### PR DESCRIPTION
This fixes #500.
The issue encountered above is due to ChatBase interpreting a non-slash command (in this case, a filepath in an error message) as a slash command:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/237c73ba-7445-4d09-a469-3e8a12bf360d)

`isCommand()` currently treats every prompt starting with a forward slash as a potential slash command, then either tries to execute the slash command or parse the invalid command to notify the user (i.e **[invalid command] is not a valid command!**).

This PR reuses the **parseCommand() Regex** in **isCommand()** so things like filepaths aren't treated as a potential slash command:
https://github.com/tarasglek/chatcraft.org/blob/f7b28038b3820d617a14b346536377977f4379d0/src/lib/ChatCraftCommand.ts#L10-L12

How to Test
---
- Test every existing slash command in the preview and confirm they still work
- Copy/paste the codeblock from the Issue description into a new chat and confirm it is sent as a message analyzed by the LLM.

Potential Issue
---
I think this is a step in the right direction, but the Regex in the new **isCommand()** is not perfect.
If the user enters a slash command containing a non-word (special) character, it will be sent to the LLM:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/e87379ee-b57d-41b7-a382-c8be1b364a9c)

