### PR TITLE
Allow Attaching/Drag-and-Dropping more file types

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "p-limit": "^5.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-dropzone": "^14.3.5",
     "react-icons": "^5.3.0",
     "react-markdown": "^9.0.1",
     "react-router-dom": "^6.26.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "katex": "^0.16.11",
     "linkedom": "^0.18.5",
     "lodash-es": "^4.17.21",
+    "mammoth": "^1.8.0",
     "mermaid": "^10.9.1",
     "nanoid": "^5.0.7",
     "nomnoml": "^1.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-dropzone:
+        specifier: ^14.3.5
+        version: 14.3.5(react@18.3.1)
       react-icons:
         specifier: ^5.3.0
         version: 5.3.0(react@18.3.1)
@@ -2464,6 +2467,10 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  attr-accept@2.2.5:
+    resolution: {integrity: sha512-0bDNnY/u6pPwHDMoF0FieU354oBi0a8rD9FcsLwzcGWbc8KS8KPIi7y+s13OlVY+gMWc/9xEMUgNE6Qm8ZllYQ==}
+    engines: {node: '>=4'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3426,6 +3433,10 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  file-selector@2.1.0:
+    resolution: {integrity: sha512-ZuXAqGePcSPz4JuerOY06Dzzq0hrmQ6VGoXVzGyFI1npeOfBgqGIKKpznfYWRkSLJlXutkqVC5WvGZtkFVhu9Q==}
+    engines: {node: '>= 12'}
 
   filelist@1.0.4:
     resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
@@ -4778,6 +4789,12 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-dropzone@14.3.5:
+    resolution: {integrity: sha512-9nDUaEEpqZLOz5v5SUcFA0CjM4vq8YbqO0WRls+EYT7+DvxUdzDPKNCPLqGfj3YL9MsniCLCD4RFA6M95V6KMQ==}
+    engines: {node: '>= 10.13'}
+    peerDependencies:
+      react: '>= 16.8 || 18.0.0'
 
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
@@ -8581,6 +8598,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  attr-accept@2.2.5: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.0.0
@@ -9796,6 +9815,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-selector@2.1.0:
+    dependencies:
+      tslib: 2.7.0
 
   filelist@1.0.4:
     dependencies:
@@ -11507,6 +11530,13 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-dropzone@14.3.5(react@18.3.1):
+    dependencies:
+      attr-accept: 2.2.5
+      file-selector: 2.1.0
+      prop-types: 15.8.1
+      react: 18.3.1
 
   react-fast-compare@3.2.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
+      mammoth:
+        specifier: ^1.8.0
+        version: 1.8.0
       mermaid:
         specifier: ^10.9.1
         version: 10.9.2
@@ -2326,6 +2329,10 @@ packages:
   '@vitest/utils@2.1.2':
     resolution: {integrity: sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==}
 
+  '@xmldom/xmldom@0.8.10':
+    resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
+    engines: {node: '>=10.0.0'}
+
   '@xobotyi/scrollbar-width@1.9.5':
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
 
@@ -2398,6 +2405,9 @@ packages:
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -2524,6 +2534,9 @@ packages:
 
   blake3-wasm@2.1.5:
     resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  bluebird@3.4.7:
+    resolution: {integrity: sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==}
 
   bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
@@ -3092,6 +3105,9 @@ packages:
   diffie-hellman@5.0.3:
     resolution: {integrity: sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==}
 
+  dingbat-to-unicode@1.0.1:
+    resolution: {integrity: sha512-98l0sW87ZT58pU4i61wa2OHwxbiYSbuxsCBozaVnYX2iCnr3bLM3fIes1/ej7h1YdOKuKt/MLs706TVnALA65w==}
+
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
@@ -3119,6 +3135,9 @@ packages:
   dotenv@10.0.0:
     resolution: {integrity: sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==}
     engines: {node: '>=10'}
+
+  duck@0.1.12:
+    resolution: {integrity: sha512-wkctla1O6VfP89gQ+J/yDesM0S7B7XLXjKGzXxMDVFg7uEn706niAtyYovKbyq1oT9YwDcly721/iUWoc8MVRg==}
 
   efrt@2.7.0:
     resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
@@ -3778,6 +3797,9 @@ packages:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
@@ -4074,6 +4096,9 @@ packages:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
 
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
+
   katex@0.16.11:
     resolution: {integrity: sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==}
     hasBin: true
@@ -4105,6 +4130,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
   lilconfig@3.1.2:
     resolution: {integrity: sha512-eop+wDAvpItUys0FWkHIKeC9ybYrTGbU41U5K7+bttZZeohvnY7M9dZ5kB21GNWiFT2q1OoPTvncPCgSOVO5ow==}
@@ -4158,6 +4186,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  lop@0.4.2:
+    resolution: {integrity: sha512-RefILVDQ4DKoRZsJ4Pj22TxE3omDO47yFpkIBoDKzkqPRISs5U1cnAdg/5583YPkWPaLIYHOKRMQSvjFsO26cw==}
+
   loupe@3.1.1:
     resolution: {integrity: sha512-edNu/8D5MKVfGVFRhFf8aAxiTM6Wumfz5XsaatSxlD3w4R1d/WEKUTydCdPGbl9K7QG/Ca3GnDV2sIKIpXRQcw==}
 
@@ -4172,6 +4203,11 @@ packages:
 
   magic-string@0.30.11:
     resolution: {integrity: sha512-+Wri9p0QHMy+545hKww7YAu5NyzF8iomPL/RQazugQ9+Ez4Ic3mERMd8ZTX5rfK944j+560ZJi8iAwgak1Ac7A==}
+
+  mammoth@1.8.0:
+    resolution: {integrity: sha512-pJNfxSk9IEGVpau+tsZFz22ofjUsl2mnA5eT8PjPs2n0BP+rhVte4Nez6FdgEuxv3IGI3afiV46ImKqTGDVlbA==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
 
   markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
@@ -4587,6 +4623,9 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  option@0.2.4:
+    resolution: {integrity: sha512-pkEqbDyl8ou5cpq+VsnQbe/WlEy5qS7xPzMS1U55OCG9KPvwFD46zDbxQIj3egJSFc3D+XhYOPUzz49zQAVy7A==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -5194,6 +5233,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
   stack-generator@2.0.10:
     resolution: {integrity: sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==}
 
@@ -5489,6 +5531,9 @@ packages:
 
   unbox-primitive@1.0.2:
     resolution: {integrity: sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==}
+
+  underscore@1.13.7:
+    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -5894,6 +5939,10 @@ packages:
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
+
+  xmlbuilder@10.1.1:
+    resolution: {integrity: sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==}
+    engines: {node: '>=4.0'}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -8426,6 +8475,8 @@ snapshots:
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
+  '@xmldom/xmldom@0.8.10': {}
+
   '@xobotyi/scrollbar-width@1.9.5': {}
 
   '@zag-js/dom-query@0.16.0': {}
@@ -8494,6 +8545,10 @@ snapshots:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
 
@@ -8657,6 +8712,8 @@ snapshots:
   binary-extensions@2.3.0: {}
 
   blake3-wasm@2.1.5: {}
+
+  bluebird@3.4.7: {}
 
   bn.js@4.12.0: {}
 
@@ -9316,6 +9373,8 @@ snapshots:
       miller-rabin: 4.0.1
       randombytes: 2.1.0
 
+  dingbat-to-unicode@1.0.1: {}
+
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
@@ -9343,6 +9402,10 @@ snapshots:
       domhandler: 5.0.3
 
   dotenv@10.0.0: {}
+
+  duck@0.1.12:
+    dependencies:
+      underscore: 1.13.7
 
   efrt@2.7.0: {}
 
@@ -10181,6 +10244,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  immediate@3.0.6: {}
+
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -10439,6 +10504,13 @@ snapshots:
       object.assign: 4.1.5
       object.values: 1.2.0
 
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
+
   katex@0.16.11:
     dependencies:
       commander: 8.3.0
@@ -10465,6 +10537,10 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lilconfig@3.1.2: {}
 
@@ -10532,6 +10608,12 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  lop@0.4.2:
+    dependencies:
+      duck: 0.1.12
+      option: 0.2.4
+      underscore: 1.13.7
+
   loupe@3.1.1:
     dependencies:
       get-func-name: 2.0.2
@@ -10552,6 +10634,19 @@ snapshots:
   magic-string@0.30.11:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  mammoth@1.8.0:
+    dependencies:
+      '@xmldom/xmldom': 0.8.10
+      argparse: 1.0.10
+      base64-js: 1.5.1
+      bluebird: 3.4.7
+      dingbat-to-unicode: 1.0.1
+      jszip: 3.10.1
+      lop: 0.4.2
+      path-is-absolute: 1.0.1
+      underscore: 1.13.7
+      xmlbuilder: 10.1.1
 
   markdown-table@3.0.3: {}
 
@@ -11335,6 +11430,8 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  option@0.2.4: {}
+
   optionator@0.9.4:
     dependencies:
       deep-is: 0.1.4
@@ -12026,6 +12123,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sprintf-js@1.0.3: {}
+
   stack-generator@2.0.10:
     dependencies:
       stackframe: 1.3.4
@@ -12346,6 +12445,8 @@ snapshots:
       has-bigints: 1.0.2
       has-symbols: 1.0.3
       which-boxed-primitive: 1.0.2
+
+  underscore@1.13.7: {}
 
   undici-types@5.26.5: {}
 
@@ -12866,6 +12967,8 @@ snapshots:
   xml-js@1.6.11:
     dependencies:
       sax: 1.4.1
+
+  xmlbuilder@10.1.1: {}
 
   xtend@4.0.2: {}
 

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -252,7 +252,7 @@ function OptionsButton({
             ref={fileInputRef}
             hidden
             onChange={handleFileChange}
-            accept="image/*,text/*,.pdf,application/pdf,.json,application/json,application/markdown"
+            accept="image/*,text/*,.pdf,application/pdf,*.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.json,application/json,application/markdown"
           />
           <MenuItem icon={<BsPaperclip />} onClick={handleAttachFiles}>
             Attach Files...

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -1,4 +1,12 @@
-import { FormEvent, KeyboardEvent, type RefObject, useEffect, useMemo, useState } from "react";
+import {
+  FormEvent,
+  KeyboardEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   Box,
   Card,
@@ -11,9 +19,11 @@ import {
   Spinner,
   Square,
   Text,
+  useColorModeValue,
   VStack,
 } from "@chakra-ui/react";
 import AutoResizingTextarea from "../AutoResizingTextarea";
+import { useDropzone } from "react-dropzone";
 
 import { useSettings } from "../../hooks/use-settings";
 import { compressImageToBase64, getMetaKey, updateImageUrls } from "../../lib/utils";
@@ -27,6 +37,9 @@ import { useKeyDownHandler } from "../../hooks/use-key-down-handler";
 import { useAlert } from "../../hooks/use-alert";
 import ImageModal from "../ImageModal";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
+import { ChatCraftHumanMessage } from "../../lib/ChatCraftMessage";
+import { JinjaReaderResponse } from "../../lib/ai";
+import { importFiles } from "../../lib/file";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -76,7 +89,7 @@ function DesktopPromptForm({
   previousMessage,
 }: DesktopPromptFormProps) {
   const [isPromptEmpty, setIsPromptEmpty] = useState(true);
-  const { error } = useAlert();
+  const { error, progress, closeToast } = useAlert();
   const { settings } = useSettings();
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
@@ -88,6 +101,79 @@ function DesktopPromptForm({
   const [imageModalOpen, setImageModalOpen] = useState<boolean>(false);
   const [selectedImageUrl, setSelectedImageUrl] = useState<string>("");
   const location = useLocation();
+
+  const onImportFile = useCallback(
+    (file: File, contents: string | JinjaReaderResponse) => {
+      if (file.type === "application/pdf") {
+        const document = (contents as JinjaReaderResponse).data;
+        // TODO: should we handle the title, URL, description here too?
+        chat.addMessage(new ChatCraftHumanMessage({ text: `${document.content}\n` }));
+      } else if (
+        file.type.startsWith("text/") ||
+        file.type === "application.json" ||
+        file.type === "application/markdown"
+      ) {
+        const document = contents as string;
+        chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
+      } else if (file.type.startsWith("image/")) {
+        const base64 = contents as string;
+        updateImageUrls(base64, setInputImageUrls);
+      } else {
+        error({
+          title: "Unsupported file type",
+          message: `The file ${file.name} could not be read`,
+        });
+      }
+    },
+    [chat, error]
+  );
+
+  /**
+   * When we drag-and-drop or click "Attach Files" and import files
+   */
+  const onImportFiles = useCallback(
+    async (files: File[]) => {
+      if (!files?.length) {
+        return;
+      }
+
+      const progressId = progress({
+        title: `Processing file${files.length > 1 ? "" : "s"}`,
+        progressPercentage: 0,
+      });
+
+      try {
+        await importFiles(files, {
+          onFile: onImportFile,
+          onProgress: (value: number) =>
+            progress({
+              id: progressId,
+              title: `Processing file${files.length > 1 ? "" : "s"}`,
+              progressPercentage: value,
+              updateOnly: true,
+            }),
+          onError: (_file, err) => error({ title: "Unable to import file", message: err.message }),
+        });
+      } catch (err: any) {
+        console.error(err);
+        error({ title: "Error processing file", message: err.message });
+      } finally {
+        closeToast(progressId);
+      }
+    },
+    [closeToast, error, progress, onImportFile]
+  );
+  const { getRootProps, isDragActive } = useDropzone({
+    onDrop: onImportFiles,
+    multiple: true,
+    accept: {
+      "image/*": [],
+      "application/pdf": [".pdf"],
+      "application/json": [],
+      "application/markdown": [],
+      "text/*": [],
+    },
+  });
 
   // Focus the prompt form when the user navigates
   useEffect(() => {
@@ -236,13 +322,6 @@ function DesktopPromptForm({
       });
   };
 
-  const handleDropImage = (e: React.DragEvent) => {
-    e.preventDefault();
-    const files = Array.from(e.dataTransfer.files);
-    const imageFiles = files.filter((file) => file.type.startsWith("image/"));
-    processImages(imageFiles);
-  };
-
   const handleDeleteImage = (index: number) => {
     const updatedImageUrls = [...inputImageUrls];
     updatedImageUrls.splice(index, 1);
@@ -291,19 +370,23 @@ function DesktopPromptForm({
     // Otherwise, let the default paste handling happen
   };
 
+  const activeBorder = useColorModeValue("green.100", "green.600");
+
   return (
     <Flex dir="column" w="100%" h="100%">
       <Card flex={1} my={3} mx={1}>
         <chakra.form onSubmit={handlePromptSubmit} h="100%">
-          <CardBody h="100%" px={6} py={4}>
+          <CardBody
+            h="100%"
+            px={6}
+            py={4}
+            transition="background-color 0.2 ease"
+            _hover={{ borderColor: activeBorder }}
+            borderColor={isDragActive ? activeBorder : "inherit"}
+            {...getRootProps()}
+          >
             <VStack w="100%" h="100%" gap={3}>
-              <InputGroup
-                h="100%"
-                bg="white"
-                _dark={{ bg: "gray.700" }}
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={handleDropImage}
-              >
+              <InputGroup h="100%" bg="white" _dark={{ bg: "gray.700" }}>
                 <Flex w="100%" h="100%" direction="column">
                   <Flex flexWrap="wrap">
                     {inputImageUrls.map((imageUrl, index) => (
@@ -409,9 +492,7 @@ function DesktopPromptForm({
                   forkUrl={forkUrl}
                   variant="outline"
                   isDisabled={isLoading}
-                  onFileSelected={(base64String) => {
-                    updateImageUrls(base64String, setInputImageUrls);
-                  }}
+                  onFileSelected={onImportFile}
                 />
 
                 <Flex alignItems="center" gap={2}>

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -304,7 +304,7 @@ function DesktopPromptForm({
     // Otherwise, let the default paste handling happen
   };
 
-  const activeBorder = useColorModeValue("green.100", "green.600");
+  const dragDropBorderColor = useColorModeValue("blue.200", "blue.600");
 
   return (
     <Flex dir="column" w="100%" h="100%">
@@ -314,9 +314,9 @@ function DesktopPromptForm({
             h="100%"
             px={6}
             py={4}
-            transition="background-color 0.2 ease"
-            _hover={{ borderColor: activeBorder }}
-            borderColor={isDragActive ? activeBorder : "inherit"}
+            border={"4px solid"}
+            borderColor={isDragActive ? dragDropBorderColor : "transparent"}
+            borderRadius={".375rem"}
             {...getRootProps()}
           >
             <VStack w="100%" h="100%" gap={3}>

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -104,6 +104,7 @@ function DesktopPromptForm({
       "application/pdf": [".pdf"],
       "application/json": [],
       "application/markdown": [],
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document": [],
       "text/*": [],
     },
   });

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useAlert } from "./use-alert";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
-import { JinjaReaderResponse, pdfToMarkdown } from "../lib/ai";
+import { JinaAiReaderResponse, pdfToMarkdown } from "../lib/ai";
 import { compressImageToBase64, formatAsCodeBlock } from "../lib/utils";
 import { getSettings } from "../lib/settings";
 
@@ -133,7 +133,7 @@ function formatTextContent(filename: string, type: string, content: string): str
 async function processFile(
   file: File,
   settings: ReturnType<typeof getSettings>
-): Promise<string | JinjaReaderResponse> {
+): Promise<string | JinaAiReaderResponse> {
   if (file.type.startsWith("image/")) {
     return await compressImageToBase64(file, {
       compressionFactor: settings.compressionFactor,
@@ -173,18 +173,18 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
   const settings = getSettings();
 
   const importFile = useCallback(
-    (file: File, contents: string | JinjaReaderResponse) => {
+    (file: File, contents: string | JinaAiReaderResponse) => {
       if (file.type.startsWith("image/")) {
         const base64 = contents as string;
         onImageImport(base64);
       } else if (file.type === "application/pdf") {
-        const document = (contents as JinjaReaderResponse).data;
+        const document = (contents as JinaAiReaderResponse).data;
         chat.addMessage(new ChatCraftHumanMessage({ text: `${document.content}\n` }));
       } else if (
         file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
       ) {
         // TODO: need to get HTML -> Markdown working
-        // const document = (contents as JinjaReaderResponse).data;
+        // const document = (contents as JinaAiReaderResponse).data;
         console.log("contents", contents);
         const document = contents as string;
         chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -2,7 +2,7 @@ import { useCallback } from "react";
 import { useAlert } from "./use-alert";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
 import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
-import { JinaAiReaderResponse, pdfToMarkdown } from "../lib/ai";
+import { type JinaAiReaderResponse, pdfToMarkdown } from "../lib/ai";
 import { compressImageToBase64, formatAsCodeBlock } from "../lib/utils";
 import { getSettings } from "../lib/settings";
 
@@ -40,26 +40,11 @@ async function readWordDocx(docx: File) {
   try {
     const mammoth = await import("mammoth");
     const arrayBuffer = await readBinaryFile(docx);
-    console.log({ arrayBuffer });
-    const result = await mammoth.convertToHtml(
-      { arrayBuffer },
-      {
-        // TODO: how should we handle inline images?  Strip them out for now (too many tokens)
-        // https://github.com/mwilliamson/mammoth.js/?tab=readme-ov-file#image-converters
-        convertImage: mammoth.images.imgElement(async () => ({
-          src: "",
-        })),
-      }
-    );
-    console.log({ result });
-    const html = result.value;
-
-    // TODO: this isn't working, not sure why...
-    // const markdown = await htmlToMarkdown(html);
-    // return markdown;
-
-    // TODO: return the HTML until we can get proper Markdown
-    return html;
+    // NOTE: we can also extract an HTML version, but it produces more tokens for not
+    // much benefit. We could try to pass the HTML through a parser to produce Markdown
+    // but so far that hasn't worked. See mammoth.convertToHtml().
+    const result = await mammoth.extractRawText({ arrayBuffer });
+    return result.value;
   } catch (err: any) {
     console.error("Error reading DOCX", err);
     throw new Error("Unable to parse DOCX file: " + err.message);

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -1,0 +1,179 @@
+import { useCallback } from "react";
+import { useAlert } from "./use-alert";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
+import { JinjaReaderResponse, pdfToMarkdown } from "../lib/ai";
+import { compressImageToBase64, formatAsCodeBlock } from "../lib/utils";
+import { getSettings } from "../lib/settings";
+
+function readTextFile(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error(`Unable to read text from file ${file.name}`));
+      }
+    };
+    reader.readAsText(file, "utf-8");
+  });
+}
+
+const FILE_EXTENSIONS: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  py: "python",
+  rb: "ruby",
+  java: "java",
+  cpp: "cpp",
+  c: "c",
+  cs: "csharp",
+  go: "go",
+  rs: "rust",
+  php: "php",
+  swift: "swift",
+  kt: "kotlin",
+  scala: "scala",
+  html: "html",
+  htm: "html",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  sh: "bash",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  xml: "xml",
+};
+
+// MIME type mappings for common programming languages
+const MIME_TYPES: Record<string, string> = {
+  "text/typescript": "typescript",
+  "application/typescript": "typescript",
+  "text/javascript": "javascript",
+  "application/javascript": "javascript",
+  "text/python": "python",
+  "text/x-python": "python",
+  "text/x-ruby": "ruby",
+  "text/java": "java",
+  "text/x-c": "c",
+  "text/x-c++": "cpp",
+  "text/x-csharp": "csharp",
+  "text/x-go": "go",
+  "text/x-rust": "rust",
+  "text/x-php": "php",
+  "text/x-swift": "swift",
+  "text/x-kotlin": "kotlin",
+  "text/html": "html",
+  "text/css": "css",
+  "text/x-sql": "sql",
+  "application/json": "json",
+  "text/xml": "xml",
+  "application/xml": "xml",
+};
+
+function detectLanguage(filename: string, mimeType: string): string | undefined {
+  const extension = filename.split(".").pop()?.toLowerCase() || "";
+  return FILE_EXTENSIONS[extension] || MIME_TYPES[mimeType];
+}
+
+function formatTextContent(filename: string, type: string, content: string): string {
+  const language = detectLanguage(filename, type);
+  return formatAsCodeBlock(content, language);
+}
+
+async function processFile(
+  file: File,
+  settings: ReturnType<typeof getSettings>
+): Promise<string | JinjaReaderResponse> {
+  if (file.type.startsWith("image/")) {
+    return await compressImageToBase64(file, {
+      compressionFactor: settings.compressionFactor,
+      maxSizeMB: settings.maxCompressedFileSizeMB,
+      maxWidthOrHeight: settings.maxImageDimension,
+    });
+  }
+
+  if (file.type === "application/pdf") {
+    return await pdfToMarkdown(file);
+  }
+
+  if (file.type === "application/markdown" || file.type === "text/markdown") {
+    return await readTextFile(file);
+  }
+
+  if (file.type.startsWith("text/") || file.type === "application/json") {
+    const text = await readTextFile(file);
+    return formatTextContent(file.name, file.type, text);
+  }
+
+  throw new Error(`Unsupported file type: ${file.name} (${file.type})`);
+}
+
+type UseFileImportOptions = {
+  chat: ChatCraftChat;
+  // We (currently) handle images differently, placing them in the prompt vs. a message
+  onImageImport: (base64: string) => void;
+};
+
+export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
+  const { error, progress, closeToast } = useAlert();
+  const settings = getSettings();
+
+  const importFile = useCallback(
+    (file: File, contents: string | JinjaReaderResponse) => {
+      if (file.type.startsWith("image/")) {
+        const base64 = contents as string;
+        onImageImport(base64);
+      } else if (file.type === "application/pdf") {
+        const document = (contents as JinjaReaderResponse).data;
+        chat.addMessage(new ChatCraftHumanMessage({ text: `${document.content}\n` }));
+      } else {
+        const document = contents as string;
+        chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
+      }
+    },
+    [chat, onImageImport]
+  );
+
+  const importFiles = useCallback(
+    async (files: File[]) => {
+      if (!files?.length) {
+        return;
+      }
+
+      let processed = 0;
+      const progressId = progress({
+        title: `Processing file${files.length > 1 ? "s" : ""}`,
+        progressPercentage: 0,
+      });
+
+      try {
+        for (const file of files) {
+          try {
+            const contents = await processFile(file, settings);
+            importFile(file, contents);
+          } catch (err: any) {
+            error({ title: "Unable to import file", message: err.message });
+          } finally {
+            progress({
+              id: progressId,
+              title: `Processing file${files.length > 1 ? "s" : ""}`,
+              progressPercentage: Math.floor((++processed * 100) / files.length),
+              updateOnly: true,
+            });
+          }
+        }
+      } finally {
+        closeToast(progressId);
+      }
+    },
+    [closeToast, error, progress, importFile, settings]
+  );
+
+  return importFiles;
+}

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -511,7 +511,7 @@ export function isChatModel(model: string): boolean {
   );
 }
 
-export type JinjaReaderResponse = {
+export type JinaAiReaderResponse = {
   code: number;
   status: number;
   data: {
@@ -531,7 +531,7 @@ export type JinjaReaderResponse = {
 async function convertToMarkdownWithJina(
   file: File | string,
   type: "pdf" | "html"
-): Promise<JinjaReaderResponse> {
+): Promise<JinaAiReaderResponse> {
   try {
     let contents: string;
     if ((type === "pdf" || type === "html") && file instanceof File) {
@@ -585,13 +585,11 @@ async function convertToMarkdownWithJina(
     });
     if (!res.ok) {
       const error = await res.json();
-      throw new Error(`Error converting ${type} file with Jinja.ai Reader: ${error}`);
+      throw new Error(`Error converting ${type} file with Jina.ai Reader: ${error}`);
     }
-    const result: JinjaReaderResponse = await res.json();
+    const result: JinaAiReaderResponse = await res.json();
     if (result.code !== 200) {
-      throw new Error(
-        `Error converting ${type} file with Jinja.ai Reader: got code ${result.code}`
-      );
+      throw new Error(`Error converting ${type} file with Jina.ai Reader: got code ${result.code}`);
     }
     return result;
   } catch (err) {
@@ -604,7 +602,7 @@ async function convertToMarkdownWithJina(
  * Parse a PDF to Markdown using https://jina.ai/reader/
  * @param file a PDF file to parse
  */
-export async function pdfToMarkdown(file: File): Promise<JinjaReaderResponse> {
+export async function pdfToMarkdown(file: File): Promise<JinaAiReaderResponse> {
   return convertToMarkdownWithJina(file, "pdf");
 }
 
@@ -612,7 +610,7 @@ export async function pdfToMarkdown(file: File): Promise<JinjaReaderResponse> {
  * Parse an HTML to Markdown using https://jina.ai/reader/
  * @param file an HTML file to parse
  */
-export async function htmlToMarkdown(html: File | string): Promise<JinjaReaderResponse> {
+export async function htmlToMarkdown(html: File | string): Promise<JinaAiReaderResponse> {
   // TODO: jina.ai is not returning the expected result for HTML, not sure why...
   return convertToMarkdownWithJina(html, "html");
 }

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,0 +1,145 @@
+import { compressImageToBase64, formatAsCodeBlock } from "./utils";
+import { getSettings } from "./settings";
+import { JinjaReaderResponse, pdfToMarkdown } from "./ai";
+
+function readTextFile(file: File) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const result = e.target?.result;
+      if (typeof result === "string") {
+        resolve(result);
+      } else {
+        reject(new Error(`Unable to read text from file ${file.name}`));
+      }
+    };
+    reader.readAsText(file, "utf-8");
+  });
+}
+
+export function textFileToMarkdownCodeBlock(
+  filename: string,
+  type: string,
+  content: string
+): string {
+  // Common programming language extensions and their markdown identifiers
+  const codeBlockMap: Record<string, string> = {
+    ts: "typescript",
+    tsx: "typescript",
+    js: "javascript",
+    jsx: "javascript",
+    py: "python",
+    rb: "ruby",
+    java: "java",
+    cpp: "cpp",
+    c: "c",
+    cs: "csharp",
+    go: "go",
+    rs: "rust",
+    php: "php",
+    swift: "swift",
+    kt: "kotlin",
+    scala: "scala",
+    html: "html",
+    htm: "html",
+    css: "css",
+    scss: "scss",
+    sql: "sql",
+    sh: "bash",
+    yaml: "yaml",
+    yml: "yaml",
+    json: "json",
+    xml: "xml",
+  };
+
+  // MIME type mappings for common programming languages
+  const mimeTypeMap: Record<string, string> = {
+    "text/typescript": "typescript",
+    "application/typescript": "typescript",
+    "text/javascript": "javascript",
+    "application/javascript": "javascript",
+    "text/python": "python",
+    "text/x-python": "python",
+    "text/x-ruby": "ruby",
+    "text/java": "java",
+    "text/x-c": "c",
+    "text/x-c++": "cpp",
+    "text/x-csharp": "csharp",
+    "text/x-go": "go",
+    "text/x-rust": "rust",
+    "text/x-php": "php",
+    "text/x-swift": "swift",
+    "text/x-kotlin": "kotlin",
+    "text/html": "html",
+    "text/css": "css",
+    "text/x-sql": "sql",
+    "application/json": "json",
+    "text/xml": "xml",
+    "application/xml": "xml",
+  };
+
+  // Get file extension
+  const extension = filename.split(".").pop()?.toLowerCase() || "";
+
+  // Try to determine language from extension or MIME type
+  const languageFromExt = extension ? codeBlockMap[extension] : undefined;
+  const languageFromMime = mimeTypeMap[type];
+  const language = languageFromExt || languageFromMime;
+
+  // If we found a matching language, wrap in code block
+  if (language) {
+    return formatAsCodeBlock(content, language);
+  }
+
+  // Default: return content as-is
+  return content;
+}
+
+type ImportFilesOptions = {
+  onFile: (file: File, contents: string | JinjaReaderResponse) => void;
+  onProgress?: (progress: number) => void;
+  onError?: (file: File, err: Error) => void;
+};
+
+export async function importFiles(
+  files: FileList | File[],
+  { onFile, onProgress, onError }: ImportFilesOptions
+) {
+  const settings = getSettings();
+
+  let processed = 0;
+  for (const file of files) {
+    try {
+      console.log(file);
+      if (file.type.startsWith("image/")) {
+        const base64 = await compressImageToBase64(file, {
+          compressionFactor: settings.compressionFactor,
+          maxSizeMB: settings.maxCompressedFileSizeMB,
+          maxWidthOrHeight: settings.maxImageDimension,
+        });
+        onFile(file, base64);
+      } else if (file.type === "application/pdf") {
+        const markdown = await pdfToMarkdown(file);
+        onFile(file, markdown);
+      } else if (file.type === "application/markdown" || file.type === "text/markdown") {
+        const markdown = await readTextFile(file);
+        onFile(file, markdown);
+      } else if (file.type.startsWith("text/") || file.type === "application/json") {
+        const text = await readTextFile(file);
+        const markdown = textFileToMarkdownCodeBlock(file.name, file.type, text);
+        onFile(file, markdown);
+      } else {
+        throw new Error(`Unable to import file: ${file.name} (${file.type})`);
+      }
+    } catch (err: any) {
+      console.error(err);
+      if (onError) {
+        onError(file, err);
+      }
+    } finally {
+      if (onProgress) {
+        onProgress(Math.floor((processed++ * 100) / files.length));
+      }
+    }
+  }
+}

--- a/src/lib/file.ts
+++ b/src/lib/file.ts
@@ -1,6 +1,6 @@
 import { compressImageToBase64, formatAsCodeBlock } from "./utils";
 import { getSettings } from "./settings";
-import { JinjaReaderResponse, pdfToMarkdown } from "./ai";
+import { JinaAiReaderResponse, pdfToMarkdown } from "./ai";
 
 function readTextFile(file: File) {
   return new Promise<string>((resolve, reject) => {
@@ -96,7 +96,7 @@ export function textFileToMarkdownCodeBlock(
 }
 
 type ImportFilesOptions = {
-  onFile: (file: File, contents: string | JinjaReaderResponse) => void;
+  onFile: (file: File, contents: string | JinaAiReaderResponse) => void;
   onProgress?: (progress: number) => void;
   onError?: (file: File, err: Error) => void;
 };


### PR DESCRIPTION
This updates our "Attach Files..." menu option and Drag-and-Drop to support the following file types:

- images: works same as before
- PDF files: converts to markdown with jina.ai, then creates a new message with the contents
- text files: tries to syntax highlight when type is known and creates a new message with the contents
- Word DOCX: converts to HTML then to Markdown (the last bit isn't working yet)

You can attach or drag-and-drop a bunch of files and it will process them all.

A few things could be improved, which I ran out of time to work on (can happen in follow ups, or others can push fixes):

1. I want proper CSS to happen when the user drags over the prompt form so you know it's a drop target.  I tried to do something with a green border, but it's not working.
2. ~There is a bunch of code duplication here that could be tamed~
3. I want to be able to add a jina.ai provider key in the settings modal so you can have LLM Providers and "Document Providers" (e.g., services that allow you to process file types into text for LLMs).  This isn't critical, since it works now.

@menghif, @Amnish04: can you see what I'm doing wrong with my CSS on the drop target?