### PR TITLE
Fixing an overflow in Web handler body

### DIFF
--- a/src/components/Preferences/PreferencesModal.tsx
+++ b/src/components/Preferences/PreferencesModal.tsx
@@ -180,7 +180,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
         </Flex>
         {!isSmallViewport && <Divider />}
         <ModalBody p={0} display="flex" h="95vh">
-          <Flex flexDirection={isSmallViewport ? "column" : "row"}>
+          <Flex flexDirection={isSmallViewport ? "column" : "row"} w="100%">
             {isSmallViewport ? <MobileSettingsAccordion /> : <DesktopSettingsList />}
             <Box overflowY="auto" px={8} py={3}>
               {selectedSetting.name === "Models" && <ModelsSettings isOpen={isOpen} />}


### PR DESCRIPTION
# Description
This Fixes #613 

`<Flex/>` seems to need `width` specified to prevent from overflowing its parent. I added a width to it.

# How I tested
I Tested it with different screen size on a desktop(google chrome) using inspect page and also on a mobie device (iPhone pro 15)

In the video, when I try to move the mouse to check for overflow, it may seem stuck or unresponsive. However, this is just because I'm trying to move the mouse beyond the visible area to check if there is any overflow.

## Test Video
[Test Video](https://youtu.be/CBqwkEaSLTI)
