### PR TITLE
Visual Layout fixes

### DIFF
--- a/src/Chat/ChatHeader.tsx
+++ b/src/Chat/ChatHeader.tsx
@@ -92,7 +92,7 @@ function ChatHeader({ chat }: ChatHeaderProps) {
           <Box w="100%">
             {isEditing ? (
               <form onSubmit={handleSaveSummary}>
-                <Flex align="center" gap={2}>
+                <Flex align="center" gap={2} px={2} pb={2}>
                   <Input
                     flex={1}
                     defaultValue={chat.summary}
@@ -101,15 +101,16 @@ function ChatHeader({ chat }: ChatHeaderProps) {
                     bg="white"
                     _dark={{ bg: "gray.700" }}
                     size="sm"
+                    fontSize="1rem"
                     w="100%"
                     autoFocus={true}
                     placeholder="Chat Summary"
                   />
                   <ButtonGroup>
-                    <Button variant="outline" size="xs" onClick={() => setIsEditing(false)}>
+                    <Button variant="outline" size="sm" onClick={() => setIsEditing(false)}>
                       Cancel
                     </Button>
-                    <Button size="xs" type="submit">
+                    <Button size="sm" type="submit">
                       Save
                     </Button>
                   </ButtonGroup>

--- a/src/Function/index.tsx
+++ b/src/Function/index.tsx
@@ -16,6 +16,8 @@ import {
   Text,
   useDisclosure,
 } from "@chakra-ui/react";
+import { MdContentCopy } from "react-icons/md";
+import { TbDownload, TbTrash } from "react-icons/tb";
 import debounce from "lodash-es/debounce";
 import { useCallback, useMemo, useRef } from "react";
 import { LuFunctionSquare } from "react-icons/lu";
@@ -162,11 +164,25 @@ export default function Function() {
                         variant="ghost"
                       />
                       <MenuList>
-                        <MenuItem onClick={() => handleCopyFunctionClick()}>Copy</MenuItem>
-                        <MenuItem onClick={() => handleDownloadFunctionClick()}>Download</MenuItem>
+                        <MenuItem
+                          icon={<MdContentCopy />}
+                          onClick={() => handleCopyFunctionClick()}
+                        >
+                          Copy
+                        </MenuItem>
+                        <MenuItem
+                          icon={<TbDownload />}
+                          onClick={() => handleDownloadFunctionClick()}
+                        >
+                          Download
+                        </MenuItem>
 
                         <MenuDivider />
-                        <MenuItem color="red.400" onClick={() => handleDeleteFunctionClick()}>
+                        <MenuItem
+                          icon={<TbTrash />}
+                          color="red.400"
+                          onClick={() => handleDeleteFunctionClick()}
+                        >
                           Delete
                         </MenuItem>
                       </MenuList>

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useMemo, type ReactNode, useState } from "react";
 import {
   Flex,
-  ButtonGroup,
   IconButton,
   useClipboard,
   useColorModeValue,
@@ -198,7 +197,7 @@ function CodeHeader({
             {language}
           </Text>
         </Box>
-        <ButtonGroup isAttached pr={2}>
+        <Flex pr={2}>
           {shouldShowRunButton && (
             <Menu strategy="fixed">
               <MenuButton
@@ -252,7 +251,7 @@ function CodeHeader({
             variant="ghost"
             onClick={handleCopy}
           />
-        </ButtonGroup>
+        </Flex>
       </Flex>
       {children}
     </>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ import {
   IconButton,
   Input,
   InputGroup,
+  InputRightElement,
   Link,
   Menu,
   MenuButton,
@@ -116,13 +117,24 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
           <Form action="/s" method="get">
             <InputGroup size="sm" variant="outline">
               <Input
+                fontSize="1rem"
                 type="search"
                 name="q"
                 defaultValue={searchText}
+                borderRadius={4}
                 isRequired
                 placeholder="Search chat history"
               />
-              <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
+              <InputRightElement>
+                <IconButton
+                  size="sm"
+                  height="2rem"
+                  aria-label="Search"
+                  variant="ghost"
+                  icon={<TbSearch />}
+                  type="submit"
+                />
+              </InputRightElement>
             </InputGroup>
           </Form>
         )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,7 +2,6 @@ import { useCallback, type RefObject } from "react";
 import {
   Avatar,
   Box,
-  ButtonGroup,
   Flex,
   IconButton,
   Input,
@@ -86,7 +85,8 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
   return (
     <Flex
       w="100%"
-      gap={1}
+      h="3rem"
+      gap={3}
       bg={useColorModeValue("white", "gray.700")}
       justify="space-between"
       align="center"
@@ -95,6 +95,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
     >
       <Flex pl={1} align="center" gap={2}>
         <IconButton
+          fontSize="1.5rem"
           icon={<BiMenu />}
           variant="ghost"
           aria-label="Toggle Sidebar Menu"
@@ -102,7 +103,11 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
           onClick={onToggleSidebar}
         />
 
-        <Text fontWeight="bold" color={useColorModeValue("blue.600", "blue.200")}>
+        <Text
+          fontWeight="bold"
+          fontSize="1.125rem"
+          color={useColorModeValue("blue.600", "blue.200")}
+        >
           <Link
             href="/"
             _hover={{ textDecoration: "none", color: useColorModeValue("blue.400", "blue.100") }}
@@ -140,8 +145,9 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
         )}
       </Box>
 
-      <ButtonGroup isAttached pr={2} alignItems="center">
+      <Flex pr={2} alignItems="center">
         <IconButton
+          fontSize="1.25rem"
           aria-label={"Copy Shared Chats Feed URL"}
           title={"Copy Shared Chats Feed URL"}
           icon={<FiRss />}
@@ -149,6 +155,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
           onClick={handleOpenFeedUrl}
         />
         <IconButton
+          fontSize="1.25rem"
           aria-label={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           title={useColorModeValue("Switch to Dark Mode", "Switch to Light Mode")}
           icon={useColorModeValue(<BiMoon />, <BiSun />)}
@@ -221,7 +228,7 @@ function Header({ chatId, inputPromptRef, searchText, onToggleSidebar }: HeaderP
             </MenuList>
           </Menu>
         </Box>
-      </ButtonGroup>
+      </Flex>
 
       <PreferencesModal
         isOpen={isPrefModalOpen}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -453,7 +453,7 @@ function MessageBase({
   return (
     <Box
       id={id}
-      my={6}
+      my={5}
       flex={1}
       onMouseEnter={() => setIsHovering(true)}
       onMouseLeave={() => setIsHovering(false)}
@@ -491,7 +491,7 @@ function MessageBase({
 
             <Flex align="center" zIndex={1}>
               {isHovering && (
-                <ButtonGroup isAttached display={{ base: "none", md: "block" }}>
+                <Flex display={{ base: "none", md: "block" }}>
                   <IconButton
                     variant="ghost"
                     icon={<MdContentCopy />}
@@ -517,7 +517,7 @@ function MessageBase({
                       onClick={() => onDeleteClick()}
                     />
                   )}
-                </ButtonGroup>
+                </Flex>
               )}
               <Menu align="end" isDisabled={isLoading}>
                 <MenuItem onClick={handleCopy} icon={<MdContentCopy />}>
@@ -605,15 +605,7 @@ function MessageBase({
         </CardHeader>
         <CardBody p={0}>
           <Flex direction="column" gap={3}>
-            <Box
-              maxWidth="100%"
-              minH="2em"
-              overflow="hidden"
-              // Offset for the extra pixel of padding added to the messageContent box below
-              m={-1}
-              px={6}
-              pb={2}
-            >
+            <Box maxWidth="100%" minH="2em" overflow="hidden" px={5} pb={2}>
               {
                 // only display the button before message if the message is too long and toggled
                 !editing && isLongMessage && isOpen ? (
@@ -638,7 +630,7 @@ function MessageBase({
                       defaultValue={text}
                       autoFocus={true}
                     />
-                    <Flex width="100%" alignItems="center" alignContent="end" gap={2}>
+                    <Flex width="100%" alignItems="center" alignContent="end" gap={2} mb={2}>
                       <Spacer />
                       {!isNarrowScreen && (
                         <Text fontSize="sm" color="gray">
@@ -671,11 +663,7 @@ function MessageBase({
                   </VStack>
                 </form>
               ) : (
-                <Box
-                  ref={messageContent}
-                  // Add a single pixel of offset for rendering to canvas (offset handled above with m=-1)
-                  p={1}
-                >
+                <Box ref={messageContent} p={1}>
                   {imageUrls.map((imageUrl, index) => (
                     <Box key={`${id}-${index}`}>
                       <Image

--- a/src/components/Message/SystemMessage.tsx
+++ b/src/components/Message/SystemMessage.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import {
   Avatar,
+  Box,
   Container,
   Divider,
   Flex,
@@ -102,30 +103,30 @@ function SystemPromptVersionsMenu({
         variant="ghost"
         onClick={handleStarredChanged}
       />
-      <Menu placement="bottom-end" isLazy={true}>
-        <MenuButton
-          as={IconButton}
-          size="xs"
-          variant="ghost"
-          icon={<TbChevronDown title={`${prevSystemPrompts.length} Previous System Prompts`} />}
-        />
-        <MenuList>
-          {prevSystemPrompts.map((systemPrompt, idx, arr) => (
-            <MenuItem
-              key={systemPrompt}
-              value={systemPrompt}
-              onClick={() => onChange(systemPrompt)}
-            >
-              <Container>
-                <Text noOfLines={3} title={systemPrompt}>
-                  {systemPrompt}
-                </Text>
-                {idx < arr.length - 1 && <Divider mt={4} />}
-              </Container>
-            </MenuItem>
-          ))}
-        </MenuList>
-      </Menu>
+      {prevSystemPrompts?.length != 0 && (
+        <Menu placement="bottom" isLazy={true}>
+          <MenuButton
+            as={IconButton}
+            size="sm"
+            variant="ghost"
+            icon={<TbChevronDown title={`${prevSystemPrompts.length} Previous System Prompts`} />}
+          />
+          <MenuList zIndex={2}>
+            {prevSystemPrompts.map((systemPrompt, idx, arr) => (
+              <Box key={systemPrompt}>
+                <MenuItem value={systemPrompt} onClick={() => onChange(systemPrompt)}>
+                  <Container>
+                    <Text noOfLines={3} my={2} title={systemPrompt}>
+                      {systemPrompt}
+                    </Text>
+                  </Container>
+                </MenuItem>
+                {idx < arr.length - 1 && <Divider />}
+              </Box>
+            ))}
+          </MenuList>
+        </Menu>
+      )}
     </Flex>
   );
 }

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -314,7 +314,7 @@ function DesktopPromptForm({
 
   return (
     <Flex dir="column" w="100%" h="100%">
-      <Card flex={1} my={4} mx={1}>
+      <Card flex={1} my={3} mx={1}>
         <chakra.form onSubmit={handlePromptSubmit} h="100%">
           <CardBody h="100%" p={6}>
             <VStack w="100%" h="100%" gap={3}>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -10,7 +10,6 @@ import {
   Center,
   useColorModeValue,
   IconButton,
-  ButtonGroup,
   Input,
   Accordion,
   AccordionItem,
@@ -110,15 +109,17 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
     >
       <Flex justify="space-between" align="center" minH="32px" w="100%">
         <Link to={url} style={{ width: "100%" }}>
-          <Flex align="center" gap={2}>
-            <MdOutlineChatBubbleOutline />
+          <Flex align="center">
+            <Box px={2}>
+              <MdOutlineChatBubbleOutline />
+            </Box>
             <Text flex={1} fontSize="sm" as="strong">
               {formatDate(chat.date, true)}
             </Text>
           </Flex>
         </Link>
-        {isSelected && !isEditing ? (
-          <ButtonGroup isAttached>
+        {isSelected && !isEditing && (
+          <Flex>
             {canEdit && (
               <IconButton
                 variant="ghost"
@@ -137,11 +138,7 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
               title="Delete chat"
               onClick={onDelete}
             />
-          </ButtonGroup>
-        ) : (
-          <ButtonGroup>
-            <span>&nbsp;</span>
-          </ButtonGroup>
+          </Flex>
         )}
       </Flex>
 
@@ -153,17 +150,20 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
                 flex={1}
                 defaultValue={chat.summary}
                 type="text"
+                fontSize="1rem"
                 name="summary"
                 bg="white"
                 _dark={{ bg: "gray.700" }}
-                size="xs"
+                size="sm"
+                borderRadius={4}
+                mx={1}
                 w="100%"
                 autoFocus={true}
               />
-              <ButtonGroup isAttached>
+              <Flex>
                 <IconButton
                   variant="ghost"
-                  size="xs"
+                  size="sm"
                   icon={<CgClose />}
                   aria-label="Cancel"
                   title="Cancel"
@@ -172,17 +172,17 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
                 <IconButton
                   type="submit"
                   variant="ghost"
-                  size="xs"
+                  size="sm"
                   icon={<TbCheck />}
                   aria-label="Save"
                   title="Save"
                 />
-              </ButtonGroup>
+              </Flex>
             </Flex>
           </form>
         ) : (
           <Link to={url} style={{ width: "100%" }}>
-            <Text noOfLines={2} fontSize="sm" title={text} w="100%">
+            <Text noOfLines={2} px={2} fontSize="sm" title={text} w="100%">
               {text}
             </Text>
           </Link>
@@ -233,8 +233,10 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
     >
       <Flex justify="space-between" align="center" minH="32px" w="100%">
         <Link to={url} style={{ width: "100%" }}>
-          <Flex align="center" gap={2}>
-            <LuFunctionSquare />
+          <Flex align="center">
+            <Box px={2}>
+              <LuFunctionSquare />
+            </Box>
             <Text flex={1} fontSize="sm" as="strong">
               {func.prettyName}
             </Text>
@@ -254,7 +256,7 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
 
       <Box flex={1} maxW="100%" minH="24px">
         <Link to={url} style={{ width: "100%" }}>
-          <Text noOfLines={2} fontSize="sm" title={func.description} w="100%">
+          <Text noOfLines={2} px={2} fontSize="sm" title={func.description} w="100%">
             {func.description}
           </Text>
         </Link>
@@ -360,14 +362,14 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
 
   return (
     <Flex direction="column" h="100%" p={2} gap={4}>
-      <Accordion allowToggle>
+      <Accordion allowToggle defaultIndex={0}>
         <AccordionItem>
-          <AccordionButton p={0} minH={10}>
+          <AccordionButton p={2} minH={10}>
             <Heading as="h3" size="xs">
               Saved Chats ({formatNumber(chatsTotal || 0)})
             </Heading>
 
-            <Button as={Link} to="/c/new" size="xs" variant="ghost">
+            <Button as={Link} to="/c/new" ml={1} size="xs" variant="ghost">
               New
             </Button>
 
@@ -400,7 +402,7 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
         </AccordionItem>
 
         <AccordionItem>
-          <AccordionButton p={0} minH={10}>
+          <AccordionButton p={2} minH={10}>
             <Heading as="h3" size="xs">
               Shared Chats ({formatNumber(sharedChats.length || 0)})
             </Heading>
@@ -418,27 +420,27 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
                 />
               ))
             ) : (
-              <VStack align="left">
+              <VStack px={2} align="left">
                 <Text>You don&apos;t have any shared chats yet.</Text>
                 <Text>
                   Share your first chat by clicking the <strong>Share Chat...</strong> menu option
-                  in the chat header menu. Anyone with this URL will be able to read or duplicate
-                  the chat.
+                  in the chat header menu.
                 </Text>
+                <Text>Anyone with this URL will be able to read or duplicate the chat.</Text>
               </VStack>
             )}
           </AccordionPanel>
         </AccordionItem>
 
         <AccordionItem>
-          <AccordionButton p={0} minH={10}>
+          <AccordionButton p={2} minH={10}>
             <Flex justify="space-between" align="center">
               <Heading as="h3" size="xs">
                 Functions ({formatNumber(functions.length || 0)})
               </Heading>
 
               {functions?.length > 0 && (
-                <Button as={Link} to="/f/new" size="xs" variant="ghost">
+                <Button as={Link} to="/f/new" ml={1} size="xs" variant="ghost">
                   New
                 </Button>
               )}
@@ -457,15 +459,12 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
                 />
               ))
             ) : (
-              <VStack align="left">
+              <VStack px={2} align="left">
                 <Text>You don&apos;t have any functions yet.</Text>
-                <Text>
-                  Functions can be called by some models to perform tasks.{" "}
-                  <Link to="/f/new" target="_blank" style={{ textDecoration: "underline" }}>
-                    Create a function
-                  </Link>
-                  .
-                </Text>
+                <Text>Functions can be called by some models to perform tasks.</Text>
+                <Link to="/f/new" target="_blank" style={{ textDecoration: "underline" }}>
+                  Create a function
+                </Link>
               </VStack>
             )}
           </AccordionPanel>

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -28,7 +28,7 @@ import { Link, useNavigate } from "react-router-dom";
 
 import db from "../../lib/db";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
-import { formatDate, formatNumber } from "../../lib/utils";
+import { formatNumber } from "../../lib/utils";
 import { SharedChatCraftChat } from "../../lib/SharedChatCraftChat";
 import { useUser } from "../../hooks/use-user";
 import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
@@ -97,6 +97,21 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
       .finally(() => setIsEditing(false));
   };
 
+  const formattedDate = new Intl.DateTimeFormat(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  }).format(chat.date);
+
+  const todayDate = new Date();
+
+  const currentMonth =
+    todayDate.getFullYear() === chat.date.getFullYear() &&
+    todayDate.getMonth() === chat.date.getMonth();
+
+  const isToday = currentMonth && todayDate.getDate() === chat.date.getDate();
+  const isYesterday = currentMonth && todayDate.getDate() - 1 === chat.date.getDate();
+
   return (
     <Flex
       p={1}
@@ -114,7 +129,7 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
               <MdOutlineChatBubbleOutline />
             </Box>
             <Text flex={1} fontSize="sm" as="strong">
-              {formatDate(chat.date, true)}
+              {isToday ? "Today" : isYesterday ? "Yesterday" : formattedDate}
             </Text>
           </Flex>
         </Link>

--- a/src/components/Sidebar/SidebarMobile.tsx
+++ b/src/components/Sidebar/SidebarMobile.tsx
@@ -8,6 +8,7 @@ import {
   IconButton,
   Input,
   InputGroup,
+  InputRightElement,
   Text,
   useColorModeValue,
 } from "@chakra-ui/react";
@@ -54,13 +55,24 @@ function SidebarMobile({
           <Form action="/s" method="get" onSubmit={handleToggleSidebarVisible}>
             <InputGroup size="sm" variant="outline">
               <Input
+                fontSize="1rem"
                 type="search"
                 defaultValue={searchText}
                 name="q"
+                borderRadius={4}
                 isRequired
                 placeholder="Search chat history"
               />
-              <IconButton aria-label="Search" variant="ghost" icon={<TbSearch />} type="submit" />
+              <InputRightElement>
+                <IconButton
+                  size="sm"
+                  height="2rem"
+                  aria-label="Search"
+                  variant="ghost"
+                  icon={<TbSearch />}
+                  type="submit"
+                />
+              </InputRightElement>
             </InputGroup>
           </Form>
           <DrawerCloseButton />


### PR DESCRIPTION
This PR makes the following changes (they're all small so I thought I would group them together):
- Add missing icons to functions title menu.
- Hide star arrow button when there are no starred prompts.
- Fix divider position in starred prompts list.
- Move header search icon inside search box.
- Show Saved Chats by default when opening the Side Menu.
- Show "Today" or "Yesterday" as date in Side Menu.
- Padding and Button layout improvements.

![Chatcraft.org screenshot](https://github.com/tarasglek/chatcraft.org/assets/53121061/2dfb0c2a-75d7-4b29-8764-18f6e9b54922)

