### PR TITLE
Don't throw away incomplete responses from ai

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -39,6 +39,7 @@ import { WebHandler } from "../lib/WebHandler";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import ChatHeader from "./ChatHeader";
 import PreferencesModal from "../components/Preferences/PreferencesModal";
+import { ChatCompletionError } from "../lib/ai";
 
 type ChatBaseProps = {
   chat: ChatCraftChat;
@@ -356,6 +357,11 @@ function ChatBase({ chat }: ChatBaseProps) {
           forceScroll();
         }
       } catch (err: any) {
+        if (err instanceof ChatCompletionError && err.incompleteResponse) {
+          // Add this partial response to the chat
+          await chat.addMessage(err.incompleteResponse);
+        }
+
         error({
           title: `Response Error`,
           message: err.message,
@@ -367,7 +373,7 @@ function ChatBase({ chat }: ChatBaseProps) {
       }
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [user, chat, setLoading, setShouldAutoScroll, callChatApi, error]
+    [user, chat, streamingMessage, setLoading, setShouldAutoScroll, callChatApi, error]
   );
 
   // Restart auto-scrolling and resume a paused response when Follow Chat is clicked

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -164,7 +164,7 @@ function useChatOpenAI() {
           return response;
         })
         .finally(() => {
-          setStreamingMessage(undefined);
+          setStreamingMessage(() => undefined);
           setPaused(false);
           resetScrollProgress();
           setShouldAutoScroll(false);
@@ -186,6 +186,7 @@ function useChatOpenAI() {
       settings.textToSpeech.announceMessages,
       settings.textToSpeech.voice,
       settings.countTokens,
+      setStreamingMessage,
       setShouldAutoScroll,
       resetScrollProgress,
       incrementScrollProgress,

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -123,15 +123,22 @@ function useChatOpenAI() {
 
             //#endregion
 
-            setStreamingMessage(
-              new ChatCraftAiMessage({
-                id: message.id,
-                date: message.date,
-                model: message.model,
-                text: currentText,
-              })
-            );
-            incrementScrollProgress();
+            // Only set a streaming message, if we are still in the process of streaming it
+            // If the message is `undefined`, that means we have already exited the streaming state
+            // See https://github.com/tarasglek/chatcraft.org/blob/ebd165ed22cd28411cc017646c5a7ec003efb6cd/src/hooks/use-chat-openai.ts#L173
+            // We most probably reached this block due to a race condition with `requestAnimationFrame`
+            // See https://github.com/tarasglek/chatcraft.org/blob/ebd165ed22cd28411cc017646c5a7ec003efb6cd/src/lib/ai.ts#L236
+            if (streamingMessage) {
+              setStreamingMessage(
+                new ChatCraftAiMessage({
+                  id: message.id,
+                  date: message.date,
+                  model: message.model,
+                  text: currentText,
+                })
+              );
+              incrementScrollProgress();
+            }
           }
         },
       });
@@ -164,7 +171,7 @@ function useChatOpenAI() {
           return response;
         })
         .finally(() => {
-          setStreamingMessage(() => undefined);
+          setStreamingMessage(undefined);
           setPaused(false);
           resetScrollProgress();
           setShouldAutoScroll(false);

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -31,10 +31,6 @@ export class ChatCompletionError extends Error {
   constructor(originalError: Error, incompleteResponse?: ChatCraftAiMessage) {
     super(`API Error: ${originalError.message}`);
     this.incompleteResponse = incompleteResponse?.clone();
-    // Indicate that this message is incomplete with ellipses
-    if (this.incompleteResponse) {
-      this.incompleteResponse.text += "...";
-    }
   }
 }
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -221,10 +221,6 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
     } else if (token) {
       buffer.push(token);
 
-      if (buffer.length > 100) {
-        throw new Error("Hit 100");
-      }
-
       if (onData && !isPaused) {
         pendingTokens.push(token);
 


### PR DESCRIPTION
Trying to figure out #677 (cc @tarasglek)

I spent some time on this, and I have a solution, but for some reason it doesn't clear the "streaming" state when the error occurs, so the old `newMessage` (i.e., `streamingMessage`) is still being rendered.

There's some state bug here I don't understand.  @Amnish04 do you see what I'm doing wrong?

To test this, ask an LLM anything, and after it streams a few bits of the response it will throw.