### PR TITLE
adjusted toast message width for mobile experience

### DIFF
--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -24,7 +24,7 @@ export function useAlert() {
   const isMobile = useMobileBreakpoint();
   const toast = useToast({
     containerStyle: {
-      maxWidth: isMobile ? "100vw" : undefined,
+      width: isMobile ? "90vw" : "initial",
     },
   });
 

--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -1,6 +1,6 @@
 import { useCallback } from "react";
 import { useToast } from "@chakra-ui/react";
-
+import useMobileBreakpoint from "../hooks/use-mobile-breakpoint";
 export type AlertArguments = {
   // Use `id` if you want to avoid duplicate alerts showing
   id?: string;
@@ -21,7 +21,12 @@ function truncateMessage(message?: string): string {
 }
 
 export function useAlert() {
-  const toast = useToast();
+  const isMobile = useMobileBreakpoint();
+  const toast = useToast({
+    containerStyle: {
+      maxWidth: isMobile ? "100vw" : undefined,
+    },
+  });
 
   const info = useCallback(
     ({ id, title, message }: AlertArguments) =>


### PR DESCRIPTION
This fixes #569 
I've been working with ChakraUI's [Toast props](url) and I've found a way to make toast messages fit the viewport when mobile is detected (screen width <= 480px) , but it seems the second end of my ternary operator overrides the default width we currently use for desktop.