### PR TITLE
Add analytics

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-syntax-highlighter": "^15.6.1",
     "react-textarea-autosize": "^8.5.6",
     "react-use": "^17.6.0",
+    "recharts": "^2.15.0",
     "rehype-external-links": "^3.0.0",
     "rehype-katex": "^7.0.1",
     "rehype-raw": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       react-use:
         specifier: ^17.6.0
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
@@ -2442,6 +2445,10 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   codemirror@6.0.1:
     resolution: {integrity: sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==}
 
@@ -2773,6 +2780,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   decode-named-character-reference@1.0.2:
     resolution: {integrity: sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==}
 
@@ -2846,6 +2856,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   domain-browser@4.22.0:
     resolution: {integrity: sha512-IGBwjF7tNk3cwypFNH/7bfzBcgSCbaMOD3GsaY1AU/JRrnHnYgEM0+9kQt52iZxjNsjBtJYtao146V+f8jFZNw==}
@@ -3102,6 +3115,9 @@ packages:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -3139,6 +3155,10 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
+
+  fast-equals@5.0.1:
+    resolution: {integrity: sha512-WF1Wi8PwwSY7/6Kx0vKXtw8RwuSGoM1bvDaJbu7MxDlR1vovZjIAKrnzyrThgAjm6JDTu0fVgWXDlMGspodfoQ==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
@@ -4548,6 +4568,9 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
   react-markdown@9.0.1:
     resolution: {integrity: sha512-186Gw/vF1uRkydbsOIkcGXw7aHq0sZOCRFFjGrr7b9+nVZg4UfA4enXCaxm4fUzecU38sWfrNDitGhshuU7rdg==}
     peerDependencies:
@@ -4591,6 +4614,12 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -4611,6 +4640,12 @@ packages:
     engines: {node: '>=10'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
 
   react-transition-state@2.2.0:
     resolution: {integrity: sha512-D3EyLku1Sdxrxq26Fo4Jh0q1BLEFQfDOxKKiSuyqWH84+hM6y0Guc0hcW2IXMXY5l5gQCgkOQ9y90xx6mNoj5w==}
@@ -4644,6 +4679,16 @@ packages:
   readdirp@4.0.2:
     resolution: {integrity: sha512-yDMz9g+VaZkqBYS/ozoBJwaBhTbZo3UNYQHNRw1D3UFQB8oHB4uS/tAODO+ZLjGWmUbKnIlOWO+aaIiAxrUWHA==}
     engines: {node: '>= 14.16.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.0:
+    resolution: {integrity: sha512-cIvMxDfpAmqAmVgc4yb7pgm/O1tmmkl/CjrvXuW+62/+7jj/iF9Ykm+hb/UJt42TREHMyd3gb+pkgoa2MxgDIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.9:
     resolution: {integrity: sha512-r0Ay04Snci87djAsI4U+WNRcSw5S4pOH7qFjd/veA5gC7TbqESR3tcj28ia95L/fYUDw11JKP7uqUKUAfVvV5Q==}
@@ -5114,6 +5159,9 @@ packages:
     resolution: {integrity: sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==}
     engines: {node: '>=0.6.0'}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -5385,6 +5433,9 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
   vite-node@2.1.8:
     resolution: {integrity: sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==}
@@ -8118,6 +8169,8 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
+  clsx@2.1.1: {}
+
   codemirror@6.0.1:
     dependencies:
       '@codemirror/autocomplete': 6.18.4
@@ -8486,6 +8539,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   decode-named-character-reference@1.0.2:
     dependencies:
       character-entities: 2.0.2
@@ -8554,6 +8609,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.26.0
+      csstype: 3.1.3
 
   domain-browser@4.22.0: {}
 
@@ -8980,6 +9040,8 @@ snapshots:
 
   event-target-shim@5.0.1: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
@@ -9024,6 +9086,8 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
+
+  fast-equals@5.0.1: {}
 
   fast-glob@3.3.2:
     dependencies:
@@ -10754,6 +10818,8 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@18.3.1: {}
+
   react-markdown@9.0.1(@types/react@18.3.18)(react@18.3.1):
     dependencies:
       '@types/hast': 3.0.4
@@ -10804,6 +10870,14 @@ snapshots:
       '@remix-run/router': 1.21.0
       react: 18.3.1
 
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.0.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
   react-style-singleton@2.2.3(@types/react@18.3.18)(react@18.3.1):
     dependencies:
       get-nonce: 1.0.1
@@ -10830,6 +10904,15 @@ snapshots:
       use-latest: 1.3.0(@types/react@18.3.18)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   react-transition-state@2.2.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -10881,6 +10964,23 @@ snapshots:
       util-deprecate: 1.0.2
 
   readdirp@4.0.2: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.9:
     dependencies:
@@ -11459,6 +11559,8 @@ snapshots:
     dependencies:
       setimmediate: 1.0.5
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -11742,6 +11844,23 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.1
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.8
+      '@types/d3-shape': 3.1.6
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite-node@2.1.8(@types/node@22.10.3)(terser@5.37.0):
     dependencies:

--- a/src/components/AnalyticsVisualizations.tsx
+++ b/src/components/AnalyticsVisualizations.tsx
@@ -1,0 +1,123 @@
+import React, { useEffect, useState } from "react";
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Box, Heading, VStack, Container } from "@chakra-ui/react";
+import { ChatAnalytics, generateAnalytics } from "../lib/analytics";
+
+export const AnalyticsVisualizations: React.FC = () => {
+  const [analytics, setAnalytics] = useState<ChatAnalytics>();
+
+  useEffect(() => {
+    generateAnalytics().then(setAnalytics);
+  }, [setAnalytics]);
+
+  if (!analytics) {
+    return null;
+  }
+
+  // Prepare model usage data
+  const modelUsageData = Object.entries(analytics.modelMetrics.usage).map(([model, stats]) => ({
+    name: model,
+    messages: stats.messageCount,
+    characters: stats.characterCount,
+    avgResponseTime: Math.round(stats.avgResponseTime / 1000), // Convert to seconds
+  }));
+
+  // Prepare time series data
+  const timeSeriesData = Object.entries(analytics.timeMetrics.byPeriod)
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([period, stats]) => ({
+      date: period,
+      messages: stats.messageCount,
+      conversations: stats.conversationCount,
+      avgResponseTime: Math.round(stats.avgResponseTime / 1000),
+    }));
+
+  // Prepare hourly distribution data
+  const hourlyData = Object.entries(analytics.timeMetrics.hourlyDistribution)
+    .map(([hour, count]) => ({
+      hour: `${hour}:00`,
+      messages: count,
+    }))
+    .sort((a, b) => parseInt(a.hour) - parseInt(b.hour));
+
+  return (
+    <Container maxW="1200px" py={6}>
+      <VStack spacing={8} align="stretch">
+        {/* Model Usage Chart */}
+        <Box bg="white" p={6} borderRadius="lg" boxShadow="sm">
+          <Heading size="md" mb={6} textAlign="center">
+            Model Usage
+          </Heading>
+          <Box h="400px">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={modelUsageData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" angle={-45} textAnchor="end" height={80} />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="messages" fill="#8884d8" name="Messages" />
+                <Bar dataKey="avgResponseTime" fill="#82ca9d" name="Avg Response (s)" />
+              </BarChart>
+            </ResponsiveContainer>
+          </Box>
+        </Box>
+
+        {/* Time Series Chart */}
+        <Box bg="white" p={6} borderRadius="lg" boxShadow="sm">
+          <Heading size="md" mb={6} textAlign="center">
+            Message Activity Over Time
+          </Heading>
+          <Box h="400px">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={timeSeriesData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" angle={-45} textAnchor="end" height={80} />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="messages" stroke="#8884d8" name="Messages" />
+                <Line
+                  type="monotone"
+                  dataKey="conversations"
+                  stroke="#82ca9d"
+                  name="Conversations"
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </Box>
+        </Box>
+
+        {/* Hourly Distribution Chart */}
+        <Box bg="white" p={6} borderRadius="lg" boxShadow="sm">
+          <Heading size="md" mb={6} textAlign="center">
+            Message Distribution by Hour
+          </Heading>
+          <Box h="400px">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={hourlyData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="hour" />
+                <YAxis />
+                <Tooltip />
+                <Legend />
+                <Bar dataKey="messages" fill="#8884d8" name="Messages" />
+              </BarChart>
+            </ResponsiveContainer>
+          </Box>
+        </Box>
+      </VStack>
+    </Container>
+  );
+};

--- a/src/components/Preferences/PreferencesModal.tsx
+++ b/src/components/Preferences/PreferencesModal.tsx
@@ -30,6 +30,7 @@ import { IconType } from "react-icons";
 import { TbPrompt } from "react-icons/tb";
 import { FaRobot } from "react-icons/fa";
 import { FaDatabase } from "react-icons/fa";
+import { AnalyticsVisualizations } from "../AnalyticsVisualizations";
 
 type PreferencesModalProps = {
   isOpen: boolean;
@@ -56,6 +57,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
     { name: "Web Handlers", icon: MdSignalCellularAlt },
     { name: "Customization", icon: MdOutlineDashboardCustomize },
     { name: "Database", icon: FaDatabase },
+    { name: "Analytics", icon: FaDatabase },
   ];
 
   const handleSettingClick = (setting: Setting) => {
@@ -193,6 +195,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               {selectedSetting.name === "Web Handlers" && <WebHandlersConfig />}
               {selectedSetting.name === "Customization" && <CustomizationSettings />}
               {selectedSetting.name === "Database" && <Database />}
+              {selectedSetting.name === "Analytics" && <AnalyticsVisualizations />}
             </Box>
           </Flex>
         </ModalBody>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,318 @@
+import { MessageType } from "./ChatCraftMessage";
+import db from "./db";
+
+type Period = "day" | "week" | "month";
+
+// Get a standardized key for a time period
+function getPeriodKey(date: Date, periodType: Period = "day"): string {
+  switch (periodType) {
+    case "day":
+      return date.toISOString().slice(0, 10); // YYYY-MM-DD
+    case "week": {
+      const startOfWeek = new Date(date);
+      startOfWeek.setDate(date.getDate() - date.getDay());
+      return startOfWeek.toISOString().slice(0, 10);
+    }
+    case "month":
+      return date.toISOString().slice(0, 7); // YYYY-MM
+    default:
+      throw new Error(`Invalid period type: ${periodType}`);
+  }
+}
+
+// Base metrics without calculation fields
+interface BaseMetrics {
+  messageCount: number;
+  characterCount: number;
+  conversationCount: number;
+  avgResponseTime: number;
+  uniqueModels: string[];
+}
+
+// Working metrics with calculation fields
+interface WorkingPeriodMetrics extends BaseMetrics {
+  totalResponseTime: number;
+  responseCount: number;
+  conversationIds: Set<string>;
+}
+
+// Working model metrics
+interface WorkingModelMetrics {
+  messageCount: number;
+  characterCount: number;
+  avgResponseLength: number;
+  avgResponseTime: number;
+  totalResponseTime: number;
+  responseCount: number;
+}
+
+// Final model metrics
+interface ModelMetrics {
+  messageCount: number;
+  characterCount: number;
+  avgResponseLength: number;
+  avgResponseTime: number;
+}
+
+export interface ChatAnalytics {
+  timeMetrics: {
+    byPeriod: Record<string, BaseMetrics>;
+    hourlyDistribution: Record<number, number>;
+    weekdayDistribution: Record<number, number>;
+  };
+  modelMetrics: {
+    usage: Record<string, ModelMetrics>;
+    transitions: Record<string, Record<string, number>>;
+  };
+  contentMetrics: {
+    messageTypes: Record<MessageType, number>;
+    avgMessageLength: number;
+    codeSnippetCount: number;
+    conversationDepth: {
+      min: number;
+      max: number;
+      avg: number;
+      distribution: Record<number, number>;
+    };
+  };
+}
+
+export async function generateAnalytics(startDate?: Date, endDate?: Date): Promise<ChatAnalytics> {
+  const messages = await db.messages
+    .where("date")
+    .between(startDate || new Date(0), endDate || new Date())
+    .toArray();
+
+  const chats = await db.chats.toArray();
+  const workingMetrics: Record<string, WorkingPeriodMetrics> = {};
+  const workingModelMetrics: Record<string, WorkingModelMetrics> = {};
+
+  // First, organize chats by period based on their creation date
+  const chatsByPeriod: Record<string, Set<string>> = {};
+  chats.forEach((chat) => {
+    // Use the first message's date as the chat creation date
+    const firstMessage = messages.find((m) => m.chatId === chat.id);
+    if (firstMessage) {
+      const period = getPeriodKey(firstMessage.date);
+      if (!chatsByPeriod[period]) {
+        chatsByPeriod[period] = new Set();
+      }
+      chatsByPeriod[period].add(chat.id);
+    }
+  });
+
+  // Initialize period metrics with the correct conversation counts
+  Object.entries(chatsByPeriod).forEach(([period, chatIds]) => {
+    workingMetrics[period] = {
+      messageCount: 0,
+      characterCount: 0,
+      conversationCount: chatIds.size,
+      avgResponseTime: 0,
+      uniqueModels: [],
+      totalResponseTime: 0,
+      responseCount: 0,
+      conversationIds: chatIds,
+    };
+  });
+
+  // Initialize results structure
+  const results: ChatAnalytics = {
+    timeMetrics: {
+      byPeriod: {},
+      hourlyDistribution: {},
+      weekdayDistribution: {},
+    },
+    modelMetrics: {
+      usage: {},
+      transitions: {},
+    },
+    contentMetrics: {
+      messageTypes: {} as Record<MessageType, number>,
+      avgMessageLength: 0,
+      codeSnippetCount: 0,
+      conversationDepth: {
+        min: Infinity,
+        max: 0,
+        avg: 0,
+        distribution: {},
+      },
+    },
+  };
+
+  // Process messages in a single pass
+  messages.forEach((msg, idx, arr) => {
+    const period = getPeriodKey(msg.date);
+    const hour = msg.date.getHours();
+    const weekday = msg.date.getDay();
+
+    // Initialize period metrics if needed
+    if (!workingMetrics[period]) {
+      workingMetrics[period] = {
+        messageCount: 0,
+        characterCount: 0,
+        conversationCount: 0,
+        avgResponseTime: 0,
+        uniqueModels: [],
+        totalResponseTime: 0,
+        responseCount: 0,
+        conversationIds: new Set(),
+      };
+    }
+
+    const periodMetrics = workingMetrics[period];
+
+    // Basic message counting
+    periodMetrics.messageCount++;
+    periodMetrics.characterCount += msg.text.length;
+
+    // Track response times for AI messages
+    if (msg.type === "ai" && idx > 0) {
+      const prevMsg = arr[idx - 1];
+      if (prevMsg.chatId === msg.chatId && prevMsg.type === "human") {
+        const responseTime = msg.date.getTime() - prevMsg.date.getTime();
+        periodMetrics.totalResponseTime += responseTime;
+        periodMetrics.responseCount++;
+      }
+    }
+
+    // Track models
+    if (msg.model) {
+      if (!periodMetrics.uniqueModels.includes(msg.model)) {
+        periodMetrics.uniqueModels.push(msg.model);
+      }
+    }
+
+    // Update distributions
+    results.timeMetrics.hourlyDistribution[hour] =
+      (results.timeMetrics.hourlyDistribution[hour] || 0) + 1;
+    results.timeMetrics.weekdayDistribution[weekday] =
+      (results.timeMetrics.weekdayDistribution[weekday] || 0) + 1;
+
+    // Model metrics
+    if (msg.model) {
+      if (!workingModelMetrics[msg.model]) {
+        workingModelMetrics[msg.model] = {
+          messageCount: 0,
+          characterCount: 0,
+          avgResponseLength: 0,
+          avgResponseTime: 0,
+          totalResponseTime: 0,
+          responseCount: 0,
+        };
+      }
+
+      const modelMetrics = workingModelMetrics[msg.model];
+      modelMetrics.messageCount++;
+      modelMetrics.characterCount += msg.text.length;
+
+      // Track model response times
+      if (msg.type === "ai" && idx > 0) {
+        const prevMsg = arr[idx - 1];
+        if (prevMsg.chatId === msg.chatId && prevMsg.type === "human") {
+          const responseTime = msg.date.getTime() - prevMsg.date.getTime();
+          modelMetrics.totalResponseTime += responseTime;
+          modelMetrics.responseCount++;
+        }
+      }
+
+      // Track model transitions
+      if (idx > 0 && arr[idx - 1].model && arr[idx - 1].model !== msg.model) {
+        const prevModel = arr[idx - 1].model;
+        if (prevModel) {
+          if (!results.modelMetrics.transitions[prevModel]) {
+            results.modelMetrics.transitions[prevModel] = {};
+          }
+          results.modelMetrics.transitions[prevModel][msg.model] =
+            (results.modelMetrics.transitions[prevModel][msg.model] || 0) + 1;
+        }
+      }
+    }
+
+    // Content metrics
+    results.contentMetrics.messageTypes[msg.type] =
+      (results.contentMetrics.messageTypes[msg.type] || 0) + 1;
+    results.contentMetrics.codeSnippetCount += (msg.text.match(/```/g) || []).length / 2;
+
+    console.log(`Period ${period}:`, {
+      messages: periodMetrics.messageCount,
+      conversations: periodMetrics.conversationIds.size,
+      responseTimes: {
+        total: periodMetrics.totalResponseTime,
+        count: periodMetrics.responseCount,
+        avg: periodMetrics.responseCount
+          ? periodMetrics.totalResponseTime / periodMetrics.responseCount
+          : 0,
+      },
+      models: periodMetrics.uniqueModels,
+    });
+  });
+
+  // Process chats for conversation depth
+  chats.forEach((chat) => {
+    const depth = chat.messageIds.length;
+    results.contentMetrics.conversationDepth.min = Math.min(
+      results.contentMetrics.conversationDepth.min,
+      depth
+    );
+    results.contentMetrics.conversationDepth.max = Math.max(
+      results.contentMetrics.conversationDepth.max,
+      depth
+    );
+    results.contentMetrics.conversationDepth.distribution[depth] =
+      (results.contentMetrics.conversationDepth.distribution[depth] || 0) + 1;
+  });
+
+  // Calculate final averages
+  results.contentMetrics.avgMessageLength =
+    messages.reduce((sum, msg) => sum + msg.text.length, 0) / messages.length;
+  results.contentMetrics.conversationDepth.avg =
+    chats.reduce((sum, chat) => sum + chat.messageIds.length, 0) / chats.length;
+
+  // Convert working metrics to final format
+  Object.entries(workingMetrics).forEach(([period, metrics]) => {
+    results.timeMetrics.byPeriod[period] = {
+      messageCount: metrics.messageCount,
+      characterCount: metrics.characterCount,
+      conversationCount: metrics.conversationCount,
+      avgResponseTime: metrics.responseCount
+        ? metrics.totalResponseTime / metrics.responseCount
+        : 0,
+      uniqueModels: metrics.uniqueModels,
+    };
+  });
+
+  // Convert working model metrics to final format
+  Object.entries(workingModelMetrics).forEach(([model, metrics]) => {
+    results.modelMetrics.usage[model] = {
+      messageCount: metrics.messageCount,
+      characterCount: metrics.characterCount,
+      avgResponseLength: metrics.messageCount ? metrics.characterCount / metrics.messageCount : 0,
+      avgResponseTime: metrics.responseCount
+        ? metrics.totalResponseTime / metrics.responseCount
+        : 0,
+    };
+  });
+
+  return results;
+}
+
+export function visualizeAnalytics(analytics: ChatAnalytics) {
+  // Model Usage Chart
+  const modelUsageData = Object.entries(analytics.modelMetrics.usage).map(([model, stats]) => ({
+    model,
+    messages: stats.messageCount,
+    characters: stats.characterCount,
+  }));
+
+  // Time Distribution Chart
+  const timeData = Object.entries(analytics.timeMetrics.byPeriod).map(([period, stats]) => ({
+    period,
+    messages: stats.messageCount,
+    conversations: stats.conversationCount,
+  }));
+
+  return {
+    modelUsageData,
+    timeData,
+  };
+}

--- a/src/lib/commands/AnalyticsCommand.ts
+++ b/src/lib/commands/AnalyticsCommand.ts
@@ -1,0 +1,21 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { generateAnalytics, visualizeAnalytics } from "../analytics";
+import { ChatCraftAppMessage } from "../ChatCraftMessage";
+
+export class AnalyticsCommand extends ChatCraftCommand {
+  constructor() {
+    super("analytics", "/analytics", "Generate chat analytics.");
+  }
+
+  async execute(chat: ChatCraftChat) {
+    const analytics = await generateAnalytics();
+    chat.addMessage(
+      new ChatCraftAppMessage({ text: "```json\n" + JSON.stringify(analytics, null, 2) + "\n```" })
+    );
+    const visualized = visualizeAnalytics(analytics);
+    chat.addMessage(
+      new ChatCraftAppMessage({ text: "```json\n" + JSON.stringify(visualized, null) + "\n```" })
+    );
+  }
+}

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -9,6 +9,7 @@ import { ImportCommand } from "./ImportCommand";
 import { CommandsHelpCommand } from "./CommandsHelpCommand";
 import { ImageCommand } from "./ImageCommand";
 import { StatsCommand } from "./StatsCommand";
+import { AnalyticsCommand } from "./AnalyticsCommand";
 
 // Register all our commands
 ChatCraftCommandRegistry.registerCommand(new NewCommand());
@@ -19,3 +20,4 @@ ChatCraftCommandRegistry.registerCommand(new CommandsHelpCommand());
 ChatCraftCommandRegistry.registerCommand(new ImportCommand());
 ChatCraftCommandRegistry.registerCommand(new ImageCommand());
 ChatCraftCommandRegistry.registerCommand(new StatsCommand());
+ChatCraftCommandRegistry.registerCommand(new AnalyticsCommand());


### PR DESCRIPTION
Part of #765.  I've added code to pull some analytics from the db, and created two ways to view it:

- use the `/analytics` slash command, which dumps your stats as JSON into messages in the chat
- in the Settings modal, I added another temporary pane, to try adding some charts

The UI for this is all terrible at the moment, but the stuff you get out of it is cool.  It would be easy to add more.