### PR TITLE
added UI Error display for failed retry on message

### DIFF
--- a/src/components/Message/AiMessage.tsx
+++ b/src/components/Message/AiMessage.tsx
@@ -89,6 +89,7 @@ function AiMessage(props: AiMessageProps) {
   const [message, setMessage] = useState(props.message);
   const [retrying, setRetrying] = useState(false);
   const { settings } = useSettings();
+  const { error } = useAlert();
 
   useEffect(() => {
     setMessage(props.message);
@@ -127,8 +128,11 @@ function AiMessage(props: AiMessageProps) {
         message.addVersion(version);
         message.switchVersion(version.id);
         await message.save(chat.id);
-      } catch (err) {
-        // TODO: UI error handling
+      } catch (err: any) {
+        error({
+          title: `Response Error`,
+          message: err.message,
+        });
         console.warn("Unable to retry message", { model, err });
       } finally {
         setRetrying(false);


### PR DESCRIPTION
This Fixes #716 

##  Changes
- chatcraft.org\src\components\Message\AiMessage.tsx  (https://github.com/tarasglek/chatcraft.org/blob/83d180244708becc62ac61e4452b923a2412a33b/src/components/Message/AiMessage.tsx#L130)

Update the catch block for retry from this
```py
catch (err) {
        // TODO: UI error handling
        console.warn("Unable to retry message", { model, err });
      }
```

to this
```py
catch (err: any) {
        error({
          title: `Response Error`,
          message: err.message,
        });
        console.warn("Unable to retry message", { model, err });
      }
```

Here is the demo:


https://github.com/user-attachments/assets/371ebd0d-dbb1-4236-a38f-110eedee883e

