### PR TITLE
switch to newer (standard) worker handler syntax

### DIFF
--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -11,64 +11,66 @@ interface Env {
   GOOGLE_OUATH_CLIENT_SECRET: string;
 }
 
-export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
-  const {
-    GITHUB_OAUTH_CLIENT_ID,
-    GITHUB_OAUTH_CLIENT_SECRET,
-    JWT_SECRET,
-    GOOGLE_OAUTH_CLIENT_ID,
-    GOOGLE_OUATH_CLIENT_SECRET,
-  } = env;
-  const reqUrl = new URL(request.url);
-
-  // Determine the login provider
-  let provider = reqUrl.searchParams.get("provider");
-  if (!provider) {
-    let state = reqUrl.searchParams.get("state");
-    if (state) {
-      state = decodeURIComponent(state);
-      const stateParams = new URLSearchParams(state);
-      provider = stateParams.get("provider");
-    }
-  }
-
-  // Include ?chat_id=... to redirect back to a given chat in the client.  Google will
-  // return it back to us via ?state=provider%3Dgoogle%26chat_id%3Dl77...
-  let chatId = reqUrl.searchParams.get("chat_id");
-  if (!chatId) {
-    let state = reqUrl.searchParams.get("state");
-    if (state) {
-      state = decodeURIComponent(state);
-      const stateParams = new URLSearchParams(state);
-      chatId = stateParams.get("chatId");
-    }
-  }
-
-  const code = reqUrl.searchParams.get("code");
-
-  const { appUrl, isDev, tokenProvider } = createResourcesForEnv(env.ENVIRONMENT, request.url);
-
-  if (provider === "google") {
-    return handleGoogleLogin({
-      isDev,
-      code,
-      chatId,
-      GOOGLE_OAUTH_CLIENT_ID,
-      GOOGLE_OUATH_CLIENT_SECRET,
-      JWT_SECRET,
-      tokenProvider,
-      appUrl,
-    });
-  } else {
-    return handleGithubLogin({
-      isDev,
-      code,
-      chatId,
+export default {
+  fetch: async (request, env) => {
+    const {
       GITHUB_OAUTH_CLIENT_ID,
       GITHUB_OAUTH_CLIENT_SECRET,
       JWT_SECRET,
-      tokenProvider,
-      appUrl,
-    });
-  }
+      GOOGLE_OAUTH_CLIENT_ID,
+      GOOGLE_OUATH_CLIENT_SECRET,
+    } = env;
+    const reqUrl = new URL(request.url);
+
+    // Determine the login provider
+    let provider = reqUrl.searchParams.get("provider");
+    if (!provider) {
+      let state = reqUrl.searchParams.get("state");
+      if (state) {
+        state = decodeURIComponent(state);
+        const stateParams = new URLSearchParams(state);
+        provider = stateParams.get("provider");
+      }
+    }
+
+    // Include ?chat_id=... to redirect back to a given chat in the client.  Google will
+    // return it back to us via ?state=provider%3Dgoogle%26chat_id%3Dl77...
+    let chatId = reqUrl.searchParams.get("chat_id");
+    if (!chatId) {
+      let state = reqUrl.searchParams.get("state");
+      if (state) {
+        state = decodeURIComponent(state);
+        const stateParams = new URLSearchParams(state);
+        chatId = stateParams.get("chatId");
+      }
+    }
+
+    const code = reqUrl.searchParams.get("code");
+
+    const { appUrl, isDev, tokenProvider } = createResourcesForEnv(env.ENVIRONMENT, request.url);
+
+    if (provider === "google") {
+      return handleGoogleLogin({
+        isDev,
+        code,
+        chatId,
+        GOOGLE_OAUTH_CLIENT_ID,
+        GOOGLE_OUATH_CLIENT_SECRET,
+        JWT_SECRET,
+        tokenProvider,
+        appUrl,
+      });
+    } else {
+      return handleGithubLogin({
+        isDev,
+        code,
+        chatId,
+        GITHUB_OAUTH_CLIENT_ID,
+        GITHUB_OAUTH_CLIENT_SECRET,
+        JWT_SECRET,
+        tokenProvider,
+        appUrl,
+      });
+    }
+  },
 };

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -11,66 +11,68 @@ interface Env {
   GOOGLE_OUATH_CLIENT_SECRET: string;
 }
 
