### PR TITLE
Fix for mobile Ask menu and z-index fixes

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -144,7 +144,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
           onClick={toggleColorMode}
         />
 
-        <Box>
+        <Box zIndex={2}>
           <Menu>
             <MenuButton
               as={IconButton}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -478,7 +478,7 @@ function MessageBase({
               </Flex>
             </Flex>
 
-            <Flex align="center">
+            <Flex align="center" zIndex={1}>
               {isHovering && (
                 <ButtonGroup isAttached display={{ base: "none", md: "block" }}>
                   <IconButton
@@ -688,7 +688,6 @@ function MessageBase({
                   <Flex w="100%" justify="space-between" align="center">
                     <Button
                       hidden={!isLongMessage || editing}
-                      zIndex={10}
                       size="sm"
                       variant="ghost"
                       onClick={() => onToggle()}

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -119,7 +119,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           title="Choose Model"
           icon={<TbChevronUp />}
         />
-        <MenuList maxHeight={"70vh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
+        <MenuList maxHeight={"85dvh"} overflowY={"auto"} zIndex={theme.zIndices.dropdown}>
           <MenuGroup title="Providers">
             {Object.entries(providersList).map(([providerName, providerObject]) => (
               <MenuItem
@@ -140,7 +140,29 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           </MenuGroup>
           <MenuDivider />
           <MenuGroup title="Models">
-            <InputGroup>
+            <Box maxHeight="40dvh" overflowY="auto">
+              {models
+                .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
+                .filter((model) =>
+                  model.prettyModel.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
+                )
+                .map((model) => (
+                  <MenuItem
+                    paddingInline={4}
+                    closeOnSelect={true}
+                    key={model.id}
+                    onClick={() => setSettings({ ...settings, model })}
+                  >
+                    {settings.model.id === model.id ? (
+                      <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
+                    ) : (
+                      <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
+                    )}
+                    {model.prettyModel}
+                  </MenuItem>
+                ))}
+            </Box>
+            <InputGroup marginTop={2}>
               <InputLeftElement paddingLeft={3} pointerEvents="none">
                 <TbSearch />
               </InputLeftElement>
@@ -158,26 +180,6 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
                 }}
               />
             </InputGroup>
-            {models
-              .filter((model) => !usingOfficialOpenAI() || model.id.includes("gpt"))
-              .filter((model) =>
-                model.prettyModel.toLowerCase().includes(debouncedSearchQuery.toLowerCase())
-              )
-              .map((model) => (
-                <MenuItem
-                  paddingInline={4}
-                  closeOnSelect={true}
-                  key={model.id}
-                  onClick={() => setSettings({ ...settings, model })}
-                >
-                  {settings.model.id === model.id ? (
-                    <IoMdCheckmark style={{ marginRight: "0.6rem" }} />
-                  ) : (
-                    <span style={{ paddingLeft: "1.6rem", display: "inline-block" }} />
-                  )}
-                  {model.prettyModel}
-                </MenuItem>
-              ))}
           </MenuGroup>
         </MenuList>
       </Menu>


### PR DESCRIPTION
After the change in https://github.com/tarasglek/chatcraft.org/pull/642, on iOS the keyboard covers the search results in the Ask Menu.

I fixed this by moving the search bar to the bottom. Bonus: it's now easier to reach!

I left the Desktop version as is, but let me know if I should change it to match the mobile version.

---

I also fixed these two visual bugs:

<img width="620" alt="Show More Button overlapping the Favourite Providers List" src="https://github.com/tarasglek/chatcraft.org/assets/53121061/3a0ea693-126f-4d86-8a3d-906dc12537b8">

<img width="285" alt="Sidebar Menu Button overlapping the Settings Menu" src="https://github.com/tarasglek/chatcraft.org/assets/53121061/a7dc7158-9714-4db0-ac78-17071c95475f">

