### PR TITLE
Allow exporting/copying to OpenAI format JSON, YAML, fix menus, remove chat header menu

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -89,57 +89,55 @@ function ChatHeader({ chat }: ChatHeaderProps) {
         mt={2}
       >
         <CardBody pb={0}>
-          <Flex justify="space-between" align="center">
-            <Box w="100%">
-              {isEditing ? (
-                <form onSubmit={handleSaveSummary}>
-                  <Flex align="center" gap={2}>
-                    <Input
-                      flex={1}
-                      defaultValue={chat.summary}
-                      type="text"
-                      name="summary"
-                      bg="white"
-                      _dark={{ bg: "gray.700" }}
-                      size="sm"
-                      w="100%"
-                      autoFocus={true}
-                      placeholder="Chat Summary"
-                    />
-                    <ButtonGroup>
-                      <Button variant="outline" size="xs" onClick={() => setIsEditing(false)}>
-                        Cancel
-                      </Button>
-                      <Button size="xs" type="submit">
-                        Save
-                      </Button>
-                    </ButtonGroup>
-                  </Flex>
-                </form>
-              ) : (
-                <Flex align="center" gap={2} maxW="100%">
-                  <Box>
-                    <MdOutlineChatBubbleOutline />
-                  </Box>
-                  <Text fontSize="md" fontWeight="bold" noOfLines={1} title={title}>
-                    <Link as={ReactRouterLink} to={`/c/${chat.id}`}>
-                      {title}
-                    </Link>
-                  </Text>
-                  {!chat.readonly && settings.currentProvider.apiKey && (
-                    <IconButton
-                      variant="ghost"
-                      size="sm"
-                      icon={<AiOutlineEdit />}
-                      aria-label="Edit summary"
-                      title="Edit summary"
-                      onClick={() => setIsEditing(true)}
-                    />
-                  )}
+          <Box w="100%">
+            {isEditing ? (
+              <form onSubmit={handleSaveSummary}>
+                <Flex align="center" gap={2}>
+                  <Input
+                    flex={1}
+                    defaultValue={chat.summary}
+                    type="text"
+                    name="summary"
+                    bg="white"
+                    _dark={{ bg: "gray.700" }}
+                    size="sm"
+                    w="100%"
+                    autoFocus={true}
+                    placeholder="Chat Summary"
+                  />
+                  <ButtonGroup>
+                    <Button variant="outline" size="xs" onClick={() => setIsEditing(false)}>
+                      Cancel
+                    </Button>
+                    <Button size="xs" type="submit">
+                      Save
+                    </Button>
+                  </ButtonGroup>
                 </Flex>
-              )}
-            </Box>
-          </Flex>
+              </form>
+            ) : (
+              <Flex align="center" gap={2} maxW="100%">
+                <Box>
+                  <MdOutlineChatBubbleOutline />
+                </Box>
+                <Text fontSize="md" fontWeight="bold" noOfLines={1} title={title}>
+                  <Link as={ReactRouterLink} to={`/c/${chat.id}`}>
+                    {title}
+                  </Link>
+                </Text>
+                {!chat.readonly && settings.currentProvider.apiKey && (
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
+                    icon={<AiOutlineEdit />}
+                    aria-label="Edit summary"
+                    title="Edit summary"
+                    onClick={() => setIsEditing(true)}
+                  />
+                )}
+              </Flex>
+            )}
+          </Box>
         </CardBody>
         <CardFooter pt={0}>
           <Flex w="100%" gap={4} color="gray.500" _dark={{ color: "gray.400" }}>

--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -10,43 +10,35 @@ import {
   IconButton,
   Input,
   Link,
-  Menu,
-  MenuButton,
-  MenuDivider,
-  MenuItem,
-  MenuList,
   Tag,
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Link as ReactRouterLink, useFetcher } from "react-router-dom";
+import { Link as ReactRouterLink } from "react-router-dom";
 import { MdOutlineChatBubbleOutline } from "react-icons/md";
-import { TbDots } from "react-icons/tb";
 import { AiOutlineEdit } from "react-icons/ai";
-import { useCopyToClipboard, useKey } from "react-use";
+import { useKey } from "react-use";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
-import { download, formatCurrency, formatDate, formatNumber } from "../lib/utils";
+import { formatCurrency, formatDate, formatNumber } from "../lib/utils";
 import ShareModal from "../components/ShareModal";
 import { useSettings } from "../hooks/use-settings";
 import useTitle from "../hooks/use-title";
-import { useAlert } from "../hooks/use-alert";
 import { useCost } from "../hooks/use-cost";
+import { useAlert } from "../hooks/use-alert";
 
 type ChatHeaderProps = {
   chat: ChatCraftChat;
 };
 
 function ChatHeader({ chat }: ChatHeaderProps) {
-  const [, copyToClipboard] = useCopyToClipboard();
-  const { info, error } = useAlert();
-  const fetcher = useFetcher();
-  const { isOpen, onOpen, onClose } = useDisclosure();
+  const { isOpen, onClose } = useDisclosure();
   const [tokens, setTokens] = useState<number | null>(null);
   const { cost } = useCost();
   const [isEditing, setIsEditing] = useState(false);
   const { settings } = useSettings();
   const title = useTitle(chat);
+  const { error } = useAlert();
 
   useKey("Escape", () => setIsEditing(false), { event: "keydown" }, [setIsEditing]);
 
@@ -59,26 +51,6 @@ function ChatHeader({ chat }: ChatHeaderProps) {
       chat.tokens().then(setTokens).catch(console.warn);
     }
   }, [settings.countTokens, chat]);
