### PR TITLE
Include message card in Image Export so dark mode text is visible

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -127,6 +127,7 @@ function MessageBase({
   const isNarrowScreen = useMobileBreakpoint();
   const messageForm = useRef<HTMLFormElement>(null);
   const messageContent = useRef<HTMLDivElement>(null);
+  const messageCard = useRef<HTMLDivElement>(null);
   const meta = useMemo(getMetaKey, []);
   const [imageModalOpen, setImageModalOpen] = useState<boolean>(false);
   const [selectedImage, setSelectedImage] = useState<string>("");
@@ -210,7 +211,7 @@ function MessageBase({
   }, [info, text]);
 
   const handleDownloadImage = useCallback(() => {
-    const elem = messageContent.current;
+    const elem = messageCard.current;
     if (!elem) {
       return;
     }
@@ -230,7 +231,7 @@ function MessageBase({
         message: err.message,
       });
     }
-  }, [messageContent, info, error]);
+  }, [messageCard, info, error]);
 
   const handleDownloadPlainText = useCallback(() => {
     if (messageContent.current) {
@@ -447,7 +448,7 @@ function MessageBase({
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
     >
-      <Card>
+      <Card ref={messageCard}>
         <CardHeader p={0} pt={3} pb={2} pr={1}>
           <Flex justify="space-between" align="center" ml={5} mr={2}>
             <Flex gap={3}>


### PR DESCRIPTION
This fixes #651

The white text in the dark mode card body is camouflaged by the white background of [html2canvas](https://html2canvas.hertzen.com/).

One solution to make this text visible is to include the entire card (which wraps the text) in the HTML sent to html2canvas:
**Before (card body only, white text invisible):**
![message](https://github.com/tarasglek/chatcraft.org/assets/78163326/f0af9bc0-a474-4053-a0e8-d20c31c14a5c)
**After (entire card, white text appears as rendered inside card:**
![message](https://github.com/tarasglek/chatcraft.org/assets/78163326/6f7f3608-9270-4e5a-883e-d1ee65ec96d4)
