### PR TITLE
Disable message editing on shared chats

### DIFF
--- a/src/components/Message/AiMessage.tsx
+++ b/src/components/Message/AiMessage.tsx
@@ -159,7 +159,7 @@ function AiMessage(props: AiMessageProps) {
       onRetryClick={retrying ? undefined : handleRetryClick}
       onDeleteClick={retrying ? undefined : props.onDeleteClick}
       disableFork={retrying}
-      disableEdit={retrying}
+      disableEdit={message.readonly ?? retrying}
     />
   );
 }

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -430,7 +430,7 @@ function MessageBase({
                       onClick={() => onEditingChange(!editing)}
                     />
                   )}
-                  {onDeleteClick && (
+                  {!disableEdit && onDeleteClick && (
                     <IconButton
                       variant="ghost"
                       icon={<TbTrash />}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -498,7 +498,6 @@ function MessageBase({
                     {editing ? "Cancel Editing" : "Edit"}
                   </MenuItem>
                 )}
-
                 {shouldShowDeleteMenu && (
                   <>
                     {onDeleteClick && !onDeleteBeforeClick && !onDeleteAfterClick ? (

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -132,9 +132,8 @@ function MessageBase({
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
   const isLongMessage = text.length > 5000;
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
-  const shouldShowDeleteMenu = Boolean(
-    (onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit
-  );
+  const shouldShowDeleteMenu =
+    Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;
   const chat = useLiveQuery(() => ChatCraftChat.find(chatId), [chatId]);
   const { user } = useUser();
   const handleShareMessage = useCallback(async () => {

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -132,7 +132,9 @@ function MessageBase({
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
   const isLongMessage = text.length > 5000;
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
-  const shouldShowDeleteMenu = Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick);
+  const shouldShowDeleteMenu = Boolean(
+    (onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit
+  );
   const chat = useLiveQuery(() => ChatCraftChat.find(chatId), [chatId]);
   const { user } = useUser();
   const handleShareMessage = useCallback(async () => {

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -137,7 +137,7 @@ type SystemMessageProps = Omit<MessageBaseProps, "avatar" | "message"> & {
 };
 
 function SystemMessage(props: SystemMessageProps) {
-  const { chatId, message, editing, onEditingChange } = props;
+  const { chatId, message, disableEdit, editing, onEditingChange } = props;
   const { isOpen, onToggle } = useDisclosure();
   const summaryText = createSystemPromptSummary(message);
   const { error } = useAlert();
@@ -161,7 +161,12 @@ function SystemMessage(props: SystemMessageProps) {
           <Button size="sm" variant="ghost" onClick={() => onToggle()}>
             {isOpen ? "Show Less" : "Show More..."}
           </Button>
-          <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
+          <Button
+            hidden={!!disableEdit}
+            size="sm"
+            variant="ghost"
+            onClick={() => onEditingChange(true)}
+          >
             <Text fontSize="xs" as="em">
               Edit to customize
             </Text>

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -68,7 +68,7 @@ function Message({
         onDeleteAfterClick={onDeleteAfterClick}
         hasMessagesAfter={hasMessagesAfter}
         disableFork={disableFork}
-        disableEdit={message.readonly && disableEdit}
+        disableEdit={message.readonly ?? disableEdit}
       />
     );
   }
@@ -92,7 +92,7 @@ function Message({
         onDeleteAfterClick={onDeleteAfterClick}
         hasMessagesAfter={hasMessagesAfter}
         disableFork={disableFork}
-        disableEdit={message.readonly && disableEdit}
+        disableEdit={message.readonly ?? disableEdit}
       />
     );
   }
@@ -112,7 +112,7 @@ function Message({
         onDeleteAfterClick={onDeleteAfterClick}
         hasMessagesAfter={hasMessagesAfter}
         disableFork={true}
-        disableEdit={message.readonly && disableEdit}
+        disableEdit={message.readonly ?? disableEdit}
       />
     );
   }
@@ -131,6 +131,7 @@ function Message({
         onDeleteClick={onDeleteClick}
         onDeleteAfterClick={onDeleteAfterClick}
         hasMessagesAfter={hasMessagesAfter}
+        disableEdit={message.readonly ?? disableEdit}
       />
     );
   }


### PR DESCRIPTION
## Description 

Due to the special behavior of the JavaScript language, the previous logic `message.readonly && disableEdit` will be `undefined` if `disableEdit` is `undefined`, so `!disableEdit` still `true` and display the edit button in shared chat.

To fix the issue, and given `message.readonly` comes from`SerializedChatCraftMessage`, we can give `message.readonly` higher priority, as `message.readonly ?? disableEdit`

## Result

Only display the copy button in the
[shared chat](https://mingming-sharedchats-570.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/3Y5Hrv-sIB2GSfxV-_32s)

![image](https://github.com/tarasglek/chatcraft.org/assets/133393905/c5b289d8-9f4b-4b1f-a7bc-5a9a9c75f683)

Fixes #570 