### PR TITLE
Fix zIndex bug with message header menus

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -1,9 +1,7 @@
-import { Box, IconButton, useColorMode } from "@chakra-ui/react";
+import { IconButton, useColorMode } from "@chakra-ui/react";
 import { Menu as ReactMenu, type MenuProps as ReactMenuProps } from "@szhsin/react-menu";
 import React from "react";
 import { TbDots } from "react-icons/tb";
-
-import theme from "../../theme";
 
 // Stylesheets
 import "@szhsin/react-menu/dist/core.css";
@@ -24,20 +22,18 @@ const Menu: React.FC<MenuProps> = (props) => {
   );
 
   return (
-    <Box zIndex={theme.zIndices.dropdown}>
-      <ReactMenu
-        transition={true}
-        theming={colorMode === "dark" ? "dark" : undefined}
-        {...props}
-        menuButton={menuButton}
-        menuStyle={{
-          minWidth: "225px",
-          ...props.menuStyle,
-        }}
-      >
-        {props.children}
-      </ReactMenu>
-    </Box>
+    <ReactMenu
+      transition={true}
+      theming={colorMode === "dark" ? "dark" : undefined}
+      {...props}
+      menuButton={menuButton}
+      menuStyle={{
+        minWidth: "225px",
+        ...props.menuStyle,
+      }}
+    >
+      {props.children}
+    </ReactMenu>
   );
 };
 

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -489,7 +489,7 @@ function MessageBase({
               </Flex>
             </Flex>
 
-            <Flex align="center" zIndex={1}>
+            <Flex align="center">
               {isHovering && (
                 <Flex display={{ base: "none", md: "block" }}>
                   <IconButton


### PR DESCRIPTION
This PR fixes the `zIndex` bug with messages header menus, where the `menuButton` of other menu places itself over the menu list of the first expanded menu.

**Preview:**
<img width="1203" alt="image" src="https://github.com/user-attachments/assets/bfee2198-56d8-4ccb-85c2-ae16ab05d87d">

**Explanation:**

Since the header options had a `zIndex` of `1` and they were higher up in [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context) than the **options menus**, the options menus could never be placed higher with whatever zIndex we gave them were placed within the stacking context of the **header options**.

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/f9c285ec-a56f-4a7f-afc3-e38055487a41">

One thing I was wondering was that why would a zIndex value on header options flexbox work as it wasn't a positioned element.
Later I found that elements that are children to a flex container [also form a stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context).
<img width="638" alt="image" src="https://github.com/user-attachments/assets/a6af57c1-7369-492e-a2a9-83588667e683">

<img width="1723" alt="image" src="https://github.com/user-attachments/assets/19cdc80f-201f-4afb-8ee5-4695ba5d5ae1">


This fixes #671 
