### PR TITLE
Fix "Show More..." twice in system prompt

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -140,7 +140,7 @@ function MessageBase({
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
   const isSystemMessage = message instanceof ChatCraftSystemMessage;
   const isLongMessage =
-    text.length > 5000 || (isSystemMessage && text.length > summaryText!.length);
+    text.length > 5000 || (isSystemMessage && text.length > (summaryText ?? "").length);
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
   const shouldShowDeleteMenu =
     Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -138,7 +138,9 @@ function MessageBase({
   const [imageModalOpen, setImageModalOpen] = useState<boolean>(false);
   const [selectedImage, setSelectedImage] = useState<string>("");
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
-  const isLongMessage = text.length > 5000;
+  const isSystemMessage = message instanceof ChatCraftSystemMessage;
+  const isLongMessage =
+    text.length > 5000 || (isSystemMessage && text.length > summaryText!.length);
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
   const shouldShowDeleteMenu =
     Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;
@@ -659,11 +661,28 @@ function MessageBase({
                   >
                     {displaySummaryText ? summaryText || text.slice(0, 500).trim() : text}
                   </Markdown>
-                  {isLongMessage ? (
-                    <Button zIndex={10} size="sm" variant="ghost" onClick={() => onToggle()}>
+                  <Flex w="100%" justify="space-between" align="center">
+                    <Button
+                      hidden={!isLongMessage || editing}
+                      zIndex={10}
+                      size="sm"
+                      variant="ghost"
+                      onClick={() => onToggle()}
+                    >
                       {isOpen ? "Show Less" : "Show More..."}
                     </Button>
-                  ) : undefined}
+                    <Button
+                      hidden={!!disableEdit || !isSystemMessage}
+                      size="sm"
+                      variant="ghost"
+                      ml="auto"
+                      onClick={() => onEditingChange(true)}
+                    >
+                      <Text fontSize="xs" as="em">
+                        Edit to customize
+                      </Text>
+                    </Button>
+                  </Flex>
                 </Box>
               )}
             </Box>

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -140,7 +140,7 @@ function MessageBase({
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
   const isSystemMessage = message instanceof ChatCraftSystemMessage;
   const isLongMessage =
-    text.length > 5000 || (isSystemMessage && text.length > (summaryText ?? "").length);
+    text.length > 5000 || (isSystemMessage && summaryText && text.length > summaryText.length);
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
   const shouldShowDeleteMenu =
     Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -1,7 +1,6 @@
 import { memo } from "react";
 import {
   Avatar,
-  Button,
   Container,
   Divider,
   Flex,
@@ -11,7 +10,6 @@ import {
   MenuItem,
   MenuList,
   Text,
-  useDisclosure,
 } from "@chakra-ui/react";
 import { useLiveQuery } from "dexie-react-hooks";
 import { TbChevronDown, TbStar, TbStarFilled } from "react-icons/tb";
@@ -137,8 +135,7 @@ type SystemMessageProps = Omit<MessageBaseProps, "avatar" | "message"> & {
 };
 
 function SystemMessage(props: SystemMessageProps) {
-  const { chatId, message, disableEdit, editing, onEditingChange } = props;
-  const { isOpen, onToggle } = useDisclosure();
+  const { chatId, message } = props;
   const summaryText = createSystemPromptSummary(message);
   const { error } = useAlert();
 
@@ -152,38 +149,6 @@ function SystemMessage(props: SystemMessageProps) {
       _dark={{ borderColor: "gray.600" }}
     />
   );
-
-  // If we're showing the whole prompt, don't bother with the "More..." button
-  const footer =
-    message.text.length > summaryText.length ? (
-      !editing && (
-        <Flex w="100%" justify="space-between" align="center">
-          <Button size="sm" variant="ghost" onClick={() => onToggle()}>
-            {isOpen ? "Show Less" : "Show More..."}
-          </Button>
-          <Button
-            hidden={!!disableEdit}
-            size="sm"
-            variant="ghost"
-            onClick={() => onEditingChange(true)}
-          >
-            <Text fontSize="xs" as="em">
-              Edit to customize
-            </Text>
-          </Button>
-        </Flex>
-      )
-    ) : (
-      <Flex w="100%" justify="flex-end" align="center">
-        {!editing && (
-          <Button size="sm" variant="ghost" onClick={() => onEditingChange(true)}>
-            <Text fontSize="xs" as="em">
-              Edit to customize
-            </Text>
-          </Button>
-        )}
-      </Flex>
-    );
 
   const handleSystemPromptVersionChange = (systemPrompt: string) => {
     message.text = systemPrompt;
@@ -207,8 +172,7 @@ function SystemMessage(props: SystemMessageProps) {
           promptMessage={message}
         />
       }
-      summaryText={!isOpen ? summaryText : undefined}
-      footer={footer}
+      summaryText={summaryText}
     />
   );
 }


### PR DESCRIPTION
## Explanation

Update `isLongMessage` when message is system prompt.
Get rid of the system prompt "Show More..." logic and merge the "Edit to customize" logic.

## Result 

[long message chat](https://mingming-issue-621.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/HHriR2E7qUbH5qdBCXx1e)

[general chat](https://mingming-issue-621.console-overthinker-dev.pages.dev/api/share/chatcraft_dev/MhLcrMYaUiPqrL3h6dJJ5)

Fixes #621 