### PR TITLE
Fix Web Handlers not executing with Re-ask option

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -80,7 +80,7 @@ export interface MessageBaseProps {
   isLoading: boolean;
   hidePreviews?: boolean;
   onPrompt?: (prompt?: string) => void;
-  onResubmitClick?: (promtText?: string) => void;
+  onResubmitClick?: (promptText?: string) => void;
   onDeleteBeforeClick?: () => void;
   onDeleteClick?: () => void;
   onDeleteAfterClick?: () => void;

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -80,7 +80,7 @@ export interface MessageBaseProps {
   isLoading: boolean;
   hidePreviews?: boolean;
   onPrompt?: (prompt?: string) => void;
-  onResubmitClick?: () => void;
+  onResubmitClick?: (promtText?: string) => void;
   onDeleteBeforeClick?: () => void;
   onDeleteClick?: () => void;
   onDeleteAfterClick?: () => void;
@@ -337,7 +337,7 @@ function MessageBase({
           .finally(() => {
             onEditingChange(false);
             if (action === "resubmit" && onResubmitClick) {
-              onResubmitClick();
+              onResubmitClick(text);
             }
             messageForm.current?.removeAttribute("data-action");
           });

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -97,9 +97,9 @@ function MessagesView({
           message={message}
           chatId={chatId}
           isLoading={isLoading}
-          onResubmitClick={async () => {
+          onResubmitClick={async (promptText?: string) => {
             await deleteMessages(message.id, "after");
-            onPrompt();
+            onPrompt(promptText);
           }}
           onDeleteBeforeClick={
             hasMessagesBefore ? () => deleteMessages(message.id, "before") : undefined


### PR DESCRIPTION
In #519, I implemented initial support for Web Handlers, which extend ChatCraft's URL handling capabilities.

However, @tarasglek noticed that when a non-matching prompt is edited to a valid url pattern that is configured in Web Handlers configuration, prompt is still sent to LLM instead of invoking the corresponding Web Handler.

I researched a bit and found that the reason for this to happen was that the `Resubmit` handler function for the message form was not passing the prompt text  to the `onPrompt` function.

This is why the handler wasn't able to determine any specifics about the prompt. I am now passing the text to that handler so `onPrompt` in `ChatBase` knows that it needs to be passed to a Web Handler.

**Before:**
```ts
onResubmitClick={async () => {
  await deleteMessages(message.id, "after");
  onPrompt();
}}
```

**After:**
```ts
onResubmitClick={async (promptText?: string) => {
  await deleteMessages(message.id, "after");
  onPrompt(promptText);
}}
```

This fixes #541 