### PR TITLE
Fix regression in streaming messages, cancel rAF on error

### DIFF
--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -123,22 +123,15 @@ function useChatOpenAI() {
 
             //#endregion
 
-            // Only set a streaming message, if we are still in the process of streaming it
-            // If the message is `undefined`, that means we have already exited the streaming state
-            // See https://github.com/tarasglek/chatcraft.org/blob/ebd165ed22cd28411cc017646c5a7ec003efb6cd/src/hooks/use-chat-openai.ts#L173
-            // We most probably reached this block due to a race condition with `requestAnimationFrame`
-            // See https://github.com/tarasglek/chatcraft.org/blob/ebd165ed22cd28411cc017646c5a7ec003efb6cd/src/lib/ai.ts#L236
-            if (streamingMessage) {
-              setStreamingMessage(
-                new ChatCraftAiMessage({
-                  id: message.id,
-                  date: message.date,
-                  model: message.model,
-                  text: currentText,
-                })
-              );
-              incrementScrollProgress();
-            }
+            setStreamingMessage(
+              new ChatCraftAiMessage({
+                id: message.id,
+                date: message.date,
+                model: message.model,
+                text: currentText,
+              })
+            );
+            incrementScrollProgress();
           }
         },
       });

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -213,6 +213,8 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
   let functionName = "";
   let functionArgs = "";
   let uiRenderPromise: Promise<void> | null = null;
+  // Track our animation frames so we we can cancel on error
+  let rafId: number | null = null;
 
   const streamOpenAIResponse = async (token: string, func: string, args: string) => {
     if (func || args) {
@@ -231,13 +233,15 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
         // when the main thread is ready before before proceeding so we don't
         // swamp it with too many concurrent updates.
         if (!uiRenderPromise) {
-          uiRenderPromise = new Promise((resolve) => {
-            requestAnimationFrame(() => {
+          uiRenderPromise = new Promise<void>((resolve) => {
+            rafId = requestAnimationFrame(() => {
               onData({ token: pendingTokens.join(""), currentText: buffer.join("") });
               pendingTokens.length = 0;
-              uiRenderPromise = null;
               resolve();
             });
+          }).finally(() => {
+            uiRenderPromise = null;
+            rafId = null;
           });
         }
       }
@@ -247,6 +251,12 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
   };
 
   const handleError = async (error: Error) => {
+    // Cancel any pending requestAnimationFrame on error
+    if (rafId !== null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+
     const chatCompletionError = new ChatCompletionError(
       error,
       buffer.length ? new ChatCraftAiMessage({ model, text: buffer.join("") }) : undefined
@@ -340,6 +350,11 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
     .then(handleResponse)
     .catch(handleError)
     .finally(() => {
+      // Clean up listeners and RAF
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+        rafId = null;
+      }
       removeEventListener("keydown", handleCancel);
     });
 

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -252,10 +252,7 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
 
   const handleError = async (error: Error) => {
     // Cancel any pending requestAnimationFrame on error
-    if (rafId !== null) {
-      cancelAnimationFrame(rafId);
-      rafId = null;
-    }
+    cancelAnimationFrame(rafId!);
 
     const chatCompletionError = new ChatCompletionError(
       error,
@@ -351,10 +348,8 @@ ${func.name}(${JSON.stringify(data, null, 2)})\n\`\`\`\n`;
     .catch(handleError)
     .finally(() => {
       // Clean up listeners and RAF
-      if (rafId !== null) {
-        cancelAnimationFrame(rafId);
-        rafId = null;
-      }
+      cancelAnimationFrame(rafId!);
+      rafId = null;
       removeEventListener("keydown", handleCancel);
     });
 


### PR DESCRIPTION
Fixes #681

I think the fix we did for that rAF race was wrong.  This does it higher-up the stack, keeping track of the current animation frame and canceling it on errors.

This seems to work well for me locally.