### PR TITLE
Fix for minor bugs in instructions page and prefs modal

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -163,8 +163,6 @@ function Instructions(props: MessageBaseProps) {
                 <PasswordInput
                   flex="1"
                   size={"md"}
-                  type="password"
-                  name="api-key"
                   bg="white"
                   _dark={{ bg: "gray.700" }}
                   style={{

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -25,7 +25,10 @@ function PasswordInput({
         paddingRight={paddingRight}
         isInvalid={isInvalid}
         {...props}
-        type={show ? "text" : "password"}
+        type="text"
+        sx={{
+          WebkitTextSecurity: show ? "none" : "disc",
+        }}
       />
       <InputRightElement width={paddingRight}>
         <IconButton

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -500,6 +500,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
   useEffect(() => {
     if (!isOpen) {
       setNewCustomProvider(null);
+      setIsApiKeyInvalid(false);
     }
   }, [isOpen]);
 

--- a/src/components/PreferencesModal.tsx
+++ b/src/components/PreferencesModal.tsx
@@ -670,7 +670,6 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                               paddingRight={"2.5rem"}
                               paddingLeft={"0.5rem"}
                               fontSize="xs"
-                              type="password"
                               placeholder="API Key"
                               value={newCustomProvider.apiKey || ""}
                               onChange={(e) => {
@@ -747,7 +746,6 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
                                     paddingRight={"2.5rem"}
                                     paddingLeft={"0.5rem"}
                                     fontSize="xs"
-                                    type="password"
                                     value={provider.apiKey || ""}
                                     onChange={(e) => handleApiKeyChange(provider, e.target.value)}
                                     onFocus={() => setFocusedProvider(provider)}

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -71,9 +71,3 @@ export const supportedProviders: ProviderData = (() => {
     [openAi.name]: openAi,
   };
 })();
-
-export const nameToUrlMap: { [key: string]: string } = {
-  [OPENAI_NAME]: OPENAI_API_URL,
-  [OPENROUTER_NAME]: OPENROUTER_API_URL,
-  [FREEMODELPROVIDER_NAME]: FREEMODELPROVIDER_API_URL,
-};

--- a/src/lib/providers/index.ts
+++ b/src/lib/providers/index.ts
@@ -1,12 +1,8 @@
 import { ChatCraftProvider, ProviderData, SerializedChatCraftProvider } from "../ChatCraftProvider";
 import { getSettings } from "../settings";
-import { OPENAI_API_URL, OPENAI_NAME, OpenAiProvider } from "./OpenAiProvider";
-import { OPENROUTER_API_URL, OPENROUTER_NAME, OpenRouterProvider } from "./OpenRouterProvider";
-import {
-  FREEMODELPROVIDER_API_URL,
-  FREEMODELPROVIDER_NAME,
-  FreeModelProvider,
-} from "./DefaultProvider/FreeModelProvider";
+import { OPENAI_API_URL, OpenAiProvider } from "./OpenAiProvider";
+import { OPENROUTER_API_URL, OpenRouterProvider } from "./OpenRouterProvider";
+import { FREEMODELPROVIDER_API_URL, FreeModelProvider } from "./DefaultProvider/FreeModelProvider";
 import { CustomProvider } from "./CustomProvider";
 
 export const usingOfficialOpenAI = () => getSettings().currentProvider.apiUrl === OPENAI_API_URL;


### PR DESCRIPTION
Fixes #583 

See the above issue for details on how to reproduce each bug in production.

**How each bug was fixed:**

**Bug 1:**

Fixed by having the dropdown display a list that is made up of `supportedProviders` and `settings.providers` merged together (without duplicates). The merge results in `providersList`. (Prior to this change, the dropdown displays only `supportedProviders` which is wrong since that does not include our custom created providers. The merge of the two lists is done the same way as @Rachit1313 did in `PromptSendButton.tsx`.

**Bug 2:**

Fixed by introducing state variable `selectedProvider` in `Instructions.tsx` so we can keep track of the selected provider's api key. This allows us to delay the setting of the currentProvider's api key until after we click the Save button. Before this change, the moment we switch to a provider with a saved key, we leave the instructions page immediately (due to the fact that we set `currentProvider.apiKey` and instructions only appears when that is blank). This is not ideal, since the key could be invalid. So we do not want to leave the instructions page yet, and this state variable allows us to delay setting `settings.currentProvider.apiKey`.

**Bug 3:**

Fixed by one line addition to `PreferencesModel.tsx`

**Bug 4:**

Fixed by banning browsers from saving api keys as password. This is done by removing `type={show ? "text" : "password"}` because when `type` is `password` it prompts browsers to use their password manager. Instead of using `type = "password"` to disguise the password as asterix, I am now using:

```
        sx={{
          WebkitTextSecurity: show ? "none" : "disc",
        }}
```