### PR TITLE
Disable edit summary for shared chats

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -154,7 +154,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                       {title}
                     </Link>
                   </Text>
-                  {settings.currentProvider.apiKey && (
+                  {!chat.readonly && settings.currentProvider.apiKey && (
                     <IconButton
                       variant="ghost"
                       size="sm"

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -491,7 +491,7 @@ function MessageBase({
                 <MenuItem onClick={() => handleShareMessage()} icon={<TbShare2 />}>
                   Share Message
                 </MenuItem>
-                {(!disableEdit || onDeleteClick) && <MenuDivider />}
+                {(!disableEdit || shouldShowDeleteMenu) && <MenuDivider />}
                 {!disableEdit && (
                   <MenuItem onClick={() => onEditingChange(!editing)} icon={<AiOutlineEdit />}>
                     {editing ? "Cancel Editing" : "Edit"}


### PR DESCRIPTION
before:
<img width="261" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/192767e1-0637-41aa-b24a-95febd0cda39">


after:
<img width="216" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/20795443/24b414d1-9996-4825-bcc6-0ca83e8c2c3f">



closes #160 