### PR TITLE
Default to gpt-4o, auto. kill preference for chatgpt-3.5 with fire

### DIFF
--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -71,14 +71,14 @@ export class ChatCraftModel {
   }
 
   get supportsImages() {
-    return this.name.includes("vision") || this.name == "gpt-4-turbo";
+    return (
+      this.name.includes("vision") ||
+      this.name.startsWith("gpt-4-turbo") ||
+      this.name.startsWith("gpt-4o")
+    );
   }
 
   get prettyModel(): string {
-    if (this.name.startsWith("gpt-3.5-turbo")) {
-      return this.name.replace("gpt-3.5-turbo", "chat-gpt");
-    }
-
     return this.name;
   }
 

--- a/src/lib/providers/OpenAiProvider.ts
+++ b/src/lib/providers/OpenAiProvider.ts
@@ -2,7 +2,7 @@ import { ChatCraftProvider, SerializedChatCraftProvider } from "../ChatCraftProv
 
 export const OPENAI_API_URL = "https://api.openai.com/v1";
 export const OPENAI_NAME = "OpenAI";
-const OPENAI_DEFAULT_MODEL = "gpt-3.5-turbo";
+const OPENAI_DEFAULT_MODEL = "gpt-4o";
 
 export type SerializedOpenAiProvider = {
   id: string;

--- a/src/lib/providers/OpenRouterProvider.ts
+++ b/src/lib/providers/OpenRouterProvider.ts
@@ -3,7 +3,7 @@ import { getReferer } from "../utils";
 
 export const OPENROUTER_API_URL = "https://openrouter.ai/api/v1";
 export const OPENROUTER_NAME = "OpenRouter.ai";
-const OPENROUTER_DEFAULT_MODEL = "openai/gpt-3.5-turbo";
+const OPENROUTER_DEFAULT_MODEL = "openrouter/auto";
 
 export type SerializedOpenRouterProvider = {
   id: string;


### PR DESCRIPTION
This change default us to gpt-4o as it's cheap enough now to use by default and nowhere near as useless as chatgpt-3.5. Also changed to 'auto' model on openrouter as that's their 'we pick best value model for your query' endpoint.

I would also like to add some '-overpriced' prettyName to old gpt-4 models, but will leave that to someone else.