### PR TITLE
Allow downloading and re-announcing messages of infinite length

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "nanoid": "^5.0.5",
     "nomnoml": "^1.6.2",
     "openai": "^4.26.1",
+    "p-limit": "^5.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-icons": "^5.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ dependencies:
   openai:
     specifier: ^4.26.1
     version: 4.26.1
+  p-limit:
+    specifier: ^5.0.0
+    version: 5.0.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -8746,7 +8749,6 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       yocto-queue: 1.0.0
-    dev: true
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
@@ -11139,7 +11141,6 @@ packages:
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
-    dev: true
 
   /youch@3.3.2:
     resolution: {integrity: sha512-9cwz/z7abtcHOIuH45nzmUFCZbyJA1nLqlirKvyNRx4wDMhqsBaifAJzBej7L4fsVPjFxYq3NK3GAcfvZsydFw==}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -33,12 +33,12 @@ import {
   type ReactNode,
 } from "react";
 
-import { Menu, MenuItem, SubMenu, MenuDivider } from "../Menu";
-import ResizeTextarea from "react-textarea-autosize";
-import { TbTrash, TbShare2 } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
+import { TbShare2, TbTrash } from "react-icons/tb";
 import { Link as ReactRouterLink } from "react-router-dom";
+import ResizeTextarea from "react-textarea-autosize";
+import { Menu, MenuDivider, MenuItem, SubMenu } from "../Menu";
 
 import { useCopyToClipboard } from "react-use";
 import { useAlert } from "../../hooks/use-alert";
@@ -66,6 +66,7 @@ import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { textToSpeech } from "../../lib/ai";
 import { usingOfficialOpenAI } from "../../lib/providers";
 import "./Message.css";
+import { getSentenceChunksFrom } from "../../lib/summarize";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -363,8 +364,12 @@ function MessageBase({
 
         const { voice } = settings.textToSpeech;
 
-        // Use lighter tts-1 model to minimize latency
-        addToAudioQueue(textToSpeech(messageContent, voice, "tts-1"));
+        const messageChunks = getSentenceChunksFrom(messageContent, 500);
+
+        messageChunks.forEach((messageChunk) => {
+          // Use lighter tts-1 model to minimize latency
+          addToAudioQueue(textToSpeech(messageChunk, voice, "tts-1"));
+        });
       } catch (err: any) {
         console.error(err);
         error({ title: "Error while generating Audio", message: err.message });

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -61,8 +61,8 @@ export function tokenize(text: string) {
  * Tries to split the provided text into
  * an array of text chunks where
  * each chunk is composed of one or more sentences.
- * The function attempts to limit each chunk to maximim
- * preferred characters preferred, but the chunk limit may still exceed
+ * The function attempts to limit each chunk to maximum
+ * preferred characters, but the chunk limit may still exceed
  * if a single sentence's length is greater than the preferred character limit.
  *
  * @param text The text content that needs to be split into Chunks
@@ -77,7 +77,7 @@ export function getSentenceChunksFrom(text: string, maxCharsPerSentence: number 
 
   for (const sentence of sentences) {
     if (currentText.length + sentence.length < maxCharsPerSentence) {
-      currentText += ` ${sentence}`;
+      currentText += ` ${sentence.trim()}`;
     } else {
       if (currentText.length) {
         chunks.push(currentText);

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -90,7 +90,8 @@ export function getSentenceChunksFrom(text: string, maxCharsPerSentence: number 
 
       // Force break the long sentence without caring
       // about natural language
-      const sentencePieces = sentence.match(new RegExp(`.{1,${500}}\\b`, "g")) || [];
+      const sentencePieces =
+        sentence.match(new RegExp(`.{1,${maxCharsPerSentence}}\\b`, "g")) || [];
 
       chunks.push(...sentencePieces);
     } else {

--- a/src/lib/summarize.ts
+++ b/src/lib/summarize.ts
@@ -56,6 +56,44 @@ export function tokenize(text: string) {
 
   return { sentences, terms };
 }
+/**
+ *
+ * Tries to split the provided text into
+ * an array of text chunks where
+ * each chunk is composed of one or more sentences.
+ * The function attempts to limit each chunk to maximim
+ * preferred characters preferred, but the chunk limit may still exceed
+ * if a single sentence's length is greater than the preferred character limit.
+ *
+ * @param text The text content that needs to be split into Chunks
+ * @param maxCharsPerSentence Maximum number of characters preferred per chunk
+ * @returns Array of text chunks
+ */
+export function getSentenceChunksFrom(text: string, maxCharsPerSentence: number = 4096): string[] {
+  const { sentences } = tokenize(text);
+  const chunks: string[] = [];
+
+  let currentText = "";
+
+  for (const sentence of sentences) {
+    if (currentText.length + sentence.length < maxCharsPerSentence) {
+      currentText += ` ${sentence}`;
+    } else {
+      if (currentText.length) {
+        chunks.push(currentText);
+      }
+
+      currentText = sentence;
+    }
+  }
+
+  if (currentText.length) {
+    chunks.push(currentText);
+    currentText = "";
+  }
+
+  return chunks;
+}
 
 function calculateTermFrequencies(sentences: string[], terms: string[]): Record<string, number> {
   const termFrequencies: Record<string, number> = {};


### PR DESCRIPTION
A few weeks ago, I tried to download a podcast imported from youtube using web handlers, as **audio**.

However that didn't work out well because **OpenAI TTS API** only supports maxmum of 4096 characters input.

In this PR, I have attempted to fix that issue and now ChatCraft can **Speak** and **Download** messages of infinite length (potentially) as long as you have enough network and willing to wait.

1. I have written a `getSentenceChunksFrom` function that leverages [compromise](https://github.com/spencermountain/compromise) (the nlp library we are using), to try to break piece of text into chunks of sentences where each chunk is at max the number of characters specified in function call.
2. This function is not perfect, since I do not further break the sentences given to me by the nlp tokenize function. This means my function will fail to keep a chunk under specified character limit if any of the sentences itself exceeds that limit. However, this case is next to impossible since no sentence should be longer than 4096 characters.
3. The download option makes use of this function to split huge messages into sentence chunks, sends those chunks to tts api for processing, combines the returned blobs into a single blob using the default Blob constructor (possible because all blobs have same encoding), and downloads that single combined blob on user's file system.

With this fix, I was able to download an hour long interview and the generated audio size was **33 minutes**.
![Generated Audio](https://github.com/tarasglek/chatcraft.org/assets/78865303/b42b05a1-7b34-487f-9256-9ea1f7fa9e89)

This fixes #525

**Note:** I did not have to use [ffmpeg](https://github.com/ffmpegwasm/ffmpeg.wasm?tab=readme-ov-file) as originally discussed during triage.