### PR TITLE
simplify message format, improve unofficial-openai provider compatibility 

### DIFF
--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -114,11 +114,15 @@ export class ChatCraftMessage {
       });
     }
 
+    // avoid sending multipart messages if there is only text
+    // this is to expand api provider compatibility
+    const userContent = this.imageUrls.length || content.length > 1 ? content : text;
+
     switch (this.type) {
       case "ai":
         return { role: "assistant", content: text };
       case "human":
-        return { role: "user", content: this.imageUrls.length ? content : text };
+        return { role: "user", content: userContent };
       case "system":
         return { role: "system", content: text };
       case "function":

--- a/src/lib/ChatCraftMessage.ts
+++ b/src/lib/ChatCraftMessage.ts
@@ -118,7 +118,7 @@ export class ChatCraftMessage {
       case "ai":
         return { role: "assistant", content: text };
       case "human":
-        return { role: "user", content };
+        return { role: "user", content: this.imageUrls.length ? content : text };
       case "system":
         return { role: "system", content: text };
       case "function":


### PR DESCRIPTION
A lot of providers don't like it when `typeof(message.content) != "string"`. We only send complex .content when sending images now.

This fixes llama.cpp, deepseek and possibly other providers. 