### PR TITLE
Clear regular prompt message if using Re-Ask Option

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -202,7 +202,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   // Handle prompt form submission
   const onPrompt = useCallback(
-    async (prompt?: string, imageUrls?: string[]) => {
+    async (prompt?: string, imageUrls?: string[], retry: boolean = false) => {
       setLoading(true);
 
       // Special-case for "help", to invoke /help command

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -271,6 +271,10 @@ function ChatBase({ chat }: ChatBaseProps) {
       // Not a slash command, so pass this prompt to LLM
       let promptMessage: ChatCraftHumanMessage | undefined;
       try {
+        // If retrying, set the prompt to null to avoid duplicate message
+        if (retry) {
+          prompt = "";
+        }
         // If the prompt text exist, package it up as a human message and add to the chat
         if (prompt) {
           // Add this prompt message to the chat

--- a/src/components/MessagesView.tsx
+++ b/src/components/MessagesView.tsx
@@ -22,7 +22,7 @@ type MessagesViewProps = {
   isPaused: boolean;
   onTogglePause: () => void;
   onCancel: () => void;
-  onPrompt: (prompt?: string) => void;
+  onPrompt: (prompt?: string, imageUrls?: string[], retry?: boolean) => void;
 };
 
 function MessagesView({
@@ -99,7 +99,7 @@ function MessagesView({
           isLoading={isLoading}
           onResubmitClick={async (promptText?: string) => {
             await deleteMessages(message.id, "after");
-            onPrompt(promptText);
+            onPrompt(promptText, undefined, true); // pass prompt text and true for retry, don't include any imageURLs
           }}
           onDeleteBeforeClick={
             hasMessagesBefore ? () => deleteMessages(message.id, "before") : undefined


### PR DESCRIPTION
This fixes #587 

Background
---

7cc1e2f3ec1aaf77014a56703d7d8e77c706f72d allowed web handlers and slash commands to be executed with the Re-ask option (issue described in #541) by passing the prompt text to the **onPrompt** call in **MessagesView::onResubmitClick()**.

Before this change, retrying with a regular prompt message would trigger the regular re-try routine (since the prompt text **wasn't passed** to the **onPrompt** call in **MessagesView::onResubmitClick()**:
https://github.com/tarasglek/chatcraft.org/blob/9f73deac651f7caa6144e905e326d72a543db002/src/Chat/ChatBase.tsx#L283-L297

**After this change however,** if re-asking with a regular prompt message, the updated message will be passed to **onPrompt** (as **prompt**) and add a **duplicate message** to the chat (line 278):
https://github.com/tarasglek/chatcraft.org/blob/9f73deac651f7caa6144e905e326d72a543db002/src/Chat/ChatBase.tsx#L275-L278

Changes
---

I added a **boolean** parameter to **ChatBase::onPrompt** called `retry` (**false** by default):
```tsx
    async (prompt?: string, imageUrls?: string[], retry: boolean = false) => {
      // ...
      try {
        // If retrying, set the prompt to null to avoid duplicate message
        if (retry) {
          prompt = "";
        }
        // If the prompt text exist, package it up as a human message and add to the chat
        // ...
```
If `retry` is True, the prompt will be cleared to prevent message duplication.

`retry` is False **by default** because I only want to explicitly set it to True when calling **onPrompt()** from **onResubmitClick()**:
```tsx
type MessagesViewProps = {
  // ...
  onPrompt: (prompt?: string, imageUrls?: string[], retry?: boolean) => void;
};
// ... 

function MessagesView({
          onResubmitClick={async (promptText?: string) => {
            await deleteMessages(message.id, "after");
            onPrompt(promptText, undefined, true); // pass prompt text and true for retry, don't include any imageURLs
          }}
          // ...
        })
```

I had to update the onPrompt signature in MessagesViewProps for syntax reasons. If there's a better way to implement this I'm open to suggestions.

Comparison to Production
---

Below are the observations I've made on the Re-Ask options **before** and **after** 7cc1e2f3ec1aaf77014a56703d7d8e77c706f72d, as well as for this Pull Request:

| Task | Observations pre- 7cc1e2f3ec1aaf77014a56703d7d8e77c706f72d (tested using adcfd2d44c63447e6c9c5cfbd42c91e15116f990) | Observations post- 7cc1e2f3ec1aaf77014a56703d7d8e77c706f72d (tested using Production as of e4967a99b4cb7a6478ad5d10c738c3763ffdb126) (Prompt duplication bug observed) | PR Observations |
| --- | --- | --- | --- |
| Ask with "help" (to invoke /help) | Executes /help command  | Executes /help command | Executes /help command | 
| Re-ask with "help" (to invoke /help)     | Response from LLM **(undesired)** | Executes /help command  | Executes /help command | 
| Ask with web handler | Executes web handler | Executes web handler  | Executes web handler  | 
| Re-ask with web handler | Response from LLM **(undesired)** | Executes web handler  | Executes web handler  | 
| Ask with slash command (/import) | Invokes /import | Invokes /import | Invokes /import |
| Re-ask with slash command (/import) | Response from LLM **(undesired)** | Invokes /import | Invokes /import |
| Ask with regular prompt | Response from LLM | Response from LLM | Response from LLM |
| Re-ask with regular prompt | Response from LLM  | Response from LLM, **duplicates new message (undesired)** | Response from LLM, **no message duplication**|

My PR preserves the changes from 7cc1e2f3ec1aaf77014a56703d7d8e77c706f72d but prevent the message duplication when re-trying with a regular prompt message.