### PR TITLE
Move `isTtsSupported` into `useModels`

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -63,7 +63,7 @@ import useAudioPlayer from "../../hooks/use-audio-player";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useUser } from "../../hooks/use-user";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
-import { isChatModel, isTextToSpeechModel, textToSpeech } from "../../lib/ai";
+import { isChatModel, textToSpeech } from "../../lib/ai";
 import { getSentenceChunksFrom } from "../../lib/summarize";
 import "./Message.css";
 
@@ -114,10 +114,7 @@ function MessageBase({
 }: MessageBaseProps) {
   const [, copyToClipboard] = useCopyToClipboard();
   const { id, date, text, imageUrls } = message;
-  const { models } = useModels();
-  const isTtsSupported = useMemo(() => {
-    return !!models.find((model) => isTextToSpeechModel(model.id));
-  }, [models]);
+  const { models, isTtsSupported } = useModels();
   const { onCopy } = useClipboard(text);
   const { info, error, progress, closeToast } = useAlert();
   const [isHovering, setIsHovering] = useState(false);

--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -28,7 +28,7 @@ import {
   Tr,
   VStack,
 } from "@chakra-ui/react";
-import { ChangeEvent, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
 
 import { capitalize } from "lodash-es";
 import { FaCheck } from "react-icons/fa";
@@ -39,7 +39,7 @@ import { useModels } from "../../hooks/use-models";
 import { useSettings } from "../../hooks/use-settings";
 import { ChatCraftModel } from "../../lib/ChatCraftModel";
 import { ChatCraftProvider, ProviderData } from "../../lib/ChatCraftProvider";
-import { isTextToSpeechModel, textToSpeech } from "../../lib/ai";
+import { textToSpeech } from "../../lib/ai";
 import db from "../../lib/db";
 import { providerFromUrl, supportedProviders } from "../../lib/providers";
 import { CustomProvider } from "../../lib/providers/CustomProvider";
@@ -69,7 +69,7 @@ interface ModelsSettingsProps {
 
 function ModelsSettings(isOpen: ModelsSettingsProps) {
   const { settings, setSettings } = useSettings();
-  const { models } = useModels();
+  const { models, isTtsSupported } = useModels();
 
   // Whether our db is being persisted
   const [isPersisted, setIsPersisted] = useState(false);
@@ -499,11 +499,6 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isOpen]);
-
-  // we have multiple isTtsSupported
-  const isTtsSupported = useMemo(() => {
-    return !!models.find((model) => isTextToSpeechModel(model.id));
-  }, [models]);
 
   return (
     <Box my={3}>

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -23,10 +23,10 @@ import { useModels } from "../../hooks/use-models";
 import theme from "../../theme";
 import { MdVolumeOff, MdVolumeUp } from "react-icons/md";
 import { IoMdCheckmark } from "react-icons/io";
-import { type KeyboardEvent, useMemo, useRef, useState } from "react";
+import { type KeyboardEvent, useRef, useState } from "react";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import { useDebounce } from "react-use";
-import { isChatModel, isTextToSpeechModel } from "../../lib/ai";
+import { isChatModel } from "../../lib/ai";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -36,12 +36,8 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const { settings, setSettings } = useSettings();
-  const { models } = useModels();
+  const { models, isTtsSupported } = useModels();
   const inputRef = useRef<HTMLInputElement>(null);
-
-  const isTtsSupported = useMemo(() => {
-    return !!models.find((model) => isTextToSpeechModel(model.id));
-  }, [models]);
 
   const { clearAudioQueue } = useAudioPlayer();
 
@@ -191,10 +187,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const { settings, setSettings } = useSettings();
-  const { models } = useModels();
-  const isTtsSupported = useMemo(() => {
-    return !!models.find((model) => isTextToSpeechModel(model.id));
-  }, [models]);
+  const { models, isTtsSupported } = useModels();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useDebounce(

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -8,19 +8,14 @@ import {
   ChatCraftMessage,
 } from "../lib/ChatCraftMessage";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import {
-  calculateTokenCost,
-  chatWithLLM,
-  countTokensInMessages,
-  isTtsSupported,
-  textToSpeech,
-} from "../lib/ai";
+import { calculateTokenCost, chatWithLLM, countTokensInMessages, textToSpeech } from "../lib/ai";
 import { tokenize } from "../lib/summarize";
 import useAudioPlayer from "./use-audio-player";
 import { useAutoScroll } from "./use-autoscroll";
 import { useCost } from "./use-cost";
 import { useSettings } from "./use-settings";
 import { useAlert } from "./use-alert";
+import { useModels } from "./use-models";
 
 const noop = () => {};
 
@@ -46,6 +41,8 @@ function useChatOpenAI() {
   const { addToAudioQueue } = useAudioPlayer();
   const { error } = useAlert();
 
+  const { isTtsSupported } = useModels();
+
   const callChatApi = useCallback(
     async (
       messages: ChatCraftMessage[],
@@ -66,7 +63,6 @@ function useChatOpenAI() {
       setShouldAutoScroll(true);
       resetScrollProgress();
 
-      const ttsSupported = await isTtsSupported();
       // Set a maximum words in a sentence that we need to wait for.
       // This reduces latency and number of TTS api calls
       const TTS_BUFFER_THRESHOLD = 25;
@@ -94,7 +90,7 @@ function useChatOpenAI() {
 
               const { sentences } = tokenize(ttsWordsBuffer);
 
-              if (ttsSupported && settings.textToSpeech.announceMessages) {
+              if (isTtsSupported && settings.textToSpeech.announceMessages) {
                 if (
                   sentences.length > 1 // Has one full sentence
                 ) {
@@ -169,7 +165,7 @@ function useChatOpenAI() {
           resetScrollProgress();
           setShouldAutoScroll(false);
 
-          if (ttsSupported && settings.textToSpeech.announceMessages && ttsWordsBuffer.length) {
+          if (isTtsSupported && settings.textToSpeech.announceMessages && ttsWordsBuffer.length) {
             try {
               // Call TTS for any remaining words
               const audioClipUri = textToSpeech(ttsWordsBuffer, settings.textToSpeech.voice);
@@ -190,6 +186,7 @@ function useChatOpenAI() {
       setShouldAutoScroll,
       resetScrollProgress,
       incrementScrollProgress,
+      isTtsSupported,
       addToAudioQueue,
       error,
       incrementCost,

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -6,21 +6,25 @@ import {
   useRef,
   type ReactNode,
   type FC,
+  useMemo,
 } from "react";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { getSettings } from "../lib/settings";
 import { useSettings } from "./use-settings";
+import { isTextToSpeechModel } from "../lib/ai";
 
 const defaultModels = [getSettings().currentProvider.defaultModelForProvider()];
 
 type ModelsContextType = {
   models: ChatCraftModel[];
   error: Error | null;
+  isTtsSupported: boolean;
 };
 
 const ModelsContext = createContext<ModelsContextType>({
   models: defaultModels,
   error: null,
+  isTtsSupported: false,
 });
 
 export const useModels = () => useContext(ModelsContext);
@@ -43,6 +47,11 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const [error, setError] = useState<Error | null>(null);
   const isFetching = useRef(false);
   const { settings, setSettings } = useSettings();
+
+  const isTtsSupported = useMemo(() => {
+    const availableModels = models || defaultModels;
+    return !!availableModels.some((model) => isTextToSpeechModel(model.id));
+  }, [models]);
 
   useEffect(() => {
     const apiKey = settings.currentProvider.apiKey;
@@ -74,6 +83,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
   const value = {
     models: models || defaultModels,
     error,
+    isTtsSupported,
   };
 
   return <ModelsContext.Provider value={value}>{children}</ModelsContext.Provider>;


### PR DESCRIPTION
This PR simply moves the `isTtsSupported` function inside `useModels` hook as the determination criteria is closely coupled with the **list of available models** and areas consuming it need to react as it changes.

This also eliminates the duplication of this function at multiple places throughout the tree, and all the concerned features still work well based on my testing.

Fixes #703.