### PR TITLE
Fix speech toggle button icon size

### DIFF
--- a/src/components/PromptForm/PromptSendButton.tsx
+++ b/src/components/PromptForm/PromptSendButton.tsx
@@ -79,7 +79,7 @@ function MobilePromptSendButton({ isLoading }: PromptSendButtonProps) {
           >
             <IconButton
               type="button"
-              size="lg"
+              size="md"
               variant="solid"
               aria-label={
                 settings.textToSpeech.announceMessages


### PR DESCRIPTION
Fixed the icon size that recently got broken.

![image](https://github.com/user-attachments/assets/cb179a38-1fff-4dba-b039-0f8d811aba7e)

This closes #724 