### PR TITLE
Extend ImportCommand to fetch error messages from CloudFlare Worker error pages

### DIFF
--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -60,7 +60,7 @@ export class ImportCommand extends ChatCraftCommand {
         // Parse the HTML string into a Document object
         const doc = parser.parseFromString(content, "text/html");
         // Extract error message
-        const errorMessage = doc.getElementsByClassName("error-message")[0].innerHTML;
+        const errorMessage = doc.getElementsByClassName("error-message")[0].innerHTML.trim();
         throw new Error(`${errorMessage}`);
       } else {
         throw new Error(`Unable to proxy request for URL: ${res.statusText}`);

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -59,9 +59,9 @@ export class ImportCommand extends ChatCraftCommand {
         const parser = new DOMParser();
         // Parse the HTML string into a Document object
         const doc = parser.parseFromString(content, "text/html");
-        // Extract error message
-        const errorMessage = doc.getElementsByClassName("error-message")[0].innerHTML.trim();
-        throw new Error(`${errorMessage}`);
+        // Try to extract CloudFlare error message from HTML
+        const errorMessage = doc.querySelector(".error-message")?.innerHTML?.trim();
+        throw new Error(errorMessage ?? `Unable to proxy request for URL: ${res.statusText}`);
       } else {
         throw new Error(`Unable to proxy request for URL: ${res.statusText}`);
       }

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -1,7 +1,7 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
-import { load } from "cheerio";
+
 // To keep this small, just deal with some common cases vs doing proper parser/list
 const guessType = (contentType: string | null) => {
   if (!contentType) {
@@ -55,10 +55,12 @@ export class ImportCommand extends ChatCraftCommand {
     if (!res.ok) {
       // If res.text() is a CloudFlare Worker error page (HTML), extract the error message
       if (type === "html") {
-        // Load HTML content using Cheerio
-        const htmlContent = load(content);
-        // Error message located in 'error-message'
-        const errorMessage = htmlContent(".error-message").html();
+        // Create a new DOMParser instance
+        const parser = new DOMParser();
+        // Parse the HTML string into a Document object
+        const doc = parser.parseFromString(content, "text/html");
+        // Extract error message
+        const errorMessage = doc.getElementsByClassName("error-message")[0].innerHTML;
         throw new Error(`${errorMessage}`);
       } else {
         throw new Error(`Unable to proxy request for URL: ${res.statusText}`);


### PR DESCRIPTION
This fixes #605

Background
---
Currently, if you use /import with a Youtube video that either has no captions or English subtitles, ChatCraft will throw this Error Toast:

![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/d39a8d78-eadd-406e-824d-1cfe582e6f7f)

This Error Toast isn't very descriptive.

When /import successfully parses YouTube video captions, `res.text()` returns the actual content that populates the Message:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/4bf1eb2f-cdca-4b8b-8654-9b953f1c67e4).

However, **if /import** (when using [youtube-captions-scraper](https://github.com/algolia/youtube-captions-scraper/tree/master)) fails to do so (either due to [no captions in specified language](https://github.com/algolia/youtube-captions-scraper/blob/394ce9d61d2d2166f92ac394fa678c705e94fac8/src/index.js#L47-L49) or [no captions at all](https://github.com/algolia/youtube-captions-scraper/blob/394ce9d61d2d2166f92ac394fa678c705e94fac8/src/index.js#L30-L32)), **res.text() returns the HTML of a CloudFlare Worker error page**:

![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/4ee6082d-e3d3-4eee-b454-1dd0a10a2d84)

We only want the actual error message, nested inside the html content:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/e94faf3e-0368-4909-9fb6-971d038b5061)

Solution
---

I tried modifying the error handling in [youtube-rewriter.ts](https://github.com/tarasglek/chatcraft.org/blob/main/functions/lib/rewriters/youtube-rewriter.ts) and in [proxy.ts](https://github.com/tarasglek/chatcraft.org/blob/main/functions/api/proxy.ts) (API handler for /import command) so **res.text()** would contain just the error message, but it seems no matter what I did, a bad response would always return HTML in **res.text()**.

Instead, I decided to use [Cheerio](https://github.com/cheeriojs/cheerio) (already installed) to extract the error message from any bad responses that have an HTML type. I kept the old error message in case other error responses don't contain HTML.

The result is that if /import fails on a YouTube video, the user will get a useful Error Toast telling them why:
**No English captions (https://www.youtube.com/watch?v=y6120QOlsfU)**:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/9b7650b9-6d88-4351-bf59-1c121c6078c4)

**No captions at all (https://www.youtube.com/watch?v=TKfS5zVfGBc)**:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/b49709ad-75bc-4d00-a289-b42d8a4fc22a)
