### PR TITLE
Prevent Toast Error Duplication

### DIFF
--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -44,17 +44,20 @@ export function useAlert() {
   );
 
   const error = useCallback(
-    ({ id, title, message }: AlertArguments) =>
-      toast({
-        id,
-        title,
-        description: truncateMessage(message),
-        status: "error",
-        position: "top",
-        isClosable: true,
-        // Don't auto-close errors
-        duration: null,
-      }),
+    ({ id, title, message }: AlertArguments) => {
+      if (id && !toast.isActive(id)) {
+        toast({
+          id,
+          title,
+          description: truncateMessage(message),
+          status: "error",
+          position: "top",
+          isClosable: true,
+          // Don't auto-close errors
+          duration: null,
+        });
+      }
+    },
     [toast]
   );
 


### PR DESCRIPTION
This fixes #586, which appears to be caused by https://github.com/tarasglek/chatcraft.org/pull/577

### Background

#577 adds toast configuration overrides within the **useToast()** call:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/d302e474-ad4b-4431-ad0d-81737aeafc07)

I don't know why, but the configuration overrides causes the error toast described in #586 to **trigger twice**:
- once before the **b** key is entered
- a second time after the **b** key is entered
![toastDuplication](https://github.com/tarasglek/chatcraft.org/assets/78163326/9ede2e34-7531-418f-bcbe-a9888e8b7efc)

Removing the configuration override eliminates this bug, however my PR uses a different solution.


### My Solution

The ChakraUI Documentation on Toast provides an example of how to [prevent duplicates of specific toasts](https://v2.chakra-ui.com/docs/components/toast#preventing-duplicate-toast).

This example above will only render a toast message if a toast message with that ID isn't already active, preventing duplicates.
Currently, my PR will prevent all **error** toasts from being duplicated, not just the error toast described in #586.

#### How to test: 
For some reason, the error toast won't appear if you use the preview URL.
For this, I suggest **testing the branch locally**:
```bash
git fetch
git checkout issue-586
pnpm dev
```
Attempt to replicate the bug by following the instructions described in #586. You should observe only one toast message being generated instead of multiple at once. 
Because this change prevents error toast duplications, **repeating an error while its associated toast is active will not pop another toast**. If you close the error toast and replicate the error again, the error toast will pop again

However, I have two concerns:
1. Do we want any error toasts to be duplicated (i.e an error toast to duplicate if a user keeps repeating an error)? 
If so then we shouldn't proceed with this change.
2. If we're proceeding with this change, should we also apply it to the other toast messages in **src/hooks/use-alert.ts** (info, success, and warning)?

If this change isn't ideal then we should consider reverting my change in #577 