### PR TITLE
Add custom progress alert and integrate with export as audio

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -249,10 +249,18 @@ function MessageBase({
     if (messageContent.current) {
       const text = messageContent.current.textContent;
       if (text) {
+        let cancelled = false;
+
+        const handleClose = () => {
+          limit.clearQueue();
+          cancelled = true;
+        };
+
         const alertId = progress({
           title: "Downloading...",
           message: "Please wait while we prepare your audio download.",
           progressPercentage: 0,
+          handleClose,
         });
 
         // Limit the number of concurrent tasks
@@ -285,6 +293,7 @@ function MessageBase({
                 message: "Please wait while we prepare your audio download.",
                 progressPercentage: processedPercentage,
                 updateOnly: true,
+                handleClose,
               });
             });
           });
@@ -294,17 +303,20 @@ function MessageBase({
 
           const audioClip = new Blob(audioClips, { type: audioClips[0].type });
 
-          download(
-            audioClip,
-            `${settings.currentProvider.name}_message.${audioClip.type.split("/")[1]}`,
-            audioClip.type
-          );
+          if (!cancelled) {
+            download(
+              audioClip,
+              `${settings.currentProvider.name}_message.${audioClip.type.split("/")[1]}`,
+              audioClip.type
+            );
 
-          closeToast(alertId);
-          info({
-            title: "Downloaded",
-            message: "Message was downloaded as Audio",
-          });
+            closeToast(alertId);
+
+            info({
+              title: "Downloaded",
+              message: "Message was downloaded as Audio",
+            });
+          }
         } catch (err: any) {
           console.error(err);
 

--- a/src/components/ProgressToast.tsx
+++ b/src/components/ProgressToast.tsx
@@ -1,0 +1,30 @@
+import { Flex, Progress, Text, useColorModeValue } from "@chakra-ui/react";
+import { AlertArguments } from "../hooks/use-alert";
+
+type ProgressAlertArguements = AlertArguments & {
+  progressPercentage: number;
+};
+
+function ProgressToast({ title, message, progressPercentage }: ProgressAlertArguements) {
+  return (
+    <Flex
+      bgColor={useColorModeValue("blue.600", "blue.200")}
+      color={useColorModeValue("white", "black")}
+      p={3}
+      gap={1}
+      flexDirection={"column"}
+      justifyContent={"center"}
+      rounded={"md"}
+    >
+      <Text as={"h2"} fontSize={"md"} fontWeight={"bold"}>
+        {title}
+      </Text>
+
+      {message && <Text>{message}</Text>}
+
+      <Progress variant={"ghost"} value={progressPercentage} size="xs" colorScheme="gray" />
+    </Flex>
+  );
+}
+
+export default ProgressToast;

--- a/src/components/ProgressToast.tsx
+++ b/src/components/ProgressToast.tsx
@@ -3,9 +3,15 @@ import { AlertArguments } from "../hooks/use-alert";
 
 type ProgressAlertArguements = AlertArguments & {
   progressPercentage: number;
+  showPercentage: boolean;
 };
 
-function ProgressToast({ title, message, progressPercentage }: ProgressAlertArguements) {
+function ProgressToast({
+  title,
+  message,
+  progressPercentage,
+  showPercentage,
+}: ProgressAlertArguements) {
   return (
     <Flex
       bgColor={useColorModeValue("blue.500", "blue.200")}
@@ -28,16 +34,20 @@ function ProgressToast({ title, message, progressPercentage }: ProgressAlertArgu
       </Flex>
 
       {/* The 'css' hack is to animate the progress bar as value changes */}
-      <Progress
-        value={progressPercentage}
-        size="xs"
-        colorScheme="whatsapp"
-        css={{
-          "> div:first-of-type": {
-            transition: "width 500ms ease-in-out",
-          },
-        }}
-      />
+      <Flex alignItems={"center"} gap={2}>
+        {showPercentage && <Text>{progressPercentage}%</Text>}
+        <Progress
+          flexGrow={1}
+          value={progressPercentage}
+          size="xs"
+          colorScheme="whatsapp"
+          css={{
+            "> div:first-of-type": {
+              transition: "width 500ms ease-in-out",
+            },
+          }}
+        />
+      </Flex>
     </Flex>
   );
 }

--- a/src/components/ProgressToast.tsx
+++ b/src/components/ProgressToast.tsx
@@ -1,4 +1,4 @@
-import { Flex, Progress, Text, useColorModeValue } from "@chakra-ui/react";
+import { Box, CircularProgress, Flex, Progress, Text, useColorModeValue } from "@chakra-ui/react";
 import { AlertArguments } from "../hooks/use-alert";
 
 type ProgressAlertArguements = AlertArguments & {
@@ -8,21 +8,36 @@ type ProgressAlertArguements = AlertArguments & {
 function ProgressToast({ title, message, progressPercentage }: ProgressAlertArguements) {
   return (
     <Flex
-      bgColor={useColorModeValue("blue.600", "blue.200")}
+      bgColor={useColorModeValue("blue.500", "blue.200")}
       color={useColorModeValue("white", "black")}
       p={3}
-      gap={1}
+      gap={5}
       flexDirection={"column"}
       justifyContent={"center"}
       rounded={"md"}
     >
-      <Text as={"h2"} fontSize={"md"} fontWeight={"bold"}>
-        {title}
-      </Text>
+      <Flex alignItems={"center"} gap={5}>
+        <CircularProgress isIndeterminate thickness={5} color="black" />
 
-      {message && <Text>{message}</Text>}
+        <Box>
+          <Text as={"h2"} fontSize={"md"} fontWeight={"bold"}>
+            {title}
+          </Text>
+          {message && <Text>{message}</Text>}
+        </Box>
+      </Flex>
 
-      <Progress variant={"ghost"} value={progressPercentage} size="xs" colorScheme="gray" />
+      {/* The 'css' hack is to animate the progress bar as value changes */}
+      <Progress
+        value={progressPercentage}
+        size="xs"
+        colorScheme="whatsapp"
+        css={{
+          "> div:first-of-type": {
+            transition: "width 500ms ease-in-out",
+          },
+        }}
+      />
     </Flex>
   );
 }

--- a/src/components/ProgressToast.tsx
+++ b/src/components/ProgressToast.tsx
@@ -1,9 +1,19 @@
-import { Box, CircularProgress, Flex, Progress, Text, useColorModeValue } from "@chakra-ui/react";
+import {
+  Box,
+  CircularProgress,
+  Flex,
+  IconButton,
+  Progress,
+  Text,
+  useColorModeValue,
+} from "@chakra-ui/react";
 import { AlertArguments } from "../hooks/use-alert";
+import { MdMinimize } from "react-icons/md";
 
 type ProgressAlertArguements = AlertArguments & {
   progressPercentage: number;
   showPercentage: boolean;
+  onClose?: () => void;
 };
 
 function ProgressToast({
@@ -11,17 +21,37 @@ function ProgressToast({
   message,
   progressPercentage,
   showPercentage,
+  onClose,
 }: ProgressAlertArguements) {
   return (
     <Flex
-      bgColor={useColorModeValue("blue.500", "blue.200")}
+      bgColor={useColorModeValue("blue.600", "blue.200")}
       color={useColorModeValue("white", "black")}
       p={3}
       gap={5}
       flexDirection={"column"}
       justifyContent={"center"}
       rounded={"md"}
+      position={"relative"}
     >
+      {/* Close Button */}
+      {onClose && (
+        <IconButton
+          position={"absolute"}
+          display={"flex"}
+          bgColor={"transparent"}
+          alignItems={"center"}
+          top={0}
+          right={2}
+          aria-label="Minimize Download Progress"
+          onClick={onClose}
+          _hover={{}} // Remove hover
+          _active={{}} // and active effects
+          size={"xs"}
+          icon={<MdMinimize size={"xs"} />}
+        ></IconButton>
+      )}
+
       <Flex alignItems={"center"} gap={5}>
         <CircularProgress isIndeterminate thickness={5} color="black" />
 
@@ -40,7 +70,7 @@ function ProgressToast({
           flexGrow={1}
           value={progressPercentage}
           size="xs"
-          colorScheme="whatsapp"
+          colorScheme={useColorModeValue("whatsapp", "gray")}
           css={{
             "> div:first-of-type": {
               transition: "width 500ms ease-in-out",

--- a/src/components/ProgressToast.tsx
+++ b/src/components/ProgressToast.tsx
@@ -8,7 +8,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import { AlertArguments } from "../hooks/use-alert";
-import { MdMinimize } from "react-icons/md";
+import { RxCross2 } from "react-icons/rx";
 
 type ProgressAlertArguements = AlertArguments & {
   progressPercentage: number;
@@ -42,13 +42,12 @@ function ProgressToast({
           bgColor={"transparent"}
           alignItems={"center"}
           top={0}
-          right={2}
-          aria-label="Minimize Download Progress"
+          right={0}
+          aria-label="Cancel Process"
           onClick={onClose}
-          _hover={{}} // Remove hover
-          _active={{}} // and active effects
-          size={"xs"}
-          icon={<MdMinimize size={"xs"} />}
+          _active={{}} // remove active effects
+          size={"sm"}
+          icon={<RxCross2 />}
         ></IconButton>
       )}
 

--- a/src/hooks/use-alert.tsx
+++ b/src/hooks/use-alert.tsx
@@ -92,6 +92,7 @@ export function useAlert() {
     updateOnly?: boolean;
     showPercentage?: boolean;
     isClosable?: boolean;
+    handleClose?: () => void;
   };
 
   const progress = useCallback(
@@ -103,21 +104,29 @@ export function useAlert() {
       updateOnly = false,
       showPercentage = true,
       isClosable = true,
+      handleClose,
     }: ProgressAlertArguements) => {
       const toastOptions: UseToastOptions = {
         status: "loading",
         position: "top",
         isClosable: isClosable,
         duration: null,
-        render: ({ onClose }) => (
-          <ProgressToast
-            title={title}
-            message={message}
-            progressPercentage={progressPercentage}
-            showPercentage={showPercentage}
-            onClose={isClosable ? onClose : undefined}
-          ></ProgressToast>
-        ),
+        render: ({ onClose }) => {
+          const closeHandler = () => {
+            handleClose?.();
+            onClose();
+          };
+
+          return (
+            <ProgressToast
+              title={title}
+              message={message}
+              progressPercentage={progressPercentage}
+              showPercentage={showPercentage}
+              onClose={isClosable ? closeHandler : undefined}
+            ></ProgressToast>
+          );
+        },
       };
 
       if (id) {

--- a/src/hooks/use-alert.tsx
+++ b/src/hooks/use-alert.tsx
@@ -90,10 +90,18 @@ export function useAlert() {
     id?: ToastId;
     progressPercentage: number;
     updateOnly?: boolean;
+    showPercentage?: boolean;
   };
 
   const progress = useCallback(
-    ({ id, title, message, progressPercentage, updateOnly = false }: ProgressAlertArguements) => {
+    ({
+      id,
+      title,
+      message,
+      progressPercentage,
+      updateOnly = false,
+      showPercentage = true,
+    }: ProgressAlertArguements) => {
       const toastOptions: UseToastOptions = {
         status: "loading",
         position: "top",
@@ -104,6 +112,7 @@ export function useAlert() {
             title={title}
             message={message}
             progressPercentage={progressPercentage}
+            showPercentage={showPercentage}
           ></ProgressToast>
         ),
       };

--- a/src/hooks/use-alert.tsx
+++ b/src/hooks/use-alert.tsx
@@ -1,5 +1,6 @@
+import { ToastId, UseToastOptions, useToast } from "@chakra-ui/react";
 import { useCallback } from "react";
-import { useToast } from "@chakra-ui/react";
+import ProgressToast from "../components/ProgressToast";
 import useMobileBreakpoint from "./use-mobile-breakpoint";
 
 export type AlertArguments = {
@@ -85,10 +86,55 @@ export function useAlert() {
     [toast]
   );
 
+  type ProgressAlertArguements = Omit<AlertArguments, "id"> & {
+    id?: ToastId;
+    progressPercentage: number;
+  };
+
+  const progress = useCallback(
+    ({ id, title, message, progressPercentage }: ProgressAlertArguements) => {
+      const toastOptions: UseToastOptions = {
+        status: "loading",
+        position: "top",
+        isClosable: false,
+        duration: null,
+        render: () => (
+          <ProgressToast
+            title={title}
+            message={message}
+            progressPercentage={progressPercentage}
+          ></ProgressToast>
+        ),
+      };
+
+      if (id) {
+        if (toast.isActive(id)) {
+          toast.update(id, toastOptions);
+        }
+      } else {
+        return toast({
+          ...toastOptions,
+        });
+      }
+    },
+    [toast]
+  );
+
+  const closeToast = useCallback(
+    (toastId?: ToastId) => {
+      if (toastId) {
+        toast.close(toastId);
+      }
+    },
+    [toast]
+  );
+
   return {
     info,
     error,
     success,
     warning,
+    progress,
+    closeToast,
   };
 }

--- a/src/hooks/use-alert.tsx
+++ b/src/hooks/use-alert.tsx
@@ -89,10 +89,11 @@ export function useAlert() {
   type ProgressAlertArguements = Omit<AlertArguments, "id"> & {
     id?: ToastId;
     progressPercentage: number;
+    updateOnly?: boolean;
   };
 
   const progress = useCallback(
-    ({ id, title, message, progressPercentage }: ProgressAlertArguements) => {
+    ({ id, title, message, progressPercentage, updateOnly = false }: ProgressAlertArguements) => {
       const toastOptions: UseToastOptions = {
         status: "loading",
         position: "top",
@@ -111,7 +112,7 @@ export function useAlert() {
         if (toast.isActive(id)) {
           toast.update(id, toastOptions);
         }
-      } else {
+      } else if (!updateOnly) {
         return toast({
           ...toastOptions,
         });

--- a/src/hooks/use-alert.tsx
+++ b/src/hooks/use-alert.tsx
@@ -91,6 +91,7 @@ export function useAlert() {
     progressPercentage: number;
     updateOnly?: boolean;
     showPercentage?: boolean;
+    isClosable?: boolean;
   };
 
   const progress = useCallback(
@@ -101,18 +102,20 @@ export function useAlert() {
       progressPercentage,
       updateOnly = false,
       showPercentage = true,
+      isClosable = true,
     }: ProgressAlertArguements) => {
       const toastOptions: UseToastOptions = {
         status: "loading",
         position: "top",
-        isClosable: false,
+        isClosable: isClosable,
         duration: null,
-        render: () => (
+        render: ({ onClose }) => (
           <ProgressToast
             title={title}
             message={message}
             progressPercentage={progressPercentage}
             showPercentage={showPercentage}
+            onClose={isClosable ? onClose : undefined}
           ></ProgressToast>
         ),
       };


### PR DESCRIPTION
As discussed in https://github.com/tarasglek/chatcraft.org/pull/602#pullrequestreview-2010490014,

I have added a custom progress bar toast to our existing `useAlert` hook.

1. Now we see this progress bar toast when trying to download a message as audio, and the value updates as the promises processing text to speech chunks get resolved.
2. I am now also clearing the `pLimit` queue if we ever run into an exception as I noticed the queued promises continued executing even though one of them failed.
3. I am not sure what color would be the best for our progress bar and have selected the best combination I could come up with. I could use some help with color selection :)
4. I also found that `tts-1-hd` model has a rate limit of `3` on non-enterprise openai keys, and had to switch to standard `tts-1` model for local testing. We should probably have another issue to add a preference control so users can choose which model they prefer for audio downloads.

**Demo:** (Ignore distorted color, the gif is corrupt)
![CustomProgressBar](https://github.com/tarasglek/chatcraft.org/assets/78865303/638b2445-5dd8-4d7c-bad8-78e317f31b4c)


This fixes #604
 