### PR TITLE
Disable line number select in Safari

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -146,6 +146,7 @@ function Markdown({
                   showLineNumbers={true}
                   showInlineLineNumbers={true}
                   wrapLines={true}
+                  lineNumberStyle={{ WebkitUserSelect: "none" }}
                   lineProps={{
                     style: { display: "block" },
                   }}


### PR DESCRIPTION
Hello, I recently started using Chatcraft and I love it!

I found this small issue when using Safari where the line numbers were getting selected during code selection:

![Screenshot 2024-04-07 at 11 52 08](https://github.com/tarasglek/chatcraft.org/assets/53121061/8cd00952-53c6-4c07-824a-9690ef41fcd9)


I fixed it in `SyntaxHighlighter`