-export default {
-  fetch: async (request, env) => {
-    const {
+export const onRequestGet: PagesFunction<Env> = async ({ request, env }) => {
+  const {
+    GITHUB_OAUTH_CLIENT_ID,
+    GITHUB_OAUTH_CLIENT_SECRET,
+    JWT_SECRET,
+    GOOGLE_OAUTH_CLIENT_ID,
+    GOOGLE_OUATH_CLIENT_SECRET,
+  } = env;
+  const reqUrl = new URL(request.url);
+
+  // Determine the login provider
+  let provider = reqUrl.searchParams.get("provider");
+  if (!provider) {
+    let state = reqUrl.searchParams.get("state");
+    if (state) {
+      state = decodeURIComponent(state);
+      const stateParams = new URLSearchParams(state);
+      provider = stateParams.get("provider");
+    }
+  }
+
+  // Include ?chat_id=... to redirect back to a given chat in the client.  Google will
+  // return it back to us via ?state=provider%3Dgoogle%26chat_id%3Dl77...
+  let chatId = reqUrl.searchParams.get("chat_id");
+  if (!chatId) {
+    let state = reqUrl.searchParams.get("state");
+    if (state) {
+      state = decodeURIComponent(state);
+      const stateParams = new URLSearchParams(state);
+      chatId = stateParams.get("chatId");
+    }
+  }
+
+  const code = reqUrl.searchParams.get("code");
+
+  const { appUrl, isDev, tokenProvider } = createResourcesForEnv(env.ENVIRONMENT, request.url);
+
+  if (provider === "google") {
+    return handleGoogleLogin({
+      isDev,
+      code,
+      chatId,
+      GOOGLE_OAUTH_CLIENT_ID,
+      GOOGLE_OUATH_CLIENT_SECRET,
+      JWT_SECRET,
+      tokenProvider,
+      appUrl,
+    });
+  } else {
+    return handleGithubLogin({
+      isDev,
+      code,
+      chatId,
       GITHUB_OAUTH_CLIENT_ID,
       GITHUB_OAUTH_CLIENT_SECRET,
       JWT_SECRET,
-      GOOGLE_OAUTH_CLIENT_ID,
-      GOOGLE_OUATH_CLIENT_SECRET,
-    } = env as Env;
-    const reqUrl = new URL(request.url);
+      tokenProvider,
+      appUrl,
+    });
+  }
+};
 
-    // Determine the login provider
-    let provider = reqUrl.searchParams.get("provider");
-    if (!provider) {
-      let state = reqUrl.searchParams.get("state");
-      if (state) {
-        state = decodeURIComponent(state);
-        const stateParams = new URLSearchParams(state);
-        provider = stateParams.get("provider");
-      }
-    }
-
-    // Include ?chat_id=... to redirect back to a given chat in the client.  Google will
-    // return it back to us via ?state=provider%3Dgoogle%26chat_id%3Dl77...
-    let chatId = reqUrl.searchParams.get("chat_id");
-    if (!chatId) {
-      let state = reqUrl.searchParams.get("state");
-      if (state) {
-        state = decodeURIComponent(state);
-        const stateParams = new URLSearchParams(state);
-        chatId = stateParams.get("chatId");
-      }
-    }
-
-    const code = reqUrl.searchParams.get("code");
-
-    const { appUrl, isDev, tokenProvider } = createResourcesForEnv(env.ENVIRONMENT, request.url);
-
-    if (provider === "google") {
-      return handleGoogleLogin({
-        isDev,
-        code,
-        chatId,
-        GOOGLE_OAUTH_CLIENT_ID,
-        GOOGLE_OUATH_CLIENT_SECRET,
-        JWT_SECRET,
-        tokenProvider,
-        appUrl,
-      });
-    } else {
-      return handleGithubLogin({
-        isDev,
-        code,
-        chatId,
-        GITHUB_OAUTH_CLIENT_ID,
-        GITHUB_OAUTH_CLIENT_SECRET,
-        JWT_SECRET,
-        tokenProvider,
-        appUrl,
-      });
-    }
-  },
+export default {
+  fetch: (req, env) => onRequestGet({ req, env: env ? env : {} }),
 };

--- a/functions/api/login.ts
+++ b/functions/api/login.ts
@@ -19,7 +19,7 @@ export default {
       JWT_SECRET,
       GOOGLE_OAUTH_CLIENT_ID,
       GOOGLE_OUATH_CLIENT_SECRET,
-    } = env;
+    } = env as Env;
     const reqUrl = new URL(request.url);
 
     // Determine the login provider


### PR DESCRIPTION
@humphd this is bizarre, when I use the new syntax, I
1. pnpm dev-functions
2.  try to login
3.  
I get 
![image](https://github.com/user-attachments/assets/ff79395f-1b2a-4ef4-a2a3-bb5c28275e9e)

As far as I can tell login handler is functioning normally(per dev tools), not sure why dexie is hating me :(