### PR TITLE
Data Control setting is seperated from Model Setting

### DIFF
--- a/src/components/Preferences/DataControls.tsx
+++ b/src/components/Preferences/DataControls.tsx
@@ -1,0 +1,174 @@
+import {
+  Box,
+  Button,
+  Divider,
+  Flex,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  Input,
+  Link,
+  VStack,
+} from "@chakra-ui/react";
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from "react";
+import { useAlert } from "../../hooks/use-alert";
+import db from "../../lib/db";
+import { download } from "../../lib/utils";
+
+// https://dexie.org/docs/StorageManager
+async function isStoragePersisted() {
+  if (navigator.storage?.persisted) {
+    return await navigator.storage.persisted();
+  }
+
+  return false;
+}
+
+function DataControls() {
+  // Whether our db is being persisted
+  const [isPersisted, setIsPersisted] = useState(false);
+  const { info, error } = useAlert();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    isStoragePersisted()
+      .then((value) => setIsPersisted(value))
+      .catch(console.error);
+  }, []);
+
+  async function handlePersistClick() {
+    if (navigator.storage?.persist) {
+      await navigator.storage.persist();
+      const persisted = await isStoragePersisted();
+      setIsPersisted(persisted);
+    }
+  }
+
+  const handleExportClick = useCallback(
+    async function () {
+      // Don't load this unless it's needed (150K)
+      const { exportDB } = await import("dexie-export-import");
+      const blob = await exportDB(db);
+      download(blob, "chatcraft-db.json", "application/json");
+      info({
+        title: "Downloaded",
+        message: "Message was downloaded as a file",
+      });
+    },
+    [info]
+  );
+
+  const handleFileChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        const reader = new FileReader();
+        reader.onloadend = () => {
+          const blob = new Blob([new Uint8Array(reader.result as ArrayBuffer)]);
+          // Don't load this unless it's needed (150K)
+          import("dexie-export-import")
+            .then(({ importDB }) => importDB(blob))
+            .then(() => {
+              info({
+                title: "Database Import",
+                message: "Database imported successfully. You may need to refresh.",
+              });
+            })
+            .catch((err) => {
+              console.warn("Error importing db", err);
+              error({
+                title: "Database Import",
+                message: "Unable to import database. See Console for more details.",
+              });
+            });
+        };
+        reader.readAsArrayBuffer(file);
+      }
+    },
+    [error, info]
+  );
+
+  const handleImportClick = useCallback(
+    function () {
+      if (inputRef.current) {
+        inputRef.current.click();
+      }
+    },
+    [inputRef]
+  );
+
+  return (
+    <Box my={3}>
+      <VStack gap={4}>
+        <FormControl>
+          <Flex width="100%" flexDirection="column" mb={2}>
+            <Flex justify="space-between" align="center">
+              <FormLabel>
+                Offline database is {isPersisted ? "persisted" : "not persisted"}
+              </FormLabel>
+              <Button
+                size="sm"
+                onClick={() => handlePersistClick()}
+                isDisabled={isPersisted}
+                variant="outline"
+              >
+                Persist
+              </Button>
+            </Flex>
+            <FormHelperText>
+              Persisted databases use the{" "}
+              <Link
+                href="https://developer.mozilla.org/en-US/docs/Web/API/Storage_API"
+                textDecoration="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Storage API
+              </Link>{" "}
+              and are retained by the browser as long as possible. See{" "}
+              <Link
+                href="https://dexie.org/docs/ExportImport/dexie-export-import"
+                textDecoration="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                docs
+              </Link>{" "}
+              for database export details.
+            </FormHelperText>
+          </Flex>
+        </FormControl>
+
+        <Divider />
+
+        <FormControl>
+          <Flex justify="space-between" align="center">
+            <FormLabel>Data Import</FormLabel>
+            <Button size="sm" onClick={() => handleImportClick()}>
+              Import
+            </Button>
+            <Input
+              type="file"
+              ref={inputRef}
+              onChange={handleFileChange}
+              style={{ display: "none" }}
+            />
+          </Flex>
+        </FormControl>
+
+        <Divider />
+
+        <FormControl>
+          <Flex justify="space-between" align="center">
+            <FormLabel>Data Export</FormLabel>
+            <Button size="sm" onClick={() => handleExportClick()}>
+              Export
+            </Button>
+          </Flex>
+        </FormControl>
+      </VStack>
+    </Box>
+  );
+}
+
+export default DataControls;

--- a/src/components/Preferences/PreferencesModal.tsx
+++ b/src/components/Preferences/PreferencesModal.tsx
@@ -24,10 +24,12 @@ import ModelsSettings from "./ModelsSettings";
 import WebHandlersConfig from "./WebHandlersConfig";
 import DefaultSystemPrompt from "./DefaultSystemPrompt";
 import CustomizationSettings from "./CustomizationSettings";
+import DataControls from "./DataControls";
 import { MdOutlineDashboardCustomize, MdSignalCellularAlt } from "react-icons/md";
 import { IconType } from "react-icons";
 import { TbPrompt } from "react-icons/tb";
 import { FaRobot } from "react-icons/fa";
+import { FaDatabase } from "react-icons/fa";
 
 type PreferencesModalProps = {
   isOpen: boolean;
@@ -53,6 +55,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
     { name: "System Prompt", icon: TbPrompt },
     { name: "Web Handlers", icon: MdSignalCellularAlt },
     { name: "Customization", icon: MdOutlineDashboardCustomize },
+    { name: "Data Controls", icon: FaDatabase },
   ];
 
   const handleSettingClick = (setting: Setting) => {
@@ -187,6 +190,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               {selectedSetting.name === "System Prompt" && <DefaultSystemPrompt />}
               {selectedSetting.name === "Web Handlers" && <WebHandlersConfig />}
               {selectedSetting.name === "Customization" && <CustomizationSettings />}
+              {selectedSetting.name === "Data Controls" && <DataControls />}
             </Box>
           </Flex>
         </ModalBody>


### PR DESCRIPTION
This fixes https://github.com/tarasglek/chatcraft.org/issues/626

## Description
This PR seperates Data Control settings such as Persist, Import, and Export from modelsSettings Component.

## Test Screenshots

### ModelsSettings Page After Change On Desktop(Google Chrome)
<img width="912" alt="Screenshot 2024-12-05 at 4 39 38 PM" src="https://github.com/user-attachments/assets/35adbc9d-06af-43a9-837e-9cd8bdf1d3e1">

### DataControls Page On Desktop
<img width="942" alt="Screenshot 2024-12-05 at 4 39 26 PM" src="https://github.com/user-attachments/assets/b8506d37-10cc-4a31-be41-9ce16dbfa00c">

### ModelsSettings Page After Change on Mobile (iPhone 15 Pro)
![IMG_0742](https://github.com/user-attachments/assets/0f1adb23-daed-4c65-a0e1-0eaebab7f27e)

### DataControls Page on Mobile (iPhone 15 Pro)
![IMG_0743](https://github.com/user-attachments/assets/48d84681-43d3-44e3-af50-ebfdf892d51d)

### DataControls Page with the Dropdown menu unfolded on Mobile (iPhone 15 Pro)
![IMG_0744](https://github.com/user-attachments/assets/96f2dea1-e5b7-4bb0-9773-f45f0d23c0d9)


## Extra fix
I think this is not directly related to this issue, but there was duplicate declearations of interface in ModelsSettings Page.
So I removed one of them.
<img width="594" alt="Screenshot 2024-12-01 at 6 26 31 PM" src="https://github.com/user-attachments/assets/2eb48672-ba43-46d1-9732-2257d03c11a6">
