### PR TITLE
Refactor PasswordInput component to follow Chakra's design system

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -156,6 +156,7 @@ function Instructions(props: MessageBaseProps) {
               <Flex gap={4} align="center">
                 <PasswordInput
                   flex="1"
+                  size={"md"}
                   type="password"
                   name="openai-api-key"
                   bg="white"

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,29 +1,30 @@
-import { useState, type ComponentPropsWithRef } from "react";
-import { Input, InputGroup, InputRightElement, Button } from "@chakra-ui/react";
+import { Button, Input, InputGroup, InputRightElement } from "@chakra-ui/react";
+import { type ComponentPropsWithRef, useState } from "react";
 
 type PasswordInputProps = ComponentPropsWithRef<typeof Input> & {
-  inputSize?: "sm" | "md";
+  buttonSize?: "lg" | "md" | "sm" | "xs";
   isInvalid?: boolean;
 };
 
-function PasswordInput({ inputSize = "md", isInvalid, ...props }: PasswordInputProps) {
+function PasswordInput({
+  isInvalid,
+  size = "sm",
+  buttonSize = "sm",
+  paddingRight = "4.5rem",
+  ...props
+}: PasswordInputProps) {
   const [show, setShow] = useState(false);
 
-  const paddingRight = inputSize === "sm" ? "2.5rem" : "4.5rem";
-  const paddingLeft = inputSize === "sm" ? "0.4rem" : undefined;
-  const inputFieldSize = inputSize === "sm" ? "sm" : "md";
-  const buttonSize = inputSize === "sm" ? "xs" : "sm";
-
   return (
-    <InputGroup size={inputFieldSize}>
+    <InputGroup size={size}>
       <Input
-        {...props}
-        pr={paddingRight}
-        pl={paddingLeft}
-        type={show ? "text" : "password"}
-        focusBorderColor={isInvalid ? "red.500" : "blue.500"}
-        borderColor={isInvalid ? "red.500" : "gray.200"}
+        size={size}
+        focusBorderColor={isInvalid ? "red.300" : "blue.500"}
+        borderColor={isInvalid ? "red.300" : "gray.200"}
+        paddingRight={paddingRight}
         isInvalid={isInvalid}
+        {...props}
+        type={show ? "text" : "password"}
       />
       <InputRightElement width={paddingRight}>
         <Button variant="ghost" h="1.75rem" size={buttonSize} onClick={() => setShow(!show)}>

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -664,7 +664,10 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                         <Td>
                           <FormControl isInvalid={!newCustomProvider.apiKey}>
                             <PasswordInput
-                              inputSize="sm"
+                              size="sm"
+                              buttonSize="xs"
+                              paddingRight={"2.5rem"}
+                              paddingLeft={"0.5rem"}
                               fontSize="xs"
                               type="password"
                               placeholder="API Key"
@@ -738,7 +741,10 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                                   }
                                 >
                                   <PasswordInput
-                                    inputSize="sm"
+                                    size="sm"
+                                    buttonSize="xs"
+                                    paddingRight={"2.5rem"}
+                                    paddingLeft={"0.5rem"}
                                     fontSize="xs"
                                     type="password"
                                     value={provider.apiKey || ""}


### PR DESCRIPTION
In #530, @kliu57 added support for custom AI providers and in implementing the UI for providers selection, she made changes to the existing `RevealablePasswordInput` component to make the appearance ideal for her use case.

However, I felt that the code had some issues.

1. Programatically determining styles based on other styles and hard coding values inside component caused tight coupling between different styles making it hard to reuse in other cases in the future. (Would need to add more if statements every time a new appearance was required)
2. In a way, it overrode Chakra's in-built styling system which is not good.

In this PR, I have tried to refactor that part to make use of Chakra's own design system as much as possible turning it into a more generic wrapper around normal Input. `PasswordInput` now behaves more like a component provided by Chakra itself since most of the styles/props are being mapped directly.

This fixes #553 