### PR TITLE
Fix the loading spinner does not disappear when image generation fails

### DIFF
--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -54,9 +54,10 @@ export class ImageCommand extends ChatCraftCommand {
     } catch (error: any) {
       console.error(`Failed to generate image: ${error.message}`);
       throw new Error(`Failed to generate image: ${error.message}`);
+    } finally {
+      closeLoading(alertId);
     }
 
-    closeLoading(alertId);
     return chat.addMessage(new ChatCraftHumanMessage({ user, text, imageUrls }));
   }
 }


### PR DESCRIPTION
Fixes #590 

Make sure `closeLoading(alertId);` will always be called, so the loading spinner can disappear whether an error is thrown or not.