### PR TITLE
cant resubmit when input is empty on mobile: debugging

### DIFF
--- a/src/components/PromptForm/MobilePromptForm.tsx
+++ b/src/components/PromptForm/MobilePromptForm.tsx
@@ -66,6 +66,7 @@ function MobilePromptForm({
   const handlePromptSubmit = (e: FormEvent) => {
     e.preventDefault();
     const textValue = inputPromptRef.current?.value.trim() || "";
+    console.log("handlePromptSubmit", e.target, textValue);
     if (!textValue) {
       return;
     }


### PR DESCRIPTION
I noticed a weird behavior.
I tried to remove the following
```
    if (!textValue) {
      return;
    }
```
from MobilePromptForm.tsx to allow resubmitting. However stuff started to resubmit when clicking the model menu(on mobile).

and added `console.log("handlePromptSubmit", e.target);` to handlePromptSubmit. 

Noticed that we run this code when when clicking on model menu. That seems wrong..Not enough of a chakra expert to understand how this is going wrong