### PR TITLE
Update youtube-rewriter error handling to pass captioning errors as ChatCraft message

### DIFF
--- a/functions/lib/rewriters/youtube-rewriter.ts
+++ b/functions/lib/rewriters/youtube-rewriter.ts
@@ -28,20 +28,26 @@ export class YouTubeRewriter extends DefaultRewriter {
   }
 
   async fetchData(url: URL) {
-    const videoInfo = getVideoId(url.href);
-    if (!videoInfo.id) {
-      throw new Error(`Unable to parse YouTube video ID from URL ${url.href}`);
-    }
+    try {
+      const videoInfo = getVideoId(url.href);
+      if (!videoInfo.id) {
+        throw new Error(`Unable to parse YouTube video ID from URL ${url.href}`);
+      }
 
-    const videoId = videoInfo.id;
-    // TODO: could allow passing lang so we can pass to getSubtitles
-    const captions: WebVTTCaption[] = await getSubtitles({ videoID: videoInfo.id, lang: "en" });
-    const text = `[![http://www.youtube.com/watch?v=${videoId}](http://img.youtube.com/vi/${videoId}/0.jpg)](http://www.youtube.com/watch?v=${videoId})
+      const videoId = videoInfo.id;
+      // TODO: could allow passing lang so we can pass to getSubtitles
+      const captions: WebVTTCaption[] = await getSubtitles({ videoID: videoInfo.id, lang: "en" });
+      const text = `[![http://www.youtube.com/watch?v=${videoId}](http://img.youtube.com/vi/${videoId}/0.jpg)](http://www.youtube.com/watch?v=${videoId})
 
 ${combineCaptions(captions.map(({ text }) => text?.trim() ?? ""))}`;
 
-    return new Response(text, {
-      headers: { "Content-Type": "text/markdown; charset=UTF-8" },
-    });
+      return new Response(text, {
+        headers: { "Content-Type": "text/markdown; charset=UTF-8" },
+      });
+    } catch (error) {
+      return new Response(`**Error**: ${error?.message}`, {
+        headers: { "Content-Type": "text/markdown; charset=UTF-8" },
+      });
+    }
   }
 }

--- a/functions/lib/rewriters/youtube-rewriter.ts
+++ b/functions/lib/rewriters/youtube-rewriter.ts
@@ -45,7 +45,7 @@ ${combineCaptions(captions.map(({ text }) => text?.trim() ?? ""))}`;
         headers: { "Content-Type": "text/markdown; charset=UTF-8" },
       });
     } catch (error) {
-      return new Response(`**Error**: ${error?.message}`, {
+      return new Response(`Error: ${error?.message}`, {
         headers: { "Content-Type": "text/markdown; charset=UTF-8" },
       });
     }


### PR DESCRIPTION
This fixes #605 

Background
---

If you use /import with a Youtube video that either has no English captions or no captions at all, ChatCraft will throw a non-descriptive error toast:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/5b5a7814-4faf-4adb-9233-5e460bb81d4b)

Caption extraction for YouTube videos is handled by [youtube-captions-scraper](https://github.com/algolia/youtube-captions-scraper/tree/master) within [functions/lib/rewriters/youtube-rewriter.ts](https://github.com/tarasglek/chatcraft.org/blob/ad93ffccbee020f1df97036bb9a7c05bba533d39/functions/lib/rewriters/youtube-rewriter.ts).

A previous PR for this (#618) would extract unhandled error messages from the HTML of a generated CloudFlare Pages page and put it inside an Error Toast.

Fix
---

In this PR, any errors thrown in youtube-rewriter will show up in the **/import** Response (as a ChatCraft message):
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/99c5e045-cdce-4354-9a61-ef0e67f479aa)
