### PR TITLE
Added condition to remove trailing backslash from github blob urls

### DIFF
--- a/functions/lib/rewriters/github-rewriter.ts
+++ b/functions/lib/rewriters/github-rewriter.ts
@@ -10,12 +10,12 @@ export class GitHubRewriter extends DefaultRewriter {
     // Blob URLs - https://github.com/<owner>/<repo>/blob/<branch>/<path>
     if (url.origin === "https://github.com" && /\/(.*)\/blob\/(.*)\/?$/.test(url.pathname)) {
       // https://github.com/<owner>/<repo>/blob/<branch>/<path> ->
-      return new URL(
-        url.href.replace(
-          /^https:\/\/github\.com\/(.*)\/blob\/(.*)\/?$/,
-          "https://raw.githubusercontent.com/$1/$2"
-        )
+      let newUrl = url.href.replace(
+        /^https:\/\/github\.com\/(.+?)\/blob\/(.+?)\/?$/,
+        "https://raw.githubusercontent.com/$1/$2"
       );
+      newUrl = newUrl.replace(/\/$/, "");
+      return new URL(newUrl);
     }
 
     // Gist URLs - https://gist.github.com/<owner>/<gist-id>


### PR DESCRIPTION
Closes #568 

Issue found:
Github blob URLs when with trailing backslash return 400 invalid request.

Screenshot:
<img width="754" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/58596563/0cee63fe-9a79-44fa-ae70-ad6490bea937">
