### PR TITLE
Add custom error toast message width on mobile

### DIFF
--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -54,7 +54,7 @@ export function useAlert() {
           width: isMobile ? "90vw" : "initial",
         },
       }),
-    [toast]
+    [toast, isMobile]
   );
 
   const success = useCallback(

--- a/src/hooks/use-alert.ts
+++ b/src/hooks/use-alert.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import { useToast } from "@chakra-ui/react";
+import useMobileBreakpoint from "./use-mobile-breakpoint";
 
 export type AlertArguments = {
   // Use `id` if you want to avoid duplicate alerts showing
@@ -19,9 +20,9 @@ function truncateMessage(message?: string): string {
 
   return message;
 }
-
 export function useAlert() {
   const toast = useToast();
+  const isMobile = useMobileBreakpoint();
 
   const info = useCallback(
     ({ id, title, message }: AlertArguments) =>
@@ -49,6 +50,9 @@ export function useAlert() {
         isClosable: true,
         // Don't auto-close errors
         duration: null,
+        containerStyle: {
+          width: isMobile ? "90vw" : "initial",
+        },
       }),
     [toast]
   );


### PR DESCRIPTION
Similar to #577, this fixes #569 by making toast error messages fit the viewport when mobile is detected.

However, instead of adding the container style within the **useAlert**, the container styling is applied to the error **useCallback**.

This appears to avoid the bugs caused by #577 and reported in #586, but I'd like more opinions.

If this does fix the issues previously encountered, do we also want to apply this change to the rest of the useCallbacks?