-
-  const handleCopyChatClick = () => {
-    const text = chat.toMarkdown();
-    copyToClipboard(text);
-    info({
-      title: "Chat copied to clipboard",
-    });
-  };
-
-  const handleDownloadClick = () => {
-    const text = chat.toMarkdown();
-    download(text, "chat.md", "text/markdown");
-    info({
-      title: "Chat downloaded as Markdown",
-    });
-  };
-
-  const handleDeleteClick = () => {
-    fetcher.submit({}, { method: "post", action: `/c/${chat.id}/delete` });
-  };
 
   const handleSaveSummary = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -167,31 +139,6 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                 </Flex>
               )}
             </Box>
-
-            <Menu>
-              <MenuButton
-                as={IconButton}
-                aria-label="Chat Menu"
-                icon={<TbDots />}
-                variant="ghost"
-              />
-              <MenuList>
-                <MenuItem onClick={() => handleCopyChatClick()}>Copy</MenuItem>
-                <MenuItem onClick={() => handleDownloadClick()}>Download</MenuItem>
-
-                {!chat.readonly && settings.currentProvider.apiKey && (
-                  <>
-                    <MenuDivider />
-                    <MenuItem onClick={onOpen}>Share Chat...</MenuItem>
-
-                    <MenuDivider />
-                    <MenuItem color="red.400" onClick={() => handleDeleteClick()}>
-                      Delete
-                    </MenuItem>
-                  </>
-                )}
-              </MenuList>
-            </Menu>
           </Flex>
         </CardBody>
         <CardFooter pt={0}>

--- a/src/components/Menu/Menu.css
+++ b/src/components/Menu/Menu.css
@@ -47,7 +47,3 @@
 .szh-menu-container--theme-dark .szh-menu__item:active {
   background-color: var(--chakra-gray-500);
 }
-
-.delete-button {
-  color: var(--chakra-red-400);
-}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -26,11 +26,14 @@ const Menu: React.FC<MenuProps> = (props) => {
   return (
     <Box zIndex={theme.zIndices.dropdown}>
       <ReactMenu
-        {...props}
-        align={"end"}
-        theming={colorMode === "dark" ? "dark" : undefined}
-        menuButton={menuButton}
         transition={true}
+        theming={colorMode === "dark" ? "dark" : undefined}
+        {...props}
+        menuButton={menuButton}
+        menuStyle={{
+          minWidth: "225px",
+          ...props.menuStyle,
+        }}
       >
         {props.children}
       </ReactMenu>

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -26,6 +26,7 @@ const Menu: React.FC<MenuProps> = (props) => {
   return (
     <Box zIndex={theme.zIndices.dropdown}>
       <ReactMenu
+        {...props}
         align={"end"}
         theming={colorMode === "dark" ? "dark" : undefined}
         menuButton={menuButton}

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,8 +1,9 @@
 import { Box, IconButton, useColorMode } from "@chakra-ui/react";
 import { Menu as ReactMenu, type MenuProps as ReactMenuProps } from "@szhsin/react-menu";
-
 import React from "react";
 import { TbDots } from "react-icons/tb";
+
+import theme from "../../theme";
 
 // Stylesheets
 import "@szhsin/react-menu/dist/core.css";
@@ -13,23 +14,21 @@ import "./Menu.css";
 
 export type MenuProps = Omit<ReactMenuProps, "menuButton" | "theming" | "transition"> & {
   isDisabled?: boolean;
+  menuButton?: ReactMenuProps["menuButton"];
 };
 
 const Menu: React.FC<MenuProps> = (props) => {
   const { colorMode } = useColorMode();
+  const menuButton = props.menuButton ?? (
+    <IconButton aria-label="Menu" icon={<TbDots />} variant="ghost" isDisabled={props.isDisabled} />
+  );
+
   return (
-    <Box>
+    <Box zIndex={theme.zIndices.dropdown}>
       <ReactMenu
         align={"end"}
         theming={colorMode === "dark" ? "dark" : undefined}
-        menuButton={
-          <IconButton
-            aria-label="Message Menu"
-            icon={<TbDots />}
-            variant="ghost"
-            isDisabled={props.isDisabled}
-          />
-        }
+        menuButton={menuButton}
         transition={true}
       >
         {props.children}

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -4,15 +4,42 @@ import {
   type MenuItemProps as ReactMenuItemProps,
 } from "@szhsin/react-menu";
 import { Box } from "@chakra-ui/react";
+import { useTheme } from "@chakra-ui/react";
 
-export type MenuItemProps = ReactMenuItemProps & { icon?: ReactNode; iconSpacing?: number };
+export type MenuItemProps = Omit<ReactMenuItemProps, "disabled"> & {
+  icon?: ReactNode;
+  iconSpacing?: number;
+  isDisabled?: boolean;
+};
 
-const MenuItem: React.FC<MenuItemProps> = ({ icon, iconSpacing = 2, children, ...props }) => {
+const MenuItem: React.FC<MenuItemProps> = ({
+  icon,
+  iconSpacing = 2,
+  isDisabled,
+  children,
+  ...props
+}) => {
+  const theme = useTheme();
+
+  const toCssColor = (colorValue?: string) => {
+    if (!colorValue) {
+      return undefined;
+    }
+
+    // Check for ChakraUI colors vs normal CSS (e.g., "red.400")
+    if (!/\w+\.\d+/.test(colorValue)) {
+      return colorValue;
+    }
+
+    const [color, shade] = colorValue.split(".");
+    return theme.colors[color]?.[shade];
+  };
+
   return (
-    <ReactMenuItem {...props}>
+    <ReactMenuItem {...props} disabled={!!isDisabled} style={{ color: toCssColor(props.color) }}>
       <>
         {icon && (
-          <Box marginRight={iconSpacing} as={"span"}>
+          <Box marginRight={iconSpacing} as={"span"} color={props.color}>
             {icon}
           </Box>
         )}

--- a/src/components/Menu/MenuItemLink.tsx
+++ b/src/components/Menu/MenuItemLink.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { Link } from "@chakra-ui/react";
+import { Link as ReactRouterLink } from "react-router-dom";
+
+import MenuItem, { type MenuItemProps } from "./MenuItem";
+
+export type MenuItemLinkProps = MenuItemProps & {
+  to: string;
+  target?: string;
+};
+
+const MenuItemLink: React.FC<MenuItemLinkProps> = ({ to, target, children, ...props }) => {
+  return (
+    <Link as={ReactRouterLink} to={to} target={target} _hover={{ textDecoration: "none" }}>
+      <MenuItem {...props}>{children}</MenuItem>
+    </Link>
+  );
+};
+
+export default MenuItemLink;

--- a/src/components/Menu/SubMenu.tsx
+++ b/src/components/Menu/SubMenu.tsx
@@ -1,9 +1,41 @@
+import { Flex, useTheme, IconProps } from "@chakra-ui/react";
 import { SubMenu as ReactMenuSubMenu, type SubMenuProps } from "@szhsin/react-menu";
-import React from "react";
+import React, { type ReactElement } from "react";
 
-const SubMenu: React.FC<SubMenuProps> = (props) => {
+type ReactSubMenuProps = Omit<SubMenuProps, "label"> & {
+  label: string;
+  icon?: ReactElement<IconProps>;
+  iconSpacing?: number;
+};
+
+const SubMenu: React.FC<ReactSubMenuProps> = ({ color, label, icon, iconSpacing, ...props }) => {
+  const theme = useTheme();
+
+  const toCssColor = (colorValue?: string) => {
+    if (!colorValue) {
+      return undefined;
+    }
+
+    // Check for ChakraUI colors vs normal CSS (e.g., "red.400")
+    if (!/\w+\.\d+/.test(colorValue)) {
+      return colorValue;
+    }
+
+    const [color, shade] = colorValue.split(".");
+    return theme.colors[color]?.[shade];
+  };
   return (
-    <ReactMenuSubMenu align="center" {...props}>
+    <ReactMenuSubMenu
+      itemProps={{ style: { color: toCssColor(color) } }}
+      align="center"
+      {...props}
+      label={
+        <Flex gap={iconSpacing ?? 2} alignItems={"center"}>
+          {icon}
+          {label}
+        </Flex>
+      }
+    >
       {props.children}
     </ReactMenuSubMenu>
   );

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,4 +1,5 @@
 export { default as Menu } from "./Menu";
 export { default as MenuItem } from "./MenuItem";
+export { default as MenuItemLink } from "./MenuItemLink";
 export { default as SubMenu } from "./SubMenu";
 export { default as MenuDivider } from "./MenuDivider";

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -35,7 +35,7 @@ import {
 
 import { AiOutlineEdit } from "react-icons/ai";
 import { MdContentCopy } from "react-icons/md";
-import { TbShare2, TbTrash } from "react-icons/tb";
+import { TbShare2, TbTrash, TbDownload } from "react-icons/tb";
 import { Link as ReactRouterLink } from "react-router-dom";
 import ResizeTextarea from "react-textarea-autosize";
 import { Menu, MenuDivider, MenuItem, SubMenu } from "../Menu";
@@ -482,21 +482,21 @@ function MessageBase({
                   )}
                 </ButtonGroup>
               )}
-              <Menu isDisabled={isLoading}>
+              <Menu align="end" isDisabled={isLoading}>
                 <MenuItem onClick={handleCopy} icon={<MdContentCopy />}>
                   Copy
                 </MenuItem>
-                <SubMenu label="Download">
-                  <MenuItem onClick={handleDownloadMarkdown}>Download as Markdown</MenuItem>
-                  <MenuItem onClick={handleDownloadPlainText}>Download as Text</MenuItem>
+                <SubMenu label="Export" icon={<TbDownload />}>
+                  <MenuItem onClick={handleDownloadMarkdown}>Export as Markdown</MenuItem>
+                  <MenuItem onClick={handleDownloadPlainText}>Export as Text</MenuItem>
                   {isTtsSupported && (
-                    <MenuItem onClick={handleDownloadAudio}>Download as Audio</MenuItem>
+                    <MenuItem onClick={handleDownloadAudio}>Export as Audio</MenuItem>
                   )}
                   <MenuItem
                     onClick={handleDownloadImage}
                     isDisabled={displaySummaryText !== false || editing}
                   >
-                    Download as Image
+                    Export as Image
                   </MenuItem>
                 </SubMenu>
                 {isTtsSupported && (
@@ -544,7 +544,7 @@ function MessageBase({
                         Delete Message
                       </MenuItem>
                     ) : (
-                      <SubMenu label="Delete">
+                      <SubMenu label="Delete" color="red.400" icon={<TbTrash />}>
                         {onDeleteBeforeClick && (
                           <MenuItem
                             onClick={onDeleteBeforeClick}
@@ -555,12 +555,12 @@ function MessageBase({
                           </MenuItem>
                         )}
                         {onDeleteClick && (
-                          <MenuItem color="red.400" onClick={onDeleteClick} icon={<TbTrash />}>
+                          <MenuItem color="red.400" onClick={onDeleteClick}>
                             Delete Message
                           </MenuItem>
                         )}
                         {onDeleteAfterClick && (
-                          <MenuItem onClick={onDeleteAfterClick} color="red.400" icon={<TbTrash />}>
+                          <MenuItem onClick={onDeleteAfterClick} color="red.400">
                             Delete Messages After
                           </MenuItem>
                         )}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -38,7 +38,7 @@ import { MdContentCopy } from "react-icons/md";
 import { TbShare2, TbTrash, TbDownload } from "react-icons/tb";
 import { Link as ReactRouterLink } from "react-router-dom";
 import ResizeTextarea from "react-textarea-autosize";
-import { Menu, MenuDivider, MenuItem, SubMenu } from "../Menu";
+import { Menu, MenuDivider, MenuItem, MenuItemLink, SubMenu } from "../Menu";
 
 import { useCopyToClipboard } from "react-use";
 import { useAlert } from "../../hooks/use-alert";
@@ -507,11 +507,9 @@ function MessageBase({
                   </MenuItem>
                 )}
                 {!disableFork && (
-                  <MenuItem>
-                    <Link as={ReactRouterLink} to={`./fork/${id}`} target="_blank">
-                      Duplicate Chat until Message...
-                    </Link>
-                  </MenuItem>
+                  <MenuItemLink to={`./fork/${id}`} target="_blank">
+                    Duplicate Chat until Message...
+                  </MenuItemLink>
                 )}
                 {onRetryClick && (
                   <>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -494,7 +494,7 @@ function MessageBase({
                   )}
                   <MenuItem
                     onClick={handleDownloadImage}
-                    disabled={displaySummaryText !== false || editing}
+                    isDisabled={displaySummaryText !== false || editing}
                   >
                     Download as Image
                   </MenuItem>
@@ -540,31 +540,27 @@ function MessageBase({
                 {shouldShowDeleteMenu && (
                   <>
                     {onDeleteClick && !onDeleteBeforeClick && !onDeleteAfterClick ? (
-                      <MenuItem
-                        onClick={onDeleteClick}
-                        className="delete-button"
-                        icon={<TbTrash color="red.400" />}
-                      >
+                      <MenuItem onClick={onDeleteClick} color="red.400" icon={<TbTrash />}>
                         Delete Message
                       </MenuItem>
                     ) : (
-                      <SubMenu label="Delete" className="delete-button">
+                      <SubMenu label="Delete">
                         {onDeleteBeforeClick && (
-                          <MenuItem onClick={onDeleteBeforeClick} className="delete-button">
+                          <MenuItem
+                            onClick={onDeleteBeforeClick}
+                            color="red.400"
+                            icon={<TbTrash />}
+                          >
                             Delete Messages Before
                           </MenuItem>
                         )}
                         {onDeleteClick && (
-                          <MenuItem
-                            onClick={onDeleteClick}
-                            className="delete-button"
-                            icon={<TbTrash color="red.400" />}
-                          >
+                          <MenuItem color="red.400" onClick={onDeleteClick} icon={<TbTrash />}>
                             Delete Message
                           </MenuItem>
                         )}
                         {onDeleteAfterClick && (
-                          <MenuItem onClick={onDeleteAfterClick} className="delete-button">
+                          <MenuItem onClick={onDeleteAfterClick} color="red.400" icon={<TbTrash />}>
                             Delete Messages After
                           </MenuItem>
                         )}

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -1,5 +1,5 @@
-import { Button, IconButton, Input, Link, useDisclosure } from "@chakra-ui/react";
-import { Link as ReactRouterLink, useFetcher } from "react-router-dom";
+import { Button, IconButton, Input, useDisclosure } from "@chakra-ui/react";
+import { useFetcher } from "react-router-dom";
 import { TbShare2, TbTrash, TbCopy, TbDownload } from "react-icons/tb";
 import { PiGearBold } from "react-icons/pi";
 import { BsPaperclip } from "react-icons/bs";
@@ -13,7 +13,7 @@ import { useAlert } from "../hooks/use-alert";
 import { useSettings } from "../hooks/use-settings";
 import ShareModal from "./ShareModal";
 import { download, compressImageToBase64 } from "../lib/utils";
-import { Menu, MenuDivider, MenuItem, SubMenu } from "./Menu";
+import { Menu, MenuDivider, MenuItem, MenuItemLink, SubMenu } from "./Menu";
 
 function ShareMenuItem({ chat }: { chat?: ChatCraftChat }) {
   const supportsWebShare = !!navigator.share;
@@ -240,23 +240,17 @@ function OptionsButton({
         )
       }
     >
-      <MenuItem>
-        <Link as={ReactRouterLink} to="/new">
-          Clear
-        </Link>
-      </MenuItem>
-      <MenuItem>
-        <Link as={ReactRouterLink} to="/new" target="_blank">
-          New Window
-        </Link>
-      </MenuItem>
+      <MenuItemLink to="/new">Clear</MenuItemLink>
+      <MenuItemLink to="/new" target="_blank">
+        New Window
+      </MenuItemLink>
+
       {!!forkUrl && (
-        <MenuItem>
-          <Link as={ReactRouterLink} to={forkUrl} target="_blank">
-            Duplicate...
-          </Link>
-        </MenuItem>
+        <MenuItemLink to={forkUrl} target="_blank">
+          Duplicate...
+        </MenuItemLink>
       )}
+
       <MenuDivider />
       <SubMenu label="Copy" icon={<TbCopy />}>
         <MenuItem isDisabled={!chat} onClick={() => handleCopyAsMarkdown()}>

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -258,26 +258,26 @@ function OptionsButton({
         </MenuItem>
       )}
       <MenuDivider />
-      <SubMenu label="Copy">
-        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsMarkdown()}>
+      <SubMenu label="Copy" icon={<TbCopy />}>
+        <MenuItem isDisabled={!chat} onClick={() => handleCopyAsMarkdown()}>
           Copy as Markdown
         </MenuItem>
-        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsJson()}>
+        <MenuItem isDisabled={!chat} onClick={() => handleCopyAsJson()}>
           Copy as JSON
         </MenuItem>
-        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsYaml()}>
+        <MenuItem isDisabled={!chat} onClick={() => handleCopyAsYaml()}>
           Copy as YAML
         </MenuItem>
       </SubMenu>
-      <SubMenu label="Download">
-        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadMarkdown}>
-          Download as Markdown
+      <SubMenu label="Export" icon={<TbDownload />}>
+        <MenuItem isDisabled={!chat} onClick={handleDownloadMarkdown}>
+          Export as Markdown
         </MenuItem>
-        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadJson}>
-          Download as JSON
+        <MenuItem isDisabled={!chat} onClick={handleDownloadJson}>
+          Export as JSON
         </MenuItem>
-        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadYaml}>
-          Download as YAML
+        <MenuItem isDisabled={!chat} onClick={handleDownloadYaml}>
+          Export as YAML
         </MenuItem>
       </SubMenu>
       <ShareMenuItem chat={chat} />

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -187,8 +187,8 @@ function OptionsButton({
     const markdown = chat.toMarkdown();
     download(markdown, "message.md", "text/markdown");
     info({
-      title: "Downloaded",
-      message: "Chat was downloaded as a Markdown file",
+      title: "Exported",
+      message: "Chat was exported as a Markdown file",
     });
   }, [info, chat]);
 
@@ -201,8 +201,8 @@ function OptionsButton({
     const json = chat.toOpenAiFormat(model);
     download(JSON.stringify(json, null, 2), "chat.json", "application/json");
     info({
-      title: "Downloaded",
-      message: "Chat was downloaded as an OpenAI formatted JSON file",
+      title: "Exported",
+      message: "Chat was exported as an OpenAI formatted JSON file",
     });
   }, [info, settings, chat]);
 
@@ -215,8 +215,8 @@ function OptionsButton({
     const json = chat.toOpenAiFormat(model);
     download(yaml.stringify(json), "chat.yaml", "application/yaml");
     info({
-      title: "Downloaded",
-      message: "Chat was downloaded as an OpenAI formatted JSON file",
+      title: "Exported",
+      message: "Chat was exported as an OpenAI formatted YAML file",
     });
   }, [info, settings, chat]);
 

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -1,20 +1,11 @@
-import {
-  Button,
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem,
-  MenuDivider,
-  IconButton,
-  Input,
-  useDisclosure,
-} from "@chakra-ui/react";
+import { Button, IconButton, Input, Link, useDisclosure } from "@chakra-ui/react";
 import { Link as ReactRouterLink, useFetcher } from "react-router-dom";
 import { TbShare2, TbTrash, TbCopy, TbDownload } from "react-icons/tb";
 import { PiGearBold } from "react-icons/pi";
 import { BsPaperclip } from "react-icons/bs";
 import { useCallback, useRef } from "react";
 import { useCopyToClipboard } from "react-use";
+import * as yaml from "yaml";
 
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { useUser } from "../hooks/use-user";
@@ -22,7 +13,7 @@ import { useAlert } from "../hooks/use-alert";
 import { useSettings } from "../hooks/use-settings";
 import ShareModal from "./ShareModal";
 import { download, compressImageToBase64 } from "../lib/utils";
-import theme from "../theme";
+import { Menu, MenuDivider, MenuItem, SubMenu } from "./Menu";
 
 function ShareMenuItem({ chat }: { chat?: ChatCraftChat }) {
   const supportsWebShare = !!navigator.share;
@@ -142,30 +133,6 @@ function OptionsButton({
     fileInputRef.current?.click();
   }, [fileInputRef]);
 
-  const handleCopyClick = useCallback(() => {
-    if (!chat) {
-      return;
-    }
-
-    const text = chat.toMarkdown();
-    copyToClipboard(text);
-    info({
-      title: "Chat copied to clipboard",
-    });
-  }, [chat, copyToClipboard, info]);
-
-  const handleDownloadClick = useCallback(() => {
-    if (!chat) {
-      return;
-    }
-
-    const text = chat.toMarkdown();
-    download(text, "chat.md", "text/markdown");
-    info({
-      title: "Chat downloaded as Markdown",
-    });
-  }, [chat, info]);
-
   const handleDeleteClick = useCallback(() => {
     if (!chat) {
       return;
@@ -174,76 +141,173 @@ function OptionsButton({
     fetcher.submit({}, { method: "post", action: `/c/${chat.id}/delete` });
   }, [chat, fetcher]);
 
+  const handleCopyAsMarkdown = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const markdown = chat.toMarkdown();
+    copyToClipboard(markdown);
+    info({
+      title: "Chat copied to clipboard as Markdown",
+    });
+  }, [chat, copyToClipboard, info]);
+
+  const handleCopyAsJson = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const model = settings.model.name;
+    const json = chat.toOpenAiFormat(model);
+    copyToClipboard(JSON.stringify(json, null, 2));
+    info({
+      title: "Chat copied to clipboard as JSON",
+    });
+  }, [chat, settings, copyToClipboard, info]);
+
+  const handleCopyAsYaml = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const model = settings.model.name;
+    const json = chat.toOpenAiFormat(model);
+    copyToClipboard(yaml.stringify(json));
+    info({
+      title: "Chat copied to clipboard as YAML",
+    });
+  }, [chat, settings, copyToClipboard, info]);
+
+  const handleDownloadMarkdown = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const markdown = chat.toMarkdown();
+    download(markdown, "message.md", "text/markdown");
+    info({
+      title: "Downloaded",
+      message: "Chat was downloaded as a Markdown file",
+    });
+  }, [info, chat]);
+
+  const handleDownloadJson = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const model = settings.model.name;
+    const json = chat.toOpenAiFormat(model);
+    download(JSON.stringify(json, null, 2), "chat.json", "application/json");
+    info({
+      title: "Downloaded",
+      message: "Chat was downloaded as an OpenAI formatted JSON file",
+    });
+  }, [info, settings, chat]);
+
+  const handleDownloadYaml = useCallback(() => {
+    if (!chat) {
+      return;
+    }
+
+    const model = settings.model.name;
+    const json = chat.toOpenAiFormat(model);
+    download(yaml.stringify(json), "chat.yaml", "application/yaml");
+    info({
+      title: "Downloaded",
+      message: "Chat was downloaded as an OpenAI formatted JSON file",
+    });
+  }, [info, settings, chat]);
+
   return (
-    <Menu strategy="fixed">
-      {iconOnly ? (
-        <MenuButton
-          isDisabled={isDisabled}
-          as={IconButton}
-          size="lg"
-          variant="outline"
-          icon={<PiGearBold />}
-          isRound
-        />
-      ) : (
-        <MenuButton
-          isDisabled={isDisabled}
-          as={Button}
-          size="sm"
-          variant={variant}
-          leftIcon={<PiGearBold />}
-        >
-          Options
-        </MenuButton>
-      )}
-      <MenuList zIndex={theme.zIndices.dropdown}>
-        <MenuItem as={ReactRouterLink} to="/new">
+    <Menu
+      isDisabled={isDisabled}
+      menuButton={
+        iconOnly ? (
+          <IconButton
+            aria-label="Options menu"
+            isDisabled={isDisabled}
+            size="lg"
+            variant="outline"
+            icon={<PiGearBold />}
+            isRound
+          />
+        ) : (
+          <Button isDisabled={isDisabled} size="sm" variant={variant} leftIcon={<PiGearBold />}>
+            Options
+          </Button>
+        )
+      }
+    >
+      <MenuItem>
+        <Link as={ReactRouterLink} to="/new">
           Clear
-        </MenuItem>
-        <MenuItem as={ReactRouterLink} to="/new" target="_blank">
+        </Link>
+      </MenuItem>
+      <MenuItem>
+        <Link as={ReactRouterLink} to="/new" target="_blank">
           New Window
-        </MenuItem>
-        {!!forkUrl && (
-          <MenuItem as={ReactRouterLink} to={forkUrl} target="_blank">
+        </Link>
+      </MenuItem>
+      {!!forkUrl && (
+        <MenuItem>
+          <Link as={ReactRouterLink} to={forkUrl} target="_blank">
             Duplicate...
-          </MenuItem>
-        )}
-        <MenuDivider />
-        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyClick()}>
-          Copy
+          </Link>
         </MenuItem>
-        <MenuItem icon={<TbDownload />} isDisabled={!chat} onClick={() => handleDownloadClick()}>
-          Download
+      )}
+      <MenuDivider />
+      <SubMenu label="Copy">
+        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsMarkdown()}>
+          Copy as Markdown
         </MenuItem>
-        <ShareMenuItem chat={chat} />
-        <MenuDivider />
-        {!!onFileSelected && (
-          <>
-            <Input
-              multiple
-              type="file"
-              ref={fileInputRef}
-              hidden
-              onChange={handleFileChange}
-              accept="image/*"
-            />
-            <MenuItem icon={<BsPaperclip />} onClick={handleAttachFiles}>
-              Attach Files...
-            </MenuItem>
-            <MenuDivider />
-          </>
-        )}
-        {!chat?.readonly && (
-          <MenuItem
-            color="red.400"
-            icon={<TbTrash />}
-            isDisabled={!chat}
-            onClick={() => handleDeleteClick()}
-          >
-            Delete Chat
+        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsJson()}>
+          Copy as JSON
+        </MenuItem>
+        <MenuItem isDisabled={!chat} icon={<TbCopy />} onClick={() => handleCopyAsYaml()}>
+          Copy as YAML
+        </MenuItem>
+      </SubMenu>
+      <SubMenu label="Download">
+        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadMarkdown}>
+          Download as Markdown
+        </MenuItem>
+        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadJson}>
+          Download as JSON
+        </MenuItem>
+        <MenuItem isDisabled={!chat} icon={<TbDownload />} onClick={handleDownloadYaml}>
+          Download as YAML
+        </MenuItem>
+      </SubMenu>
+      <ShareMenuItem chat={chat} />
+      <MenuDivider />
+      {!!onFileSelected && (
+        <>
+          <Input
+            multiple
+            type="file"
+            ref={fileInputRef}
+            hidden
+            onChange={handleFileChange}
+            accept="image/*"
+          />
+          <MenuItem icon={<BsPaperclip />} onClick={handleAttachFiles}>
+            Attach Files...
           </MenuItem>
-        )}
-      </MenuList>
+          <MenuDivider />
+        </>
+      )}
+      {!chat?.readonly && (
+        <MenuItem
+          color="red.400"
+          icon={<TbTrash />}
+          isDisabled={!chat}
+          onClick={() => handleDeleteClick()}
+        >
+          Delete Chat
+        </MenuItem>
+      )}
     </Menu>
   );
 }

--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -302,6 +302,13 @@ export class ChatCraftChat {
     });
   }
 
+  toOpenAiFormat(model: string): { messages: { role: string; content: string }[]; model: string } {
+    return {
+      messages: this._messages.map((message) => ({ role: message.type, content: message.text })),
+      model,
+    };
+  }
+
   toJSON(): SerializedChatCraftChat {
     return {
       id: this.id,


### PR DESCRIPTION
This is the export part of #607.  I'm not sure what the right UX is for import...

The PR adds support for exporting (download or copy) a chat as OpenAI formatted JSON and YAML:

<img width="1178" alt="Screenshot 2024-04-21 at 1 17 59 PM" src="https://github.com/tarasglek/chatcraft.org/assets/427398/3be21d47-3580-436f-a858-e4e3e7a9e169">

I've removed the Chat Header menu, since we do everything and more via the Options button/menu now.

I've fixed our custom Menu components to work better with Chakra colors, zIndex, naming for `isDisabled` prop, passing your own menu button, etc. and reworked the other users of it.