### PR TITLE
Avatar for Meta-Llama-3.1-405B-Instruct model fixed

### DIFF
--- a/src/lib/ChatCraftModel.ts
+++ b/src/lib/ChatCraftModel.ts
@@ -25,9 +25,10 @@ export class ChatCraftModel {
   }
 
   get logoUrl() {
-    const vendor = this.vendor;
+    const vendor = this.vendor.toLowerCase();
+    const modelName = this.name.toLowerCase();
 
-    if (vendor === "openai" && this.name.includes("gpt")) {
+    if (vendor === "openai" && modelName.includes("gpt")) {
       return "/openai-logo.png";
     }
 
@@ -35,7 +36,7 @@ export class ChatCraftModel {
       return "/anthropic-logo.png";
     }
 
-    if (vendor === "microsoft" && this.name.includes("phi")) {
+    if (vendor === "microsoft" && modelName.includes("phi")) {
       return "/microsoft-phi-logo.png"; // Microsoft's Phi model logo
     }
 
@@ -43,11 +44,11 @@ export class ChatCraftModel {
       return "/google-gemini-logo.png";
     }
 
-    if (this.name.includes("llama")) {
+    if (modelName.includes("llama")) {
       return "/meta-logo.png";
     }
 
-    if (this.name.includes("mixtral")) {
+    if (modelName.includes("mixtral")) {
       return "/mistral-logo.png";
     }
 


### PR DESCRIPTION
# Description

This PR addresses [Issue #704]((https://github.com/tarasglek/chatcraft.org/issues/704))

The `logoUrl()` function in the `ChatCraftModel` class checks the model’s name to determine the correct logo URL. However, some Llama model names contain uppercase letters, causing the function to fail to retrieve the correct logo for these models.

This issue affected models like `sambanova/Meta-Llama-3.1-405B-Instruct` and `sambanova/Meta-Llama-3.1-70B-Instruct`, among others. This update ensures that model names are handled in a case-insensitive manner for `llama` models


# How I tested
 - I built it using `pnpm build` and ran it with `pnpm preview --host` both for Desktop version(macbook m4) and Mobile version(iPhone 15pro).
 - I ran the test code with `pnpm run test', and all passed

# Screenshot with Desktop Test
## Meta-Llama-3.1-70B-Instruct
<img width="951" alt="Screenshot 2024-11-06 at 2 35 13 PM" src="https://github.com/user-attachments/assets/be56daa4-7d81-45c6-84e0-653c100b8d41">

## Meta-Llama-3.1-405B-Instruct
<img width="958" alt="Screenshot 2024-11-06 at 2 35 38 PM" src="https://github.com/user-attachments/assets/59636429-849d-45a1-bbdb-eb307d67533e">

# Screenshot  with Mobile Test
![IMG_0731](https://github.com/user-attachments/assets/5785a7b5-c85d-4c8a-8cc2-b19cf473e60c)


