### PR TITLE
it allows zoom-gesture when PreferencesModal is open

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Web-based AI Assistant for Software Developers" />
     <meta name="og:site_name" content="chatcraft.org" />
     <meta property="og:image" content="https://chatcraft.org/favicon-32x32.png" />
@@ -14,7 +14,6 @@
     <meta name="twitter:title" content="chatcraft.org" />
     <meta name="twitter:description" content="Web-based AI Assistant for Software Developers" />
     <meta name="twitter:image" content="https://chatcraft.org/favicon-32x32.png" />
-    <meta name="viewport" content="initial-scale=1, viewport-fit=cover" />
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />

--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -609,7 +609,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                         <InputGroup size="sm">
                           <Input
                             pl="0.4rem"
-                            fontSize="xs"
+                            fontSize="md"
                             placeholder="Name"
                             value={newCustomProvider.name}
                             onChange={(e) => {
@@ -632,7 +632,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                         <InputGroup size="sm">
                           <Input
                             pl="0.4rem"
-                            fontSize="xs"
+                            fontSize="md"
                             placeholder="API URL"
                             value={newCustomProvider.apiUrl}
                             onChange={(e) => {
@@ -657,7 +657,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                           buttonSize="xs"
                           paddingRight={"2rem"}
                           paddingLeft={"0.5rem"}
-                          fontSize="xs"
+                          fontSize="md"
                           value={newCustomProvider.apiKey || ""}
                           onChange={(e) => {
                             setNewCustomProvider(
@@ -743,7 +743,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                                 buttonSize="xs"
                                 paddingRight={"2rem"}
                                 paddingLeft={"0.5rem"}
-                                fontSize="xs"
+                                fontSize="md"
                                 value={provider.apiKey || ""}
                                 onChange={(e) => handleApiKeyChange(provider, e.target.value)}
                                 onFocus={() => setFocusedProvider(provider)}

--- a/src/components/Preferences/PreferencesModal.tsx
+++ b/src/components/Preferences/PreferencesModal.tsx
@@ -171,6 +171,8 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
       size={isSmallViewport ? "full" : "xl"}
       finalFocusRef={finalFocusRef}
       scrollBehavior="inside"
+      allowPinchZoom={true}
+      blockScrollOnMount={false}
     >
       <ModalOverlay />
       <ModalContent top={isSmallViewport ? "0" : "-2rem"} maxWidth="54rem" maxHeight="90vh">

--- a/src/components/Preferences/WebHandlersConfig.tsx
+++ b/src/components/Preferences/WebHandlersConfig.tsx
@@ -127,6 +127,7 @@ function WebHandlersConfig() {
             theme={colorMode}
             height={editorHeight}
             onChange={handleConfigValueChange}
+            style={{ fontSize: "16px" }}
           />
         </CodeHeader>
       </Box>


### PR DESCRIPTION
# Description

This fixes #731 

I implemented the second solution, enabling zoom-in functionality when the `PreferencesModal` is open on both mobile and desktop

# How I tested
I tested it on an iPhone 15 Pro and Google Chrome on desktop, and it now allows zoom-in, zoom-out, as well as scrolling when zoomed in

## Test Screenshot

### Zoomed in
![IMG_0734](https://github.com/user-attachments/assets/5d84b1a1-e1ef-4650-af80-41feb2c4a9ca)

### Zoomed out
![IMG_0735](https://github.com/user-attachments/assets/742fa434-0261-4d28-a5a8-ec20bb084f0d)

