### PR TITLE
Don't block sending chat when clicking Ask button

### DIFF
--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -30,11 +30,7 @@ import { useUser } from "../hooks/use-user";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { ChatCraftCommand } from "../lib/ChatCraftCommand";
 import { ChatCraftFunction } from "../lib/ChatCraftFunction";
-import {
-  ChatCraftFunctionCallMessage,
-  ChatCraftFunctionResultMessage,
-  ChatCraftHumanMessage,
-} from "../lib/ChatCraftMessage";
+import { ChatCraftFunctionCallMessage, ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
 import { WebHandler } from "../lib/WebHandler";
 import { ChatCraftCommandRegistry } from "../lib/commands";
 import ChatHeader from "./ChatHeader";

--- a/src/Chat/ChatBase.tsx
+++ b/src/Chat/ChatBase.tsx
@@ -285,20 +285,6 @@ function ChatBase({ chat }: ChatBaseProps) {
           // Add only image to the chat
           promptMessage = new ChatCraftHumanMessage({ text: "", imageUrls, user });
           await chat.addMessage(promptMessage);
-        } else {
-          // If there isn't any prompt text, see if the final message in the chat was a human
-          // message or a function response. If it was either, we'll allow sending that through
-          // again (e.g., if you modified something and want to retry, or want to share the
-          // response from the function). Otherwise bail now.
-          const finalMessage = chat.messages({ includeAppMessages: false }).at(-1);
-          if (
-            !(
-              finalMessage instanceof ChatCraftHumanMessage ||
-              finalMessage instanceof ChatCraftFunctionResultMessage
-            )
-          ) {
-            return;
-          }
         }
 
         // If there's any problem loading referenced functions, show an error

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -142,9 +142,6 @@ function DesktopPromptForm({
   const handlePromptSubmit = (e: FormEvent) => {
     e.preventDefault();
     const textValue = inputPromptRef.current?.value.trim() || "";
-    if (!textValue) {
-      return;
-    }
     if (inputPromptRef.current) {
       inputPromptRef.current.value = "";
     }


### PR DESCRIPTION
I've removed the extra logic that was blocking the chat from being submitted to the LLM when you click the Ask button.  It's annoying how it just doesn't do anything when you click "Ask" without telling you what's wrong.