### PR TITLE
`safe-area-inset-bottom` padding added to MobilePromptForm

### DIFF
--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -150,7 +150,15 @@ function MobilePromptForm({
   };
 
   return (
-    <Box flex={1} w="100%" h="100%" my={1} px={2} py={1}>
+    <Box
+      flex={1}
+      w="100%"
+      h="100%"
+      my={1}
+      px={2}
+      py={1}
+      pb="calc(env(safe-area-inset-bottom) + 15px)"
+    >
       <chakra.form onSubmit={handlePromptSubmit} h="100%">
         <Flex alignItems="end" gap={2}>
           <OptionsButton


### PR DESCRIPTION
# Description
This PR handles [Issue-655](https://github.com/tarasglek/chatcraft.org/issues/655)
It added saft-bottom padding for Mobile Devices.

# How I tested
I tried to test it with xcode simulator; however, it didn't hide the bottom navbar even though I added it to homscreen as @tarasglek told me. I also tried to access it with my phone to the locally-run chatcraft, but failed.
As a result, I tested it with using [Mobile simulator - responsive testing tool](https://www.webmobilefirst.com/en/).

# The screenshots of test for different devices.
## iPhone 13 Pro
<img width="449" alt="iPhon13Pro" src="https://github.com/user-attachments/assets/a2092988-3e4b-49b4-bbcd-14cbfe94be7a">

## Galaxy Z Flip 3
<img width="404" alt="GalaxyZ-Flip3" src="https://github.com/user-attachments/assets/bb41be15-da33-4e4c-8f3c-7faa46ebc49f">

## Galaxy Ultra 21
<img width="358" alt="GalaxyUltra21" src="https://github.com/user-attachments/assets/82304c07-92d5-4cd8-952e-93cd07c7f1e3">

## Google Pixel 6 Pro
<img width="362" alt="GooglePixel6Pro" src="https://github.com/user-attachments/assets/a69fd587-80fe-48e6-b29c-c5a5469091f4">


