### PR TITLE
API Key Field Enhancement: Replaced Show/Hide button with Eye ReactIcons

### DIFF
--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,5 +1,5 @@
-import { Button, Input, InputGroup, InputRightElement } from "@chakra-ui/react";
-import { type ComponentPropsWithRef, useState } from "react";
+import { useState, type ComponentPropsWithRef } from "react";
+import { Input, InputGroup, InputRightElement, IconButton } from "@chakra-ui/react";
 import { IoMdEye, IoMdEyeOff } from "react-icons/io";
 
 type PasswordInputProps = ComponentPropsWithRef<typeof Input> & {
@@ -28,9 +28,15 @@ function PasswordInput({
         type={show ? "text" : "password"}
       />
       <InputRightElement width={paddingRight}>
-        <Button variant="ghost" h="1.75rem" size={buttonSize} onClick={() => setShow(!show)}>
-          {show ? <IoMdEyeOff /> : <IoMdEye />}
-        </Button>
+        <IconButton
+          variant="ghost"
+          h="1.75rem"
+          size={buttonSize}
+          icon={show ? <IoMdEyeOff /> : <IoMdEye />}
+          onClick={() => setShow(!show)}
+          aria-label={show ? "Hide" : "Show"}
+          title={show ? "Hide" : "Show"}
+        />
       </InputRightElement>
     </InputGroup>
   );

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,5 +1,6 @@
 import { Button, Input, InputGroup, InputRightElement } from "@chakra-ui/react";
 import { type ComponentPropsWithRef, useState } from "react";
+import { IoMdEye, IoMdEyeOff } from "react-icons/io";
 
 type PasswordInputProps = ComponentPropsWithRef<typeof Input> & {
   buttonSize?: "lg" | "md" | "sm" | "xs";
@@ -28,7 +29,7 @@ function PasswordInput({
       />
       <InputRightElement width={paddingRight}>
         <Button variant="ghost" h="1.75rem" size={buttonSize} onClick={() => setShow(!show)}>
-          {show ? "Hide" : "Show"}
+          {show ? <IoMdEyeOff /> : <IoMdEye />}
         </Button>
       </InputRightElement>
     </InputGroup>


### PR DESCRIPTION
This fixes #552
As a followup to #530,
I replaced the Show/Hide Button with the **IoMdEye**/**IoMdEyeOff** [react icons](https://react-icons.github.io/react-icons/search/#q=eye):
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/9aadaee1-1810-43db-86c7-1af13678833e)

I modelled the behaviour based on what I observed on Facebook Messenger (show 'Eye On' when text is obscured, show 'Eye Off' when text is visible:
![messengerEyeIcons](https://github.com/tarasglek/chatcraft.org/assets/78163326/1b97d4e8-c76e-465a-94f0-4ba5ff06c88f)
