### PR TITLE
Change Providers/Models order in Ask menu

### DIFF
--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -132,7 +132,10 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
                 variant="outline"
                 placeholder="Search models..."
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  e.preventDefault();
+                  setSearchQuery(e.target.value);
+                }}
               />
             </InputGroup>
             {models
@@ -202,14 +205,17 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const onStartTyping = (e: KeyboardEvent<HTMLElement>) => {
     // Check if the inputRef is current and the input is not already focused
     if (inputRef.current && document.activeElement !== inputRef.current) {
+      if (e.key === "ArrowUp" || e.key === "ArrowDown" || e.key === "Enter") {
+        return;
+      }
       // Don't handle the keydown event more than once
       e.preventDefault();
-      // Make sure we are focused on the input element
-      inputRef.current.focus();
       // Ignore control keys
       const char = e.key.length === 1 ? e.key : "";
       // Set the initial character in the input so we don't lose it
       setSearchQuery(searchQuery + char);
+      // Make sure we are focused on the input element
+      inputRef.current.focus();
     }
   };
 
@@ -285,7 +291,10 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
                 variant="outline"
                 placeholder="Search models..."
                 value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
+                onChange={(e) => {
+                  e.preventDefault();
+                  setSearchQuery(e.target.value);
+                }}
               />
             </InputGroup>
             {models

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -265,7 +265,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </Button>
         </Tooltip>
       )}
-      <Menu placement="top-start" strategy="fixed" closeOnSelect={false}>
+      <Menu placement="top-end" strategy="fixed" closeOnSelect={false}>
         <MenuButton
           as={IconButton}
           size="sm"

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -20,7 +20,8 @@ import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useSettings } from "../../hooks/use-settings";
 import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
-import { MdVolumeUp, MdVolumeOff, MdOutlineChevronRight } from "react-icons/md";
+import { MdVolumeUp, MdVolumeOff } from "react-icons/md";
+import { IoMdCheckmark } from "react-icons/io";
 import { useMemo, useRef, useState, type KeyboardEvent } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import { usingOfficialOpenAI } from "../../lib/providers";
@@ -120,13 +121,15 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
           <MenuGroup title="Models">
             <InputGroup>
-              <InputLeftElement pointerEvents="none">
+              <InputLeftElement paddingLeft={3} pointerEvents="none">
                 <TbSearch />
               </InputLeftElement>
               <Input
+                marginInline={2}
+                marginBottom={1}
                 ref={inputRef}
                 type="text"
-                variant="ghost"
+                variant="outline"
                 placeholder="Search models..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -139,14 +142,15 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
               )
               .map((model) => (
                 <MenuItem
+                  paddingInline={4}
                   closeOnSelect={true}
                   key={model.id}
                   onClick={() => setSettings({ ...settings, model })}
                 >
                   {settings.model.id === model.id ? (
-                    <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                    <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
                   ) : (
-                    <span style={{ width: "24px", display: "inline-block" }} />
+                    <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
                   )}
                   {model.prettyModel}
                 </MenuItem>
@@ -156,15 +160,16 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           <MenuGroup title="Providers">
             {Object.entries(providersList).map(([providerName, providerObject]) => (
               <MenuItem
+                paddingInline={4}
                 key={providerName}
                 onClick={() => {
                   setSettings({ ...settings, currentProvider: providerObject });
                 }}
               >
                 {settings.currentProvider.name === providerName ? (
-                  <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
                 ) : (
-                  <span style={{ width: "24px", display: "inline-block" }} />
+                  <span style={{ width: "1.6rem", display: "inline-block" }} />
                 )}
                 {providerName}
               </MenuItem>
@@ -253,7 +258,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           </Button>
         </Tooltip>
       )}
-      <Menu placement="top" strategy="fixed" closeOnSelect={false}>
+      <Menu placement="top-start" strategy="fixed" closeOnSelect={false}>
         <MenuButton
           as={IconButton}
           size="sm"
@@ -269,13 +274,15 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
         >
           <MenuGroup title="Models">
             <InputGroup>
-              <InputLeftElement pointerEvents="none">
+              <InputLeftElement paddingLeft={3} pointerEvents="none">
                 <TbSearch />
               </InputLeftElement>
               <Input
+                marginInline={2}
+                marginBottom={1}
                 ref={inputRef}
                 type="text"
-                variant="ghost"
+                variant="outline"
                 placeholder="Search models..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
@@ -288,14 +295,15 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
               )
               .map((model) => (
                 <MenuItem
+                  paddingInline={4}
                   closeOnSelect={true}
                   key={model.id}
                   onClick={() => setSettings({ ...settings, model })}
                 >
                   {settings.model.id === model.id ? (
-                    <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                    <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
                   ) : (
-                    <span style={{ width: "24px", display: "inline-block" }} />
+                    <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
                   )}
                   {model.prettyModel}
                 </MenuItem>
@@ -305,15 +313,16 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           <MenuGroup title="Providers">
             {Object.entries(providersList).map(([providerName, providerObject]) => (
               <MenuItem
+                paddingInline={4}
                 key={providerName}
                 onClick={() => {
                   setSettings({ ...settings, currentProvider: providerObject });
                 }}
               >
                 {settings.currentProvider.name === providerName ? (
-                  <MdOutlineChevronRight style={{ marginRight: "4px" }} />
+                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
                 ) : (
-                  <span style={{ width: "24px", display: "inline-block" }} />
+                  <span style={{ width: "1.6rem", display: "inline-block" }} />
                 )}
                 {providerName}
               </MenuItem>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -12,6 +12,7 @@ import {
   Input,
   InputGroup,
   InputLeftElement,
+  Box,
 } from "@chakra-ui/react";
 import { TbChevronUp, TbSend, TbSearch } from "react-icons/tb";
 import { FreeModelProvider } from "../../lib/providers/DefaultProvider/FreeModelProvider";
@@ -273,7 +274,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList
-          maxHeight={"70vh"}
+          maxHeight={"80vh"}
           overflowY={"auto"}
           zIndex={theme.zIndices.dropdown}
           onKeyDownCapture={onStartTyping}
@@ -316,26 +317,28 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
                 }}
               />
             </InputGroup>
-            {models
-              .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
-              .filter((model) =>
-                model.prettyModel.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
-              )
-              .map((model) => (
-                <MenuItem
-                  paddingInline={4}
-                  closeOnSelect={true}
-                  key={model.id}
-                  onClick={() => setSettings({ ...settings, model })}
-                >
-                  {settings.model.id === model.id ? (
-                    <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
-                  ) : (
-                    <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
-                  )}
-                  {model.prettyModel}
-                </MenuItem>
-              ))}
+            <Box maxHeight="40vh" overflowY="auto">
+              {models
+                .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+                .filter((model) =>
+                  model.prettyModel.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
+                )
+                .map((model) => (
+                  <MenuItem
+                    paddingInline={4}
+                    closeOnSelect={true}
+                    key={model.id}
+                    onClick={() => setSettings({ ...settings, model })}
+                  >
+                    {settings.model.id === model.id ? (
+                      <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
+                    ) : (
+                      <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
+                    )}
+                    {model.prettyModel}
+                  </MenuItem>
+                ))}
+            </Box>
           </MenuGroup>
         </MenuList>
       </Menu>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -119,6 +119,25 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           icon={<TbChevronUp />}
         />
         <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
+          <MenuGroup title="Providers">
+            {Object.entries(providersList).map(([providerName, providerObject]) => (
+              <MenuItem
+                paddingInline={4}
+                key={providerName}
+                onClick={() => {
+                  setSettings({ ...settings, currentProvider: providerObject });
+                }}
+              >
+                {settings.currentProvider.name === providerName ? (
+                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
+                ) : (
+                  <span style={{ width: "1.6rem", display: "inline-block" }} />
+                )}
+                {providerName}
+              </MenuItem>
+            ))}
+          </MenuGroup>
+          <MenuDivider />
           <MenuGroup title="Models">
             <InputGroup>
               <InputLeftElement paddingLeft={3} pointerEvents="none">
@@ -158,25 +177,6 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
                   {model.prettyModel}
                 </MenuItem>
               ))}
-          </MenuGroup>
-          <MenuDivider />
-          <MenuGroup title="Providers">
-            {Object.entries(providersList).map(([providerName, providerObject]) => (
-              <MenuItem
-                paddingInline={4}
-                key={providerName}
-                onClick={() => {
-                  setSettings({ ...settings, currentProvider: providerObject });
-                }}
-              >
-                {settings.currentProvider.name === providerName ? (
-                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
-                ) : (
-                  <span style={{ width: "1.6rem", display: "inline-block" }} />
-                )}
-                {providerName}
-              </MenuItem>
-            ))}
           </MenuGroup>
         </MenuList>
       </Menu>
@@ -278,6 +278,25 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
           zIndex={theme.zIndices.dropdown}
           onKeyDownCapture={onStartTyping}
         >
+          <MenuGroup title="Providers">
+            {Object.entries(providersList).map(([providerName, providerObject]) => (
+              <MenuItem
+                paddingInline={4}
+                key={providerName}
+                onClick={() => {
+                  setSettings({ ...settings, currentProvider: providerObject });
+                }}
+              >
+                {settings.currentProvider.name === providerName ? (
+                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
+                ) : (
+                  <span style={{ width: "1.6rem", display: "inline-block" }} />
+                )}
+                {providerName}
+              </MenuItem>
+            ))}
+          </MenuGroup>
+          <MenuDivider />
           <MenuGroup title="Models">
             <InputGroup>
               <InputLeftElement paddingLeft={3} pointerEvents="none">
@@ -317,25 +336,6 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
                   {model.prettyModel}
                 </MenuItem>
               ))}
-          </MenuGroup>
-          <MenuDivider />
-          <MenuGroup title="Providers">
-            {Object.entries(providersList).map(([providerName, providerObject]) => (
-              <MenuItem
-                paddingInline={4}
-                key={providerName}
-                onClick={() => {
-                  setSettings({ ...settings, currentProvider: providerObject });
-                }}
-              >
-                {settings.currentProvider.name === providerName ? (
-                  <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
-                ) : (
-                  <span style={{ width: "1.6rem", display: "inline-block" }} />
-                )}
-                {providerName}
-              </MenuItem>
-            ))}
           </MenuGroup>
         </MenuList>
       </Menu>


### PR DESCRIPTION
Fixes #641 

This PR moves the Providers list above the Models list in the Ask menu.

Additionally, I changed the selection icon to a checkmark for better clarity. I aligned the menu to its button and changed the variant of the search bar.