### PR TITLE
hotfix icon for unknown models

### DIFF
--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -20,7 +20,7 @@ export class ChatCraftModel {
   get logoUrl() {
     const vendor = this.vendor;
 
-    if (vendor === "openai") {
+    if (vendor === "openai" && this.name.includes("gpt")) {
       return "/openai-logo.png";
     }
 


### PR DESCRIPTION
I tried to fixed similar issue in #564 for `Free AI Models` and not covered all situations, my bad 😢 
I should have added the second check `this.name.includes("gpt")` in the `src/lib/ChatCraftModel.ts`

```
    if (vendor === "openai" && this.name.includes("gpt")) {
      return "/openai-logo.png";
    }
```

## Results

(Bg color is fixed for same name.)
 
 <img width="166" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/aef8e0b0-2055-413f-bb08-a9680840698b">

<img width="187" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/d98ec1ad-e460-4279-b338-b6d774e1dc05">
<img width="190" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/b7169ca4-f100-4b63-a648-1b0c93387ed9">
<img width="185" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/01a26302-72b5-4824-94c1-b000cb32fc5a">
<img width="213" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/133393905/394bb5c1-ebc7-49cc-819b-7a1d3e1e0393">



Though more work needed to have better looking as described in issue #611.