### PR TITLE
Add Support for Audio File Transcription

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -218,7 +218,7 @@ function OptionsButton({
             ref={fileInputRef}
             hidden
             onChange={handleFileChange}
-            accept="image/*,text/*,.pdf,application/pdf,*.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.json,application/json,application/markdown"
+            accept="image/*,text/*,.pdf,application/pdf,*.docx,application/vnd.openxmlformats-officedocument.wordprocessingml.document,.json,application/json,application/markdown, audio/*"
           />
           <MenuItem icon={<BsPaperclip />} onClick={handleAttachFiles}>
             Attach Files...

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -464,6 +464,42 @@ export function isChatModel(model: string): boolean {
   );
 }
 
+export type OpenAISpeechToTextResponse = {
+  text: string;
+};
+
+/**
+ * Convert an audio file to text using https://platform.openai.com/docs/api-reference/audio/createTranscription?lang=node
+ */
+export async function audioToText(file: File): Promise<OpenAISpeechToTextResponse> {
+  try {
+    const { currentProvider } = getSettings();
+    if (!currentProvider.apiKey) {
+      throw new Error("Missing OpenAI API Key");
+    }
+
+    const { openai } = currentProvider.createClient(currentProvider.apiKey);
+
+    const response = await openai.audio.transcriptions.create({
+      file,
+      model: "whisper-1",
+    });
+
+    if (!response.text) {
+      throw new Error("Error: No transcription text returned by OpenAI.");
+    }
+
+    const result: OpenAISpeechToTextResponse = {
+      text: response.text,
+    };
+
+    return result;
+  } catch (err) {
+    console.error("Error converting audio to text", err);
+    throw err;
+  }
+}
+
 export type JinaAiReaderResponse = {
   code: number;
   status: number;

--- a/src/lib/speech-recognition.ts
+++ b/src/lib/speech-recognition.ts
@@ -132,7 +132,7 @@ export class SpeechRecognition {
     }
   }
 
-  async transcribe(audio: File) {
+  async transcribe(audio: File): Promise<string> {
     const transcriptions = new OpenAI.Audio.Transcriptions(this._openai);
     const transcription = await transcriptions.create({
       file: audio,


### PR DESCRIPTION
This PR fixes #722  

This is done by introducing support for uploading audio files. Once an audio file (e.g., MP3) is uploaded, the chatbot transcribes it into text using OpenAI's Whisper API and displays the transcription in the chat. Users can then interact with the chatbot to discuss the content of the audio file, just like the existing feature for converting PDF files to Markdown.

## Example Usage

For instance, if you upload an MP3 file of a podcast where someone says *"Hello, tell me about the universe,"* the bot will transcribe the audio into text (e.g., *"Hello, tell me about the universe"*) and add it to the chat. Users can then ask follow-up questions or have a conversation about the transcribed content.

Here's an example video demonstrating the feature. I uploaded an MP3 file where I recorded myself saying *"Hello, tell me about the universe."* The bot successfully transcribed the content, displayed it in the chat, and allowed further interaction.

https://github.com/user-attachments/assets/0896ffa9-32ee-472a-9654-885efd81b7cd

## Implementation Details

As discussed earlier with @humphd in [this issue comment](https://github.com/tarasglek/chatcraft.org/issues/722#issuecomment-2484543262), I modularized the implementation to ensure clarity and reusability:

- A new `audioToText()` function was created in `ai.ts` to handle transcription using OpenAI's Whisper API ([API Reference](https://platform.openai.com/docs/api-reference/audio/createTranscription?lang=node)).
- The code structure is now consistent with the way PDF files are processed, ensuring uniformity across the project.

## Tasks Completed

- [x] **Add return type to `transcribe()` function**  
  Ensured type safety and better maintainability ([commit](https://github.com/tarasglek/chatcraft.org/commit/8a906faaa9f87c2bdc701be78c25a7293cd3f47c)).  

- [x] **Add support for audio file uploads**  
  Updated input handling to accept MP3 and other audio file types ([commit](https://github.com/tarasglek/chatcraft.org/commit/583fea28df1086e8a2cc2cb58cedbd9394016c17)).  

- [x] **Update file import hooks**  
  Modified the file import hook to handle audio files in the same way as PDF files, as per discussions with @humphd ([commit](https://github.com/tarasglek/chatcraft.org/commit/d93fb1b18f12311fcded59bfb2264a03dc7b692b)).  

- [x] **Add `audioToText()` function**  
  Implemented the transcription logic using OpenAI Whisper ([commit](https://github.com/tarasglek/chatcraft.org/commit/8b725f371f392e7769a2c0a3052162bb9345edcf)).  

- [x] **Test multiple file uploads**  
  Verified that the system works correctly with both audio and PDF files.

- [x] **Ensure backward compatibility**  
  Tested the application to confirm that existing features remain unaffected by the changes.