### PR TITLE
Single source of truth for commands help text

### DIFF
--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -1,143 +1,142 @@
-import { memo } from "react";
+import { memo, useMemo } from "react";
 
-import MessageBase, { type MessageBaseProps } from "../MessageBase";
-import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
 import { ChatCraftCommand } from "../../../lib/ChatCraftCommand";
+import { ChatCraftCommandRegistry } from "../../../lib/ChatCraftCommandRegistry";
+import { ChatCraftAppMessage } from "../../../lib/ChatCraftMessage";
+import MessageBase, { type MessageBaseProps } from "../MessageBase";
 
-const commandsHelpText = `## Commands
+function getCommandsHelpText(supportedCommands: ChatCraftCommand[]) {
+  return `## Commands
 
-You can use "slash" commands to help accomplish various tasks. Any prompt that begins
-with a "/" (e.g., "/help") will be interpreted as a command that ChatCraft should run.
-Some commands accept arguments as well.
+  You can use "slash" commands to help accomplish various tasks. Any prompt that begins
+  with a "/" (e.g., "/help") will be interpreted as a command that ChatCraft should run.
+  Some commands accept arguments as well.
 
-| Command | Description |
-|-----|------|
-| /help         | Shows this help message. |
-| /commands | Shows a list of **supported commands** in ChatCraft |
-| /new          | Creates a new chat. |
-| /clear        | Erases all messages in the current chat. |
-| /summary&nbsp;[max-length] | Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500). |
-| /import&nbsp;<url> | Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command. |
-| /image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying \`layout=[l\\|landscape\\|p\\|portrait]\`|
-`;
-
-const helpText = `## ChatCraft.org Help
-
-ChatCraft.org lets you chat with large language models (LLM) from various vendors and
-store your chat history locally in your browser. It has many many [features](https://github.com/tarasglek/chatcraft.org/blob/main/README.md)
-designed to make it easy for software developers to discuss their code with AI and each other.
-
-## How to Chat
-
-You can ask questions, copy/paste code, get help with error messages, etc.
-
-If you'd like to use your voice instead of typing, press and hold the microphone
-icon, ask your question, and release when done.  Your voice will be transcribed by
-OpenAI and added to the chat as text. You can also cancel an audio recording by
-sliding the icon to the left and releasing.
-
-## Examples
-
-Here are a few examples to get you started:
-
-### Example 1: Learning Technologies and Concepts
-
-> I'm trying to learn React, and a I need a basic intro with some diagrams and links
-
-You can ask for code examples, links to tutorials, diagrams and more.  You can also
-try copy/pasting some text for a web site and asking for more explanation:
-
-> I don't understand what this paragraph means, explain it in more simple terms:
->
-> ...paste the text that you don't understand here...
-
-### Example 2: Writing Code with AI
-
-> Give me a regular expression for working with license plates in the US. I'm working in python.
-
-When you know what you want to do, but not **how** exactly, talking with AI can help
-you accomplish your task more quickly.
-
-All code has bugs, even code written by AI.  You'll often need to ask for clarification
-or edit the code yourself to get to your desired end goal.
-
-### Example 3: Solving Tasks
-
-> I need to trim the first 5 seconds from a video. I'm on a Mac and want to use ffmpeg.
-
-AI is great at helping find the syntax for common problems without wasting time searching
-through documentation.
-
-### Example 4: Understanding Code and Errors
-
-> I'm writing the function below, and when I run it I get an error. What does it mean?
->
-> \`\`\`
-> ...function...
-> \`\`\`
->
-> \`\`\`
-> ...text of error message
-> \`\`\`
-
-When you're stuck on a problem and need "another set of eyes," asking AI to read through
-your code and errors can help you find your bug.
-
-## Markdown support
-
-If you're [comfortable with Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), you can
-use it anywhere in your prompt, and the LLMs will do the same. ChatCraft knows how to render Markdown.
-
-For example, similar to GitHub, if you [wrap code in triple-backtick code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks), ChatCraft will
-properly display it for you.  You can also specify the language to use (e.g., typescript):
-
-\`\`\`typescript
-function greeting(name: string) {
-  return "Hello " + name;
+  | Command | Description |
+  |-----|------|
+  ${supportedCommands.map((command) => `| ${command.metaData.helpTitle} | ${command.metaData.helpDescription} |`).join("\n")}
+  `;
 }
-\`\`\`
 
-You can also use [headings](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#headings), [lists](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#lists), [tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables#creating-a-table), [links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links),
-etc. to create more readable text.
+function getHelpText(commandsHelpText: string) {
+  return `## ChatCraft.org Help
 
-${commandsHelpText}
+  ChatCraft.org lets you chat with large language models (LLM) from various vendors and
+  store your chat history locally in your browser. It has many many [features](https://github.com/tarasglek/chatcraft.org/blob/main/README.md)
+  designed to make it easy for software developers to discuss their code with AI and each other.
 
-## Functions
+  ## How to Chat
 
-Some models support function calling (e.g, OpenAI models). ChatCraft provides a way
-to write, load, and run these functions using a special syntax. Functions are ES6 Modules
-written in TypeScript.
+  You can ask questions, copy/paste code, get help with error messages, etc.
 
-To create a function within ChatCraft, use the [/f/new](/f/new) URL, which will create
-a new function and load the editor.
+  If you'd like to use your voice instead of typing, press and hold the microphone
+  icon, ask your question, and release when done.  Your voice will be transcribed by
+  OpenAI and added to the chat as text. You can also cancel an audio recording by
+  sliding the icon to the left and releasing.
 
-You can also host your function module somewhere (e.g., [gist.github.com](https:/gist.github.com))
-and have ChatCraft load it dynamically.
+  ## Examples
 
-During your chat, you can ask a model to use your function by using the following syntax in your prompt:
+  Here are a few examples to get you started:
 
-- \`@fn:name\` - use a function called 'name' stored locally within ChatCraft (i.e., written in editor)
-- \`@fn-url:url\` - use a function hosted at the given 'url'. ChatCraft will attempt to load and parse it.
+  ### Example 1: Learning Technologies and Concepts
 
-Functions mentioned in the chat's System Prompt are suggestions for the LLM, whereas a function
-you define in a message is an instruction to use the function.  For example, the following
-prompt will cause the LLM to use the sum function:
+  > I'm trying to learn React, and a I need a basic intro with some diagrams and links
 
-> add 1334134, 1324134, and 135223452 @fn:sum
+  You can ask for code examples, links to tutorials, diagrams and more.  You can also
+  try copy/pasting some text for a web site and asking for more explanation:
 
-If you instead wanted to make the LLM aware of the sum function, and let it choose when to use it,
-customize the System Prompt to include it:
+  > I don't understand what this paragraph means, explain it in more simple terms:
+  >
+  > ...paste the text that you don't understand here...
 
-> - When you need to add numbers, use @fn:sum
+  ### Example 2: Writing Code with AI
 
-## Getting More Help
+  > Give me a regular expression for working with license plates in the US. I'm working in python.
 
-ChatCraft is still very young and evolving quickly. If you want to talk more about a problem,
-have an idea for a feature, or think you've found a bug, get in touch with us:
+  When you know what you want to do, but not **how** exactly, talking with AI can help
+  you accomplish your task more quickly.
 
-- [GitHub](https://github.com/tarasglek/chatcraft.org)
-- [Discord](https://discord.gg/PE2GWHnR)
-`;
+  All code has bugs, even code written by AI.  You'll often need to ask for clarification
+  or edit the code yourself to get to your desired end goal.
+
+  ### Example 3: Solving Tasks
+
+  > I need to trim the first 5 seconds from a video. I'm on a Mac and want to use ffmpeg.
+
+  AI is great at helping find the syntax for common problems without wasting time searching
+  through documentation.
+
+  ### Example 4: Understanding Code and Errors
+
+  > I'm writing the function below, and when I run it I get an error. What does it mean?
+  >
+  > \`\`\`
+  > ...function...
+  > \`\`\`
+  >
+  > \`\`\`
+  > ...text of error message
+  > \`\`\`
+
+  When you're stuck on a problem and need "another set of eyes," asking AI to read through
+  your code and errors can help you find your bug.
+
+  ## Markdown support
+
+  If you're [comfortable with Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax), you can
+  use it anywhere in your prompt, and the LLMs will do the same. ChatCraft knows how to render Markdown.
+
+  For example, similar to GitHub, if you [wrap code in triple-backtick code blocks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks), ChatCraft will
+  properly display it for you.  You can also specify the language to use (e.g., typescript):
+
+  \`\`\`typescript
+  function greeting(name: string) {
+    return "Hello " + name;
+  }
+  \`\`\`
+
+  You can also use [headings](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#headings), [lists](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#lists), [tables](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables#creating-a-table), [links](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#links),
+  etc. to create more readable text.
+
+  ${commandsHelpText}
+
+  ## Functions
+
+  Some models support function calling (e.g, OpenAI models). ChatCraft provides a way
+  to write, load, and run these functions using a special syntax. Functions are ES6 Modules
+  written in TypeScript.
+
+  To create a function within ChatCraft, use the [/f/new](/f/new) URL, which will create
+  a new function and load the editor.
+
+  You can also host your function module somewhere (e.g., [gist.github.com](https:/gist.github.com))
+  and have ChatCraft load it dynamically.
+
+  During your chat, you can ask a model to use your function by using the following syntax in your prompt:
+
+  - \`@fn:name\` - use a function called 'name' stored locally within ChatCraft (i.e., written in editor)
+  - \`@fn-url:url\` - use a function hosted at the given 'url'. ChatCraft will attempt to load and parse it.
+
+  Functions mentioned in the chat's System Prompt are suggestions for the LLM, whereas a function
+  you define in a message is an instruction to use the function.  For example, the following
+  prompt will cause the LLM to use the sum function:
+
+  > add 1334134, 1324134, and 135223452 @fn:sum
+
+  If you instead wanted to make the LLM aware of the sum function, and let it choose when to use it,
+  customize the System Prompt to include it:
+
+  > - When you need to add numbers, use @fn:sum
+
+  ## Getting More Help
+
+  ChatCraft is still very young and evolving quickly. If you want to talk more about a problem,
+  have an idea for a feature, or think you've found a bug, get in touch with us:
+
+  - [GitHub](https://github.com/tarasglek/chatcraft.org)
+  - [Discord](https://discord.gg/PE2GWHnR)
+  `;
+}
 
 interface HelpMessageProps extends MessageBaseProps {
   onlyCommands?: boolean;
@@ -147,16 +146,20 @@ interface HelpMessageProps extends MessageBaseProps {
 }
 
 function Help(props: HelpMessageProps) {
+  const supportedCommands = useMemo(() => {
+    return ChatCraftCommandRegistry.getCommandsList();
+  }, []);
+
   // Override the text of the message
   const isQueriedCommandValid =
     props.onlyCommands && props.queriedCommand && ChatCraftCommand.isCommand(props.queriedCommand);
 
   const messageText =
     props.onlyCommands && props.queriedCommand?.length && !isQueriedCommandValid
-      ? `**"${props.queriedCommand}" is not a valid command!**\n\n${commandsHelpText}`
+      ? `**"${props.queriedCommand}" is not a valid command!**\n\n${getCommandsHelpText(supportedCommands)}`
       : props.onlyCommands
-        ? commandsHelpText
-        : helpText;
+        ? getCommandsHelpText(supportedCommands)
+        : getHelpText(getCommandsHelpText(supportedCommands));
 
   const message = new ChatCraftAppMessage({
     ...props.message,

--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -14,7 +14,7 @@ function getCommandsHelpText(supportedCommands: ChatCraftCommand[]) {
 
   | Command | Description |
   |-----|------|
-  ${supportedCommands.map((command) => `| ${command.metaData.helpTitle} | ${command.metaData.helpDescription} |`).join("\n")}
+  ${supportedCommands.map((command) => `| ${command.helpTitle} | ${command.helpDescription} |`).join("\n")}
   `;
 }
 
@@ -147,7 +147,7 @@ interface HelpMessageProps extends MessageBaseProps {
 
 function Help(props: HelpMessageProps) {
   const supportedCommands = useMemo(() => {
-    return ChatCraftCommandRegistry.getCommandsList();
+    return ChatCraftCommandRegistry.getCommands();
   }, []);
 
   // Override the text of the message

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -1,14 +1,16 @@
 import { ChatCraftChat } from "./ChatCraftChat";
 
-type ChatCraftCommandMetaData = {
-  helpTitle: string; // Help strings can be
-  helpDescription: string; // markdown text
-};
-
 export abstract class ChatCraftCommand {
+  /**
+   *
+   * @param command Name of the command to be used in format - `/<command-name>`
+   * @param helpTitle Title of the command to be displayed in help grid
+   * @param helpDescription A brief paragraph explaining how the command works, and any supported options
+   */
   constructor(
     public command: string,
-    public metaData: ChatCraftCommandMetaData
+    public helpTitle: string,
+    public helpDescription: string
   ) {}
 
   // This method should be overridden by subclasses to implement the command

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -1,7 +1,15 @@
 import { ChatCraftChat } from "./ChatCraftChat";
 
+type ChatCraftCommandMetaData = {
+  helpTitle: string; // Help strings can be
+  helpDescription: string; // markdown text
+};
+
 export abstract class ChatCraftCommand {
-  constructor(public command: string) {}
+  constructor(
+    public command: string,
+    public metaData: ChatCraftCommandMetaData
+  ) {}
 
   // This method should be overridden by subclasses to implement the command
   abstract execute(chat: ChatCraftChat, user: User | undefined, args?: string[]): Promise<void>;

--- a/src/lib/ChatCraftCommandRegistry.ts
+++ b/src/lib/ChatCraftCommandRegistry.ts
@@ -25,6 +25,14 @@ export class ChatCraftCommandRegistry {
       command.execute(chat, user, parsed.args);
   }
 
+  static getCommandsList() {
+    const commandsList: ChatCraftCommand[] = [];
+
+    this.commands.forEach((command) => commandsList.push(command));
+
+    return commandsList;
+  }
+
   static isCommand(input: string): boolean {
     return ChatCraftCommand.isCommand(input);
   }

--- a/src/lib/ChatCraftCommandRegistry.ts
+++ b/src/lib/ChatCraftCommandRegistry.ts
@@ -25,12 +25,8 @@ export class ChatCraftCommandRegistry {
       command.execute(chat, user, parsed.args);
   }
 
-  static getCommandsList() {
-    const commandsList: ChatCraftCommand[] = [];
-
-    this.commands.forEach((command) => commandsList.push(command));
-
-    return commandsList;
+  static getCommands() {
+    return Array.from(this.commands.values());
   }
 
   static isCommand(input: string): boolean {

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -3,7 +3,10 @@ import { ChatCraftChat } from "../ChatCraftChat";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear");
+    super("clear", {
+      helpTitle: "/clear",
+      helpDescription: "Erases all messages in the current chat.",
+    });
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -3,10 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear", {
-      helpTitle: "/clear",
-      helpDescription: "Erases all messages in the current chat.",
-    });
+    super("clear", "/clear", "Erases all messages in the current chat.");
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/CommandsHelpCommand.ts
+++ b/src/lib/commands/CommandsHelpCommand.ts
@@ -4,7 +4,10 @@ import { ChatCraftAppMessage } from "../ChatCraftMessage";
 
 export class CommandsHelpCommand extends ChatCraftCommand {
   constructor() {
-    super("commands");
+    super("commands", {
+      helpTitle: "/commands",
+      helpDescription: "Shows a list of **supported commands** in ChatCraft",
+    });
   }
 
   static getQueriedCommand(messageText: string) {

--- a/src/lib/commands/CommandsHelpCommand.ts
+++ b/src/lib/commands/CommandsHelpCommand.ts
@@ -4,10 +4,7 @@ import { ChatCraftAppMessage } from "../ChatCraftMessage";
 
 export class CommandsHelpCommand extends ChatCraftCommand {
   constructor() {
-    super("commands", {
-      helpTitle: "/commands",
-      helpDescription: "Shows a list of **supported commands** in ChatCraft",
-    });
+    super("commands", "/commands", "Shows a list of **supported commands** in ChatCraft");
   }
 
   static getQueriedCommand(messageText: string) {

--- a/src/lib/commands/HelpCommand.ts
+++ b/src/lib/commands/HelpCommand.ts
@@ -4,7 +4,10 @@ import { ChatCraftAppMessage } from "../ChatCraftMessage";
 
 export class HelpCommand extends ChatCraftCommand {
   constructor() {
-    super("help");
+    super("help", {
+      helpTitle: "/help",
+      helpDescription: "Shows this help message.",
+    });
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/HelpCommand.ts
+++ b/src/lib/commands/HelpCommand.ts
@@ -4,10 +4,7 @@ import { ChatCraftAppMessage } from "../ChatCraftMessage";
 
 export class HelpCommand extends ChatCraftCommand {
   constructor() {
-    super("help", {
-      helpTitle: "/help",
-      helpDescription: "Shows this help message.",
-    });
+    super("help", "/help", "Shows this help message.");
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -7,11 +7,11 @@ import type { Dalle3ImageSize } from "../../lib/ai";
 
 export class ImageCommand extends ChatCraftCommand {
   constructor() {
-    super("image", {
-      helpTitle: "/image [layout-option]<prompt>",
-      helpDescription:
-        "/image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`",
-    });
+    super(
+      "image",
+      "/image [layout-option]<prompt>",
+      "/image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`"
+    );
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -7,7 +7,11 @@ import type { Dalle3ImageSize } from "../../lib/ai";
 
 export class ImageCommand extends ChatCraftCommand {
   constructor() {
-    super("image");
+    super("image", {
+      helpTitle: "/image [layout-option]<prompt>",
+      helpDescription:
+        "/image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`",
+    });
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -34,11 +34,11 @@ const guessType = (contentType: string | null) => {
 
 export class ImportCommand extends ChatCraftCommand {
   constructor() {
-    super("import", {
-      helpTitle: "/import <url>",
-      helpDescription:
-        "	Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command.",
-    });
+    super(
+      "import",
+      "/import <url>",
+      "	Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command."
+    );
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/ImportCommand.ts
+++ b/src/lib/commands/ImportCommand.ts
@@ -34,7 +34,11 @@ const guessType = (contentType: string | null) => {
 
 export class ImportCommand extends ChatCraftCommand {
   constructor() {
-    super("import");
+    super("import", {
+      helpTitle: "/import <url>",
+      helpDescription:
+        "	Loads the provided URL and imports the text. Where possible, ChatCraft will try to get raw text vs. HTML from sites like GitHub. NOTE: to prevent abuse, you must be logged into use the import command.",
+    });
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/NewCommand.ts
+++ b/src/lib/commands/NewCommand.ts
@@ -2,10 +2,7 @@ import { ChatCraftCommand } from "../ChatCraftCommand";
 
 export class NewCommand extends ChatCraftCommand {
   constructor() {
-    super("new", {
-      helpTitle: "/new",
-      helpDescription: "Creates a new chat.",
-    });
+    super("new", "/new", "Creates a new chat.");
   }
 
   async execute() {

--- a/src/lib/commands/NewCommand.ts
+++ b/src/lib/commands/NewCommand.ts
@@ -2,7 +2,10 @@ import { ChatCraftCommand } from "../ChatCraftCommand";
 
 export class NewCommand extends ChatCraftCommand {
   constructor() {
-    super("new");
+    super("new", {
+      helpTitle: "/new",
+      helpDescription: "Creates a new chat.",
+    });
   }
 
   async execute() {

--- a/src/lib/commands/SummaryCommand.ts
+++ b/src/lib/commands/SummaryCommand.ts
@@ -5,7 +5,11 @@ import { chatWithLLM } from "../ai";
 
 export class SummaryCommand extends ChatCraftCommand {
   constructor() {
-    super("summary");
+    super("summary", {
+      helpTitle: "/summary [max-length]",
+      helpDescription:
+        "Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500).",
+    });
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {

--- a/src/lib/commands/SummaryCommand.ts
+++ b/src/lib/commands/SummaryCommand.ts
@@ -5,11 +5,11 @@ import { chatWithLLM } from "../ai";
 
 export class SummaryCommand extends ChatCraftCommand {
   constructor() {
-    super("summary", {
-      helpTitle: "/summary [max-length]",
-      helpDescription:
-        "Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500).",
-    });
+    super(
+      "summary",
+      "/summary [max-length]",
+      "Uses ChatGPT to create a summary of the current chat. Optionally takes a maximum word length (defaults to 500)."
+    );
   }
 
   async execute(chat: ChatCraftChat, user: User | undefined, args?: string[]) {


### PR DESCRIPTION
I always felt that the way we manage commands help text documentation could be done better.
Currently, every time we add a new command we have to manually go and add the corresponding documentation to the `Help` component, which many new developers might not even know about.

In this PR,
1. I have added a `metaData` property to `ChatCraftCommand` class, that takes a `helpTitle` and `helpDescription` as a markdown string.
2. The `ChatCraftCommandRegistry` now exposes a list of all the supported command objects, that is used to generate the relevant documentation markdown for the commands table (instead of static text)
3. Making the `metaData` a mandatory argument in `ChatCraftCommand` constructor also ensures that if anyone adds a new command in the future, they cannot get away without adding corresponding documentation to it.

I did not file an issue prior to this, as I was just experimenting and it turned out to work well.