### PR TITLE
Update MessageBase to show date on new line for mobile screens

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -468,20 +468,20 @@ function MessageBase({
             <Flex gap={3}>
               <Box>{avatar}</Box>
               <Flex direction="column" justify="center">
-                <Flex h="100%" align="center" gap={2} alignItems="flex-start">
+                <Flex h="100%" align="center" gap={2}>
                   <Flex
                     direction={{ base: "column", sm: "row" }} // Stack on mobile, row on larger screens
                     align={{ base: "flex-start", sm: "center" }} // Align items properly for both views
                     justify="space-between"
                     w="100%"
-                    gap={2}
+                    gap={{ base: 0, sm: 2 }}
                   >
                     <Heading as="h2" size="xs" minW="fit-content">
                       {heading}
                     </Heading>
                     <Text
                       as="span"
-                      fontSize="sm"
+                      fontSize="xs"
                       minW="fit-content"
                       color="gray.500"
                       _dark={{ color: "gray.300" }}

--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -468,21 +468,29 @@ function MessageBase({
             <Flex gap={3}>
               <Box>{avatar}</Box>
               <Flex direction="column" justify="center">
-                <Flex h="100%" align="center" gap={2}>
-                  <Heading as="h2" size="xs" minW="fit-content">
-                    {heading}
-                  </Heading>
-                  <Text
-                    as="span"
-                    fontSize="sm"
-                    minW="fit-content"
-                    color="gray.500"
-                    _dark={{ color: "gray.300" }}
+                <Flex h="100%" align="center" gap={2} alignItems="flex-start">
+                  <Flex
+                    direction={{ base: "column", sm: "row" }} // Stack on mobile, row on larger screens
+                    align={{ base: "flex-start", sm: "center" }} // Align items properly for both views
+                    justify="space-between"
+                    w="100%"
+                    gap={2}
                   >
-                    <Link as={ReactRouterLink} to={`/c/${chatId}#${id}`}>
-                      {formatDate(date, isNarrowScreen)}
-                    </Link>
-                  </Text>
+                    <Heading as="h2" size="xs" minW="fit-content">
+                      {heading}
+                    </Heading>
+                    <Text
+                      as="span"
+                      fontSize="sm"
+                      minW="fit-content"
+                      color="gray.500"
+                      _dark={{ color: "gray.300" }}
+                    >
+                      <Link as={ReactRouterLink} to={`/c/${chatId}#${id}`}>
+                        {formatDate(date, isNarrowScreen)}
+                      </Link>
+                    </Text>
+                  </Flex>
                   {headingMenu}
                   {!isLoading && settings.countTokens && !!tokens && (
                     <Tag size="sm" variant="outline" colorScheme="gray">


### PR DESCRIPTION
This Fixes #747 

I added a Flex component around heading and date and set direction of flex to row for sm screens

```py
                 <Flex
                    direction={{ base: "column", sm: "row" }} // Stack on mobile, row on larger screens
                    align={{ base: "flex-start", sm: "center" }} // Align items properly for both views
                    justify="space-between"
                    w="100%"
                    gap={2}
                  >
                    <Heading as="h2" size="xs" minW="fit-content">
                      {heading}
                    </Heading>
                    <Text
                      as="span"
                      fontSize="sm"
                      minW="fit-content"
                      color="gray.500"
                      _dark={{ color: "gray.300" }}
                    >
                      <Link as={ReactRouterLink} to={`/c/${chatId}#${id}`}>
                        {formatDate(date, isNarrowScreen)}
                      </Link>
                    </Text>
                  </Flex>
```

Demo:
![image](https://github.com/user-attachments/assets/3b2b8f56-64ac-4f5a-a593-f23b1b57b66e)
