### PR TITLE
Don't show free mode banner if an API key has been added (check settings.providers.length)

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -61,7 +61,7 @@ function ChatBase({ chat }: ChatBaseProps) {
   const { error } = useAlert();
   const { user } = useUser();
   const { clearAudioQueue } = useAudioPlayer();
-  const [showAlert, setShowAlert] = useState(true);
+  const [showAlert, setShowAlert] = useState(false);
   const {
     isOpen: isPrefModalOpen,
     onOpen: onPrefModalOpen,

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -68,6 +68,11 @@ function ChatBase({ chat }: ChatBaseProps) {
     onClose: onPrefModalClose,
   } = useDisclosure();
 
+  useEffect(() => {
+    const providersLength = Object.keys(settings.providers).length;
+    setShowAlert(providersLength === 0);
+  }, [settings.providers]);
+
   // Set focus on Prompt Input text area
   const handleChatInputFocus = useCallback((e: KeyboardEvent) => {
     e.preventDefault();
@@ -374,7 +379,7 @@ function ChatBase({ chat }: ChatBaseProps) {
 
   const defaultProviderAlert = useMemo(() => {
     // If we are using default provider, show alert banner to notify user
-    if (showAlert && settings.currentProvider instanceof FreeModelProvider) {
+    if (showAlert) {
       return (
         <Alert status="info" variant="solid" sx={{ py: 1 }}>
           <AlertIcon boxSize="4" />

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -38,7 +38,6 @@ import {
 import { WebHandler } from "../lib/WebHandler";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import ChatHeader from "./ChatHeader";
-import { FreeModelProvider } from "../lib/providers/DefaultProvider/FreeModelProvider";
 import PreferencesModal from "../components/Preferences/PreferencesModal";
 
 type ChatBaseProps = {


### PR DESCRIPTION
This fixes #544.

Sorry for sitting on this for a while. There's one concern I have that I wasn't able to figure out.
More details below.

Background
---
> We show a "You are using the free model..." banner when the user first comes to ChatCraft and we want to let them know about adding more providers for better features.
However, even after you add an OpenAI or OpenRouter provider, when you switch back to the free provider, we show the banner again.

Solution
---
If you run `console.log(settings)` you'll see that `settings` has a property called `providers`.
`settings.providers` is empty when no provider API keys are added (length 0):
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/a5ae65ec-01d3-4586-97e3-f7a9d587dd54)

...and is populated when you add an API key:
![image](https://github.com/tarasglek/chatcraft.org/assets/78163326/8267f7bc-c298-4b79-8456-3d7b28e800ba)

This PR does the following:
- adds a useEffect that toggles the Free Banner based on the length of `settings.provider`:
  - length=0 (no API Keys added) - Show banner
  - length>0 (1+ API Key(s) added) - Don't show banner
-  defaults showAlert to `false` so banner doesn't appear temporarily when user opens ChatCraft after adding a provider/API key

My concern
---
The useMemo no longer checks the current provider when showing the Free Mode banner.
This means if a user has a paid provider (like OpenAI) as the current provider and removes their API key, the **Free Mode banner will re-appear**, but the currentProvider will still be OpenAI:
![freeBannerIgnoreCurrentProvider](https://github.com/tarasglek/chatcraft.org/assets/78163326/8ee356be-af79-4622-a913-d7b02a6dacab)

We can revert back to the **original behaviour** if that's preferred (don't show Free Mode if Current Provider is a Paid provider):
![freeBannerCheckCurrentProvider](https://github.com/tarasglek/chatcraft.org/assets/78163326/2388052f-1458-4ebd-9a47-638d977b0c30).

I'd like some opinions on this.
