### PR TITLE
typo fixed in Database Modal

### DIFF
--- a/src/components/Preferences/Database.tsx
+++ b/src/components/Preferences/Database.tsx
@@ -143,7 +143,7 @@ function Database() {
 
         <FormControl>
           <Flex justify="space-between" align="center">
-            <FormLabel>Export database to to JSON file</FormLabel>
+            <FormLabel>Export database to JSON file</FormLabel>
             <Button size="sm" onClick={() => handleExportClick()}>
               Export
             </Button>


### PR DESCRIPTION
### Description
This fixes a typo in https://github.com/tarasglek/chatcraft.org/pull/760

Before
"Export Database to to JSON file"

Now
"Export Database to JSON file"

@humphd fixed the typo
Sorry for making you work twice 😭