### PR TITLE
Support TTS and STT beyond selected provider

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -128,6 +128,8 @@ function MessageBase({
   const [imageModalOpen, setImageModalOpen] = useState<boolean>(false);
   const [selectedImage, setSelectedImage] = useState<string>("");
   const { isOpen, onToggle: originalOnToggle } = useDisclosure();
+  const { clearAudioQueue, addToAudioQueue } = useAudioPlayer();
+  const { isTextToSpeechSupported, textToSpeech } = useTextToSpeech();
   const isSystemMessage = message instanceof ChatCraftSystemMessage;
   const isLongMessage =
     text.length > 5000 || (isSystemMessage && summaryText && text.length > summaryText.length);
@@ -344,6 +346,7 @@ function MessageBase({
     progress,
     settings.currentProvider.name,
     settings.textToSpeech.voice,
+    textToSpeech,
   ]);
 
   const handleClick = useCallback((e: MouseEvent<HTMLButtonElement>) => {
@@ -429,9 +432,6 @@ function MessageBase({
   };
   const closeModal = () => setImageModalOpen(false);
 
-  const { clearAudioQueue, addToAudioQueue } = useAudioPlayer();
-  const { isTextToSpeechSupported, textToSpeech } = useTextToSpeech();
-
   const handleSpeakMessage = useCallback(
     async (messageContent: string) => {
       try {
@@ -451,7 +451,7 @@ function MessageBase({
         error({ title: "Error while generating Audio", message: err.message });
       }
     },
-    [clearAudioQueue, settings.textToSpeech, addToAudioQueue, error]
+    [clearAudioQueue, settings.textToSpeech, addToAudioQueue, textToSpeech, error]
   );
 
   return (

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -63,9 +63,10 @@ import useAudioPlayer from "../../hooks/use-audio-player";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useUser } from "../../hooks/use-user";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
-import { isChatModel, textToSpeech } from "../../lib/ai";
+import { isChatModel } from "../../lib/ai";
 import { getSentenceChunksFrom } from "../../lib/summarize";
 import "./Message.css";
+import { useTextToSpeech } from "../../hooks/use-text-to-speech";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -114,7 +115,7 @@ function MessageBase({
 }: MessageBaseProps) {
   const [, copyToClipboard] = useCopyToClipboard();
   const { id, date, text, imageUrls } = message;
-  const { models, isTtsSupported } = useModels();
+  const { models } = useModels();
   const { onCopy } = useClipboard(text);
   const { info, error, progress, closeToast } = useAlert();
   const [isHovering, setIsHovering] = useState(false);
@@ -429,6 +430,7 @@ function MessageBase({
   const closeModal = () => setImageModalOpen(false);
 
   const { clearAudioQueue, addToAudioQueue } = useAudioPlayer();
+  const { isTextToSpeechSupported, textToSpeech } = useTextToSpeech();
 
   const handleSpeakMessage = useCallback(
     async (messageContent: string) => {
@@ -528,7 +530,7 @@ function MessageBase({
                 <SubMenu label="Export" icon={<TbDownload />}>
                   <MenuItem onClick={handleDownloadMarkdown}>Export as Markdown</MenuItem>
                   <MenuItem onClick={handleDownloadPlainText}>Export as Text</MenuItem>
-                  {isTtsSupported && (
+                  {isTextToSpeechSupported && (
                     <MenuItem onClick={handleDownloadAudio}>Export as Audio</MenuItem>
                   )}
                   <MenuItem
@@ -538,7 +540,7 @@ function MessageBase({
                     Export as Image
                   </MenuItem>
                 </SubMenu>
-                {isTtsSupported && (
+                {isTextToSpeechSupported && (
                   <MenuItem
                     onClick={() => handleSpeakMessage(messageContent.current?.textContent ?? "")}
                   >

--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -39,7 +39,6 @@ import { useModels } from "../../hooks/use-models";
 import { useSettings } from "../../hooks/use-settings";
 import { ChatCraftModel } from "../../lib/ChatCraftModel";
 import { ChatCraftProvider, ProviderData } from "../../lib/ChatCraftProvider";
-import { textToSpeech } from "../../lib/ai";
 import db from "../../lib/db";
 import { providerFromUrl, supportedProviders } from "../../lib/providers";
 import { CustomProvider } from "../../lib/providers/CustomProvider";
@@ -49,6 +48,7 @@ import { OpenRouterProvider } from "../../lib/providers/OpenRouterProvider";
 import { TextToSpeechVoices } from "../../lib/settings";
 import { download } from "../../lib/utils";
 import PasswordInput from "../PasswordInput";
+import { useTextToSpeech } from "../../hooks/use-text-to-speech";
 
 interface ModelsSettingsProps {
   isOpen: boolean;
@@ -69,7 +69,7 @@ interface ModelsSettingsProps {
 
 function ModelsSettings(isOpen: ModelsSettingsProps) {
   const { settings, setSettings } = useSettings();
-  const { models, isTtsSupported } = useModels();
+  const { models } = useModels();
 
   // Whether our db is being persisted
   const [isPersisted, setIsPersisted] = useState(false);
@@ -170,6 +170,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
   );
 
   const { clearAudioQueue, addToAudioQueue } = useAudioPlayer();
+  const { isTextToSpeechSupported, textToSpeech } = useTextToSpeech();
 
   const handlePlayAudioPreview = useCallback(async () => {
     try {
@@ -918,7 +919,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
             </FormHelperText>
           </FormControl>
 
-          {isTtsSupported && (
+          {isTextToSpeechSupported && (
             <FormControl>
               <FormLabel>Select Voice</FormLabel>
 

--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -183,7 +183,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
       console.error(err);
       error({ title: "Error while generating Audio", message: err.message });
     }
-  }, [addToAudioQueue, clearAudioQueue, error, settings.textToSpeech]);
+  }, [addToAudioQueue, clearAudioQueue, error, settings.textToSpeech, textToSpeech]);
 
   const handleApiKeyChange = async (provider: ChatCraftProvider, apiKey: string) => {
     const newProvider = providerFromUrl(

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -9,18 +9,6 @@ import { SpeechRecognition } from "../../lib/speech-recognition";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import { isSpeechToTextModel } from "../../lib/ai";
 
-/**
- * Checks if browser can record audio and a whisper model is available
- * @param models model ids
- * @returns stt model id | null
- */
-function getSpeechToTextModel(models: string[]) {
-  if (!(!!navigator.mediaDevices && !!window.MediaRecorder)) {
-    return null;
-  }
-  return models.find(isSpeechToTextModel);
-}
-
 type MicIconProps = {
   onRecording: () => void;
   onTranscribing: () => void;
@@ -43,21 +31,27 @@ export default function MicIcon({
   const { error } = useAlert();
   const { clearAudioQueue } = useAudioPlayer();
 
-  const { allAvailableModels, getSpeechToTextClient } = useModels();
+  const { getSpeechToTextClient, isSpeechToTextSupported, allProvidersWithModels } = useModels();
 
-  const sttModel = getSpeechToTextModel(allAvailableModels.map((x) => x.id));
-
-  if (!sttModel) {
+  if (!isSpeechToTextSupported) {
     return <></>;
   }
 
   const onRecordingStart = async () => {
     clearAudioQueue();
 
-    const sttClient = await getSpeechToTextClient(sttModel);
+    const sttClient = await getSpeechToTextClient();
 
     if (!sttClient) {
-      throw new Error(`No configured provider supports STT with model "${sttModel}"`);
+      throw new Error(`No configured provider supports STT`);
+    }
+
+    // Find which model to use based on the provider selected by STT client
+    const sttProvider = allProvidersWithModels.find((p) => p.apiUrl === sttClient.baseURL);
+    const sttModel = sttProvider?.models.find((model) => isSpeechToTextModel(model.name))?.name;
+
+    if (!sttModel) {
+      throw new Error(`Can't find "${sttModel}" in "${sttProvider?.name}"'s models list`);
     }
 
     speechRecognitionRef.current = new SpeechRecognition(sttModel, sttClient);

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -43,9 +43,9 @@ export default function MicIcon({
   const { error } = useAlert();
   const { clearAudioQueue } = useAudioPlayer();
 
-  const { models } = useModels();
+  const { allAvailableModels, getSpeechToTextClient } = useModels();
 
-  const sttModel = getSpeechToTextModel(models.map((x) => x.id));
+  const sttModel = getSpeechToTextModel(allAvailableModels.map((x) => x.id));
 
   if (!sttModel) {
     return <></>;
@@ -53,7 +53,14 @@ export default function MicIcon({
 
   const onRecordingStart = async () => {
     clearAudioQueue();
-    speechRecognitionRef.current = new SpeechRecognition(sttModel);
+
+    const sttClient = await getSpeechToTextClient(sttModel);
+
+    if (!sttClient) {
+      throw new Error(`No configured provider supports STT with model "${sttModel}"`);
+    }
+
+    speechRecognitionRef.current = new SpeechRecognition(sttModel, sttClient);
 
     // Try to get access to the user's microphone. This may or may not work...
     try {

--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -28,6 +28,7 @@ import useAudioPlayer from "../../hooks/use-audio-player";
 import { useDebounce } from "react-use";
 import { isChatModel } from "../../lib/ai";
 import InterruptSpeechButton from "../InterruptSpeechButton";
+import { useTextToSpeech } from "../../hooks/use-text-to-speech";
 
 type PromptSendButtonProps = {
   isLoading: boolean;
@@ -37,10 +38,11 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const { settings, setSettings } = useSettings();
-  const { models, isTtsSupported } = useModels();
+  const { models } = useModels();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { clearAudioQueue, isAudioQueueEmpty } = useAudioPlayer();
+  const { isTextToSpeechSupported } = useTextToSpeech();
 
   useDebounce(
     () => {
@@ -69,7 +71,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           isLoading={isLoading}
           icon={<TbSend />}
         />
-        {isTtsSupported && isAudioQueueEmpty ? (
+        {isTextToSpeechSupported && isAudioQueueEmpty ? (
           <Tooltip
             label={
               settings.textToSpeech.announceMessages
@@ -108,7 +110,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
               }}
             />
           </Tooltip>
-        ) : isTtsSupported ? (
+        ) : isTextToSpeechSupported ? (
           <InterruptSpeechButton variant={"dancingBars"} size={"lg"} clearOnly={!isLoading} />
         ) : null}
         <MenuButton
@@ -189,7 +191,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
               />
             </InputGroup>
           </MenuGroup>
-          {isTtsSupported && (
+          {isTextToSpeechSupported && (
             <>
               <MenuDivider />
               <MenuItem
@@ -230,7 +232,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   const [searchQuery, setSearchQuery] = useState("");
   const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
   const { settings, setSettings } = useSettings();
-  const { models, isTtsSupported } = useModels();
+  const { models } = useModels();
   const inputRef = useRef<HTMLInputElement>(null);
 
   useDebounce(
@@ -259,6 +261,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
   };
 
   const { clearAudioQueue, isAudioQueueEmpty } = useAudioPlayer();
+  const { isTextToSpeechSupported } = useTextToSpeech();
 
   const providersList = {
     ...settings.providers,
@@ -270,7 +273,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
       <Button type="submit" size="sm" isLoading={isLoading} loadingText="Sending">
         Ask {settings.model.prettyModel}
       </Button>
-      {isTtsSupported && isAudioQueueEmpty ? (
+      {isTextToSpeechSupported && isAudioQueueEmpty ? (
         <Tooltip
           label={
             settings.textToSpeech.announceMessages
@@ -302,7 +305,7 @@ function DesktopPromptSendButton({ isLoading }: PromptSendButtonProps) {
             )}
           </Button>
         </Tooltip>
-      ) : isTtsSupported ? (
+      ) : isTextToSpeechSupported ? (
         <InterruptSpeechButton variant={"dancingBars"} size={"sm"} clearOnly={!isLoading} />
       ) : null}
       <Menu placement="top-end" strategy="fixed" closeOnSelect={false}>

--- a/src/hooks/use-chat-openai.ts
+++ b/src/hooks/use-chat-openai.ts
@@ -8,14 +8,14 @@ import {
   ChatCraftMessage,
 } from "../lib/ChatCraftMessage";
 import { ChatCraftModel } from "../lib/ChatCraftModel";
-import { calculateTokenCost, chatWithLLM, countTokensInMessages, textToSpeech } from "../lib/ai";
+import { calculateTokenCost, chatWithLLM, countTokensInMessages } from "../lib/ai";
 import { tokenize } from "../lib/summarize";
 import useAudioPlayer from "./use-audio-player";
 import { useAutoScroll } from "./use-autoscroll";
 import { useCost } from "./use-cost";
 import { useSettings } from "./use-settings";
 import { useAlert } from "./use-alert";
-import { useModels } from "./use-models";
+import { useTextToSpeech } from "./use-text-to-speech";
 
 const noop = () => {};
 
@@ -41,7 +41,7 @@ function useChatOpenAI() {
   const { addToAudioQueue, audioQueueDisabledRef, enableAudioQueue } = useAudioPlayer();
   const { error } = useAlert();
 
-  const { isTtsSupported } = useModels();
+  const { isTextToSpeechSupported, textToSpeech } = useTextToSpeech();
 
   const callChatApi = useCallback(
     async (
@@ -91,7 +91,7 @@ function useChatOpenAI() {
               const { sentences } = tokenize(ttsWordsBuffer);
 
               if (
-                isTtsSupported &&
+                isTextToSpeechSupported &&
                 settings.textToSpeech.announceMessages &&
                 !audioQueueDisabledRef?.current
               ) {
@@ -170,7 +170,7 @@ function useChatOpenAI() {
           setShouldAutoScroll(false);
 
           if (
-            isTtsSupported &&
+            isTextToSpeechSupported &&
             settings.textToSpeech.announceMessages &&
             !audioQueueDisabledRef?.current &&
             ttsWordsBuffer.length
@@ -194,15 +194,15 @@ function useChatOpenAI() {
       settings.textToSpeech.announceMessages,
       settings.textToSpeech.voice,
       settings.countTokens,
-      setStreamingMessage,
       setShouldAutoScroll,
       resetScrollProgress,
       incrementScrollProgress,
-      isTtsSupported,
+      isTextToSpeechSupported,
+      audioQueueDisabledRef,
+      textToSpeech,
       addToAudioQueue,
       error,
       incrementCost,
-      audioQueueDisabledRef,
       enableAudioQueue,
     ]
   );

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -67,7 +67,7 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
     const providers = Object.values(settings.providers); // Get all providers
 
     if (isFetchingAllProvidersWithModels.current) {
-      return; // Return early if there's no API key or we're already fetching
+      return; // Return early if we're already fetching
     }
 
     const fetchModelsForAllProviders = async () => {
@@ -75,7 +75,8 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
       try {
         // Fetch models for all providers concurrently
         const fetchPromises = providers.map((provider) => {
-          if (!provider.apiKey) return Promise.resolve([]); // Skip providers without an apiKey
+          // Skip providers without an apiKey
+          if (!provider.apiKey) return Promise.resolve([]);
 
           return provider.queryModels(provider.apiKey).then((models) => {
             return {

--- a/src/hooks/use-models.tsx
+++ b/src/hooks/use-models.tsx
@@ -90,16 +90,23 @@ export const ModelsProvider: FC<{ children: ReactNode }> = ({ children }) => {
           // Skip providers without an apiKey
           if (!provider.apiKey) return Promise.resolve([]);
 
-          return provider.queryModels(provider.apiKey).then((models) => {
-            return {
-              ...provider,
-              models: models.map((modelName) => new ChatCraftModel(modelName)),
-            } as ChatCraftProviderWithModels;
-          });
+          return provider
+            .queryModels(provider.apiKey)
+            .then((models) => {
+              return {
+                ...provider,
+                models: models.map((modelName) => new ChatCraftModel(modelName)),
+              } as ChatCraftProviderWithModels;
+            })
+            .catch((error: any) => {
+              console.warn(`Couldn't fetch models from provider "${provider.name}"`, error);
+            });
         });
 
         // Wait for all promises to resolve
-        const allModelsData = await Promise.all(fetchPromises);
+        const allModelsData = (await Promise.all(fetchPromises))
+          // Some results might be `undefined` if provider's endpoint fails
+          .filter((data) => !!data);
 
         // Flatten the models and update the state
         setAllProvidersWithModels(allModelsData.flat());

--- a/src/hooks/use-text-to-speech.ts
+++ b/src/hooks/use-text-to-speech.ts
@@ -1,0 +1,96 @@
+import { useCallback, useMemo } from "react";
+import { TextToSpeechVoices } from "../lib/settings";
+import { useModels } from "./use-models";
+import { useSettings } from "./use-settings";
+import { isTextToSpeechModel } from "../lib/ai";
+import { ChatCraftModel } from "../lib/ChatCraftModel";
+import OpenAI from "openai";
+import { ChatCraftProvider } from "../lib/ChatCraftProvider";
+
+type TextToSpeechModel = "tts-1" | "tts-1-hd";
+
+export const useTextToSpeech = () => {
+  const { allProvidersWithModels } = useModels();
+
+  const { settings } = useSettings();
+
+  const isTextToSpeechSupported = useMemo(() => {
+    return allProvidersWithModels
+      .map((p) => p.models)
+      .flat()
+      .some((model) => isTextToSpeechModel(model.name));
+  }, [allProvidersWithModels]);
+
+  const getTextToSpeechClient = useCallback(
+    (preferredModel?: string) => {
+      let supported = false;
+      const acceptableModel = (model: ChatCraftModel) =>
+        preferredModel ? model.name === preferredModel : isTextToSpeechModel(model.name);
+
+      // Check if the current provider supports TTS
+      const currentProvider = allProvidersWithModels.find((provider) =>
+        ChatCraftProvider.areSameProviders(provider, settings.currentProvider)
+      );
+      if (currentProvider) {
+        supported = currentProvider.models.some(acceptableModel);
+
+        if (supported && currentProvider.apiKey) {
+          return new OpenAI({
+            apiKey: currentProvider.apiKey,
+            baseURL: currentProvider.apiUrl,
+            dangerouslyAllowBrowser: true,
+          });
+        }
+      }
+
+      // Check rest of the providers
+      const otherProviders = allProvidersWithModels.filter((p) => p.id !== currentProvider?.id);
+      for (const provider of otherProviders) {
+        supported = provider.models.some(acceptableModel);
+
+        if (supported && provider.apiKey) {
+          return new OpenAI({
+            apiKey: provider.apiKey,
+            baseURL: provider.apiUrl,
+            dangerouslyAllowBrowser: true,
+          });
+        }
+      }
+
+      return null;
+    },
+    [allProvidersWithModels, settings.currentProvider]
+  );
+
+  /**
+   *
+   * @param message The text for which speech needs to be generated
+   * @returns A Promise that resolves to the URL of generated audio clip
+   */
+  const textToSpeech = async (
+    message: string,
+    voice: TextToSpeechVoices = TextToSpeechVoices.ALLOY,
+    model: TextToSpeechModel = "tts-1"
+  ): Promise<string> => {
+    const openai = await getTextToSpeechClient(model);
+
+    if (!openai) {
+      throw new Error("No configured provider supports text to speech.");
+    }
+
+    const response = await openai.audio.speech.create({
+      model,
+      voice,
+      input: message,
+    });
+
+    const audioUrl = URL.createObjectURL(await response.blob());
+
+    return audioUrl;
+  };
+
+  return {
+    isTextToSpeechSupported,
+    textToSpeech,
+  };
+};

--- a/src/lib/ChatCraftProvider.ts
+++ b/src/lib/ChatCraftProvider.ts
@@ -75,4 +75,12 @@ export abstract class ChatCraftProvider {
   defaultModelForProvider(): ChatCraftModel {
     return new ChatCraftModel(this.defaultModel);
   }
+
+  static areSameProviders(p1: ChatCraftProvider, p2: ChatCraftProvider) {
+    return p1.apiUrl === p2.apiUrl && p1.apiKey === p2.apiKey;
+  }
 }
+
+export type ChatCraftProviderWithModels = ChatCraftProvider & {
+  models: ChatCraftModel[];
+};

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -9,7 +9,7 @@ import {
   ChatCraftMessage,
 } from "./ChatCraftMessage";
 import { ChatCraftModel } from "./ChatCraftModel";
-import { TextToSpeechVoices, getSettings } from "./settings";
+import { getSettings } from "./settings";
 import { usingOfficialOpenAI } from "./providers";
 
 export type ChatOptions = {
@@ -390,53 +390,6 @@ export const calculateTokenCost = (tokens: number, model: ChatCraftModel) => {
   console.warn(`Unknown pricing for model ${model.toString()}`);
   return 0;
 };
-
-/**
- * Only meant to be used outside components or hooks
- * where useModels cannot be used.
- */
-export async function isTtsSupported() {
-  const { currentProvider } = getSettings();
-  if (!currentProvider.apiKey) {
-    throw new Error("Missing API Key");
-  }
-
-  return (
-    (await currentProvider.queryModels(currentProvider.apiKey)).filter((model: string) =>
-      isTextToSpeechModel(model)
-    )?.length > 0
-  );
-}
-
-type TextToSpeechModel = "tts-1" | "tts-1-hd";
-
-/**
- *
- * @param message The text for which speech needs to be generated
- * @returns A Promise that resolves to the URL of generated audio clip
- */
-export const textToSpeech = async (
-  message: string,
-  voice: TextToSpeechVoices = TextToSpeechVoices.ALLOY,
-  model: TextToSpeechModel = "tts-1"
-): Promise<string> => {
-  const { currentProvider } = getSettings();
-  if (!currentProvider.apiKey) {
-    throw new Error("Missing API Key");
-  }
-  const { openai } = currentProvider.createClient(currentProvider.apiKey);
-
-  const response = await openai.audio.speech.create({
-    model,
-    voice,
-    input: message,
-  });
-
-  const audioUrl = URL.createObjectURL(await response.blob());
-
-  return audioUrl;
-};
-
 /**
  * Only meant to be used outside components or hooks
  * where useModels cannot be used.

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -1,5 +1,4 @@
 import OpenAI from "openai";
-import { getSettings } from "./settings";
 
 // We prefer to use webm, but Safari on iOS has to use mp4
 const supportedAudioMimeTypes = ["audio/webm", "audio/mp4"];
@@ -44,9 +43,11 @@ export class SpeechRecognition {
   private _mediaStream: MediaStream | null = null;
   private _mimeType: string | null = null;
   private _sttModel: string;
+  private _openai: OpenAI;
 
-  constructor(sttModel: string) {
+  constructor(sttModel: string, openai: OpenAI) {
     this._sttModel = sttModel;
+    this._openai = openai;
   }
 
   // Initialize, creating an audio stream, media recorder, deal with permissions, etc.
@@ -132,13 +133,7 @@ export class SpeechRecognition {
   }
 
   async transcribe(audio: File) {
-    const { currentProvider } = getSettings();
-    if (!currentProvider.apiKey) {
-      throw new Error("Missing OpenAI API Key");
-    }
-
-    const { openai } = currentProvider.createClient(currentProvider.apiKey);
-    const transcriptions = new OpenAI.Audio.Transcriptions(openai);
+    const transcriptions = new OpenAI.Audio.Transcriptions(this._openai);
     const transcription = await transcriptions.create({
       file: audio,
       model: this._sttModel,


### PR DESCRIPTION
This PR makes **Text to Speech** and **Speech to Text** functionalities independent of the current LLM provider being used for chat completions.

Here's a brief overview of changes:
1. We now cache all the providers and their models in `useModels` hook so we can query any provider's model info without an API request. This was necessary since we need to determine if we support TTS very frequently, at a rate that is greater than 1 models query per TTS chunk request.
2. Created a new hook called `useTextToSpeech` and moved the logic to determine TTS support, and generating audio from text into it, all based on the `providersWithModels` info cached in `useModels`.
3. The `textToSpeech` function now uses an OpenAI client [configured ](https://github.com/tarasglek/chatcraft.org/compare/amnish04/extend-tts-stt-availability?expand=1#diff-1c4a0de27d11b095e2cdada2a3f887c85668ebc3b88e98abce347ca9c69a181fR24)with one of the available providers that support TTS. The idea is to use the `currentProvider` if it supports TTS, else find any other providers if they do.
4. Speech to Text logic also follows a similar logic to create an OpenAI client which is now passed into the `SpeechRecognition` instance vs hard coding the client information in its `trancscribe` method.
5. I feel like `isSpeechToTextSupported` and `getSpeechToTextClient` belong in a separate hook outside `useModels`, but not sure if its necessary.

I don't think this is the best approach, but it worked out of the many I tried.

Here's a **working demo**:
https://www.loom.com/share/67024f7807254bd6a8ba89fb3e985133?sid=238e6ee8-fcb4-4b34-9b32-14464be3c7af

This closes #721.