### PR TITLE
Fix PasswordInput padding and color issues

### DIFF
--- a/src/components/Message/AppMessage/Instructions.tsx
+++ b/src/components/Message/AppMessage/Instructions.tsx
@@ -165,10 +165,6 @@ function Instructions(props: MessageBaseProps) {
                   size={"md"}
                   bg="white"
                   _dark={{ bg: "gray.700" }}
-                  style={{
-                    color:
-                      selectedProvider instanceof FreeModelProvider ? "transparent" : "initial",
-                  }}
                   isDisabled={selectedProvider instanceof FreeModelProvider}
                   value={selectedProvider.apiKey || ""}
                   onChange={handleApiKeyChange}

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -11,7 +11,7 @@ function PasswordInput({
   isInvalid,
   size = "sm",
   buttonSize = "sm",
-  paddingRight = "4.5rem",
+  paddingRight = "2.5rem",
   ...props
 }: PasswordInputProps) {
   const [show, setShow] = useState(false);

--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -658,7 +658,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                         <PasswordInput
                           size="sm"
                           buttonSize="xs"
-                          paddingRight={"2.5rem"}
+                          paddingRight={"2rem"}
                           paddingLeft={"0.5rem"}
                           fontSize="xs"
                           value={newCustomProvider.apiKey || ""}
@@ -733,7 +733,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                               <PasswordInput
                                 size="sm"
                                 buttonSize="xs"
-                                paddingRight={"2.5rem"}
+                                paddingRight={"2rem"}
                                 paddingLeft={"0.5rem"}
                                 fontSize="xs"
                                 value={provider.apiKey || ""}


### PR DESCRIPTION
#584 introduced a bug in `InstructionsPage` where text colour of `PasswordInput` is black even in dark mode.

In this PR, I have fixed that bug and also tweaked some padding settings on this component to better fit dimensions after the eye icon replacement.

**Dark Mode:**
<img width="801" alt="image" src="https://github.com/tarasglek/chatcraft.org/assets/78865303/6549115d-ac66-4bfc-89f3-da8860713d92">

This fixes #609 