### PR TITLE
Use Exponential Backoff for downloading large messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dexie-export-import": "^4.1.2",
     "dexie-react-hooks": "^1.1.7",
     "esbuild-wasm": "^0.21.3",
+    "exponential-backoff": "^3.1.1",
     "feed": "^4.2.2",
     "framer-motion": "^11.2.3",
     "get-video-id": "^3.6.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ dependencies:
   esbuild-wasm:
     specifier: ^0.21.3
     version: 0.21.3
+  exponential-backoff:
+    specifier: ^3.1.1
+    version: 3.1.1
   feed:
     specifier: ^4.2.2
     version: 4.2.2
@@ -6681,6 +6684,10 @@ packages:
     resolution: {integrity: sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==}
     engines: {node: '>=6'}
     dev: true
+
+  /exponential-backoff@3.1.1:
+    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+    dev: false
 
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -278,29 +278,34 @@ function MessageBase({
 
           const tasks = textChunks.map((textChunk, index) => {
             return limit(async () => {
-              await backOff(async () => {
-                const audioClipUrl = await textToSpeech(
-                  textChunk,
-                  settings.textToSpeech.voice,
-                  "tts-1-hd"
-                );
+              await backOff(
+                async () => {
+                  const audioClipUrl = await textToSpeech(
+                    textChunk,
+                    settings.textToSpeech.voice,
+                    "tts-1-hd"
+                  );
 
-                const audioClip = await fetch(audioClipUrl).then((r) => r.blob());
-                audioClips[index] = audioClip;
+                  const audioClip = await fetch(audioClipUrl).then((r) => r.blob());
+                  audioClips[index] = audioClip;
 
-                ++chunksProcessed;
-                const processedPercentage = Math.floor(
-                  (chunksProcessed * 100) / chunksToBeProcessed
-                );
-                progress({
-                  id: alertId,
-                  title: "Downloading...",
-                  message: "Please wait while we prepare your audio download.",
-                  progressPercentage: processedPercentage,
-                  updateOnly: true,
-                  handleClose,
-                });
-              });
+                  ++chunksProcessed;
+                  const processedPercentage = Math.floor(
+                    (chunksProcessed * 100) / chunksToBeProcessed
+                  );
+                  progress({
+                    id: alertId,
+                    title: "Downloading...",
+                    message: "Please wait while we prepare your audio download.",
+                    progressPercentage: processedPercentage,
+                    updateOnly: true,
+                    handleClose,
+                  });
+                },
+                {
+                  startingDelay: 3 * 1000,
+                }
+              );
             });
           });
 

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -274,26 +274,32 @@ function MessageBase({
 
           let chunksProcessed = 0;
 
+          const { backOff } = await import("exponential-backoff");
+
           const tasks = textChunks.map((textChunk, index) => {
             return limit(async () => {
-              const audioClipUrl = await textToSpeech(
-                textChunk,
-                settings.textToSpeech.voice,
-                "tts-1-hd"
-              );
+              await backOff(async () => {
+                const audioClipUrl = await textToSpeech(
+                  textChunk,
+                  settings.textToSpeech.voice,
+                  "tts-1-hd"
+                );
 
-              const audioClip = await fetch(audioClipUrl).then((r) => r.blob());
-              audioClips[index] = audioClip;
+                const audioClip = await fetch(audioClipUrl).then((r) => r.blob());
+                audioClips[index] = audioClip;
 
-              ++chunksProcessed;
-              const processedPercentage = Math.floor((chunksProcessed * 100) / chunksToBeProcessed);
-              progress({
-                id: alertId,
-                title: "Downloading...",
-                message: "Please wait while we prepare your audio download.",
-                progressPercentage: processedPercentage,
-                updateOnly: true,
-                handleClose,
+                ++chunksProcessed;
+                const processedPercentage = Math.floor(
+                  (chunksProcessed * 100) / chunksToBeProcessed
+                );
+                progress({
+                  id: alertId,
+                  title: "Downloading...",
+                  message: "Please wait while we prepare your audio download.",
+                  progressPercentage: processedPercentage,
+                  updateOnly: true,
+                  handleClose,
+                });
               });
             });
           });


### PR DESCRIPTION
In https://github.com/tarasglek/chatcraft.org/pull/627#issuecomment-2095352160, I was advised to use exponential backoff to counter rate limiting of **3 RPM** on HQ TTS downloads.

In this PR, I am using the [exponential-backoff](https://www.npmjs.com/package/exponential-backoff?activeTab=readme) package to retry any failed operations with increasing delays between failed attempts.

The package size was around 36 kb, so I am using dynamic import to only load it when needed.

Here's how the network tab looks when downloading,

![ExponentialBackoff](https://github.com/tarasglek/chatcraft.org/assets/78865303/8b6b1611-5d97-4b71-aa0c-027bbe455754)

I think I can optimize it more by increasing the `startingDelay` value, so we don't bombard so many requests. Not sure what else could be better.

This fixes #632 