### PR TITLE
add logic to track credit left

### DIFF
--- a/src/hooks/use-cost.tsx
+++ b/src/hooks/use-cost.tsx
@@ -1,14 +1,28 @@
-import { useCallback, createContext, useContext, type ReactNode, type FC } from "react";
+import {
+  useCallback,
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  type ReactNode,
+  type FC,
+} from "react";
 import { useSessionStorage } from "react-use";
 
 type CostContextType = {
   cost: number;
   incrementCost: (amount: number) => void;
+  credit: number | null;
+  fetchCredit: () => void;
 };
 
 const CostContext = createContext<CostContextType>({
   cost: 0,
   incrementCost: () => {
+    /* do nothing */
+  },
+  credit: null,
+  fetchCredit: () => {
     /* do nothing */
   },
 });
@@ -17,15 +31,52 @@ export const useCost = () => useContext(CostContext);
 
 export const CostProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [cost, setCost] = useSessionStorage<number>("cost", 0);
+  const [localCost, setLocalCost] = useState<number>(cost);
+  const [credit, setCredit] = useState<number | null>(null);
+  const [initialLoad, setInitialLoad] = useState<boolean>(true);
+  useEffect(() => {
+    setCost(localCost);
+  }, [localCost, setCost]);
 
   const incrementCost = useCallback(
     (amount: number) => {
-      setCost(cost + amount);
+      setLocalCost((prevCost: number) => prevCost + amount);
     },
-    [cost, setCost]
+    [setLocalCost]
   );
 
-  const value = { cost, incrementCost };
+  const fetchCredit = useCallback(async () => {
+    try {
+      const response = await fetch("https://openrouter.ai/api/v1/auth/key", {
+        headers: {
+          Authorization: `Bearer APIKey`,
+        },
+      });
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const data = await response.json();
+      console.log(data);
+
+      const limitRemaining = parseFloat(data.data.limit_remaining);
+      if (isNaN(limitRemaining)) {
+        throw new Error("limit_remaining is not a valid number");
+      }
+      setCredit(data.data.limit);
+      if (!initialLoad) {
+        setLocalCost((prevCost) => prevCost + limitRemaining);
+      }
+      setInitialLoad(false);
+    } catch (error) {
+      console.error("Failed to fetch credit", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchCredit();
+  }, [fetchCredit]);
+
+  const value = { cost: localCost, incrementCost, credit, fetchCredit };
 
   return <CostContext.Provider value={value}>{children}</CostContext.Provider>;
 };


### PR DESCRIPTION

Hi, I implemented the logic to track the credit left. However, I couldn't integrate to the click send button. 
I only made changes in use-cost.tsx file, it's a hook so you can use it at any time.
You need to set the API to be able fectch the data from OpenRouter:
```
const response = await fetch("https://openrouter.ai/api/v1/auth/key", {
        headers: {
          Authorization: `Bearer APIKey`,
        },
      });
```

It's not a fully integrated feature so just let me know any hints that I can enhance it. 