### PR TITLE
Bridge between ChatCraft DB and DuckDB

### DIFF
--- a/src/lib/commands/DuckCommand.ts
+++ b/src/lib/commands/DuckCommand.ts
@@ -2,9 +2,7 @@ import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
 import { CHATCRAFT_TABLES } from "../../lib/db";
-import { queryResultToJson } from "../duckdb";
-import { query } from "../duckdb-chatcraft";
-import { jsonToMarkdownTable } from "../utils";
+import { queryToMarkdown } from "../duckdb-chatcraft";
 
 export class DuckCommand extends ChatCraftCommand {
   constructor() {
@@ -23,9 +21,7 @@ export class DuckCommand extends ChatCraftCommand {
     }
 
     const sql = args.join(" ");
-    const data = await query(sql);
-    const json = queryResultToJson(data);
-    const markdown = jsonToMarkdownTable(json);
+    const markdown = await queryToMarkdown(sql);
     const message = [
       // show query
       "```sql",
@@ -33,7 +29,7 @@ export class DuckCommand extends ChatCraftCommand {
       "```",
       // show results
       markdown,
-    ].join("\n\n");
+    ].join("\n");
     return chat.addMessage(new ChatCraftHumanMessage({ text: message }));
   }
 }

--- a/src/lib/commands/DuckCommand.ts
+++ b/src/lib/commands/DuckCommand.ts
@@ -1,8 +1,7 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
-import { CHATCRAFT_TABLES } from "../../lib/db";
-import { queryToMarkdown } from "../duckdb-chatcraft";
+import { getTables, queryToMarkdown } from "../duckdb-chatcraft";
 
 export class DuckCommand extends ChatCraftCommand {
   constructor() {
@@ -10,18 +9,17 @@ export class DuckCommand extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat, _user: User | undefined, args?: string[]) {
+    let sql: string;
+    let markdown: string;
+
     if (!args?.length) {
-      return chat.addMessage(
-        new ChatCraftHumanMessage({
-          text:
-            `Available DuckDB Tables - ` +
-            `${CHATCRAFT_TABLES.map((t) => `chatcraft.${t}`).join(", ")}\n\nTry \`/duck describe chatcraft.chats\``,
-        })
-      );
+      sql = "SHOW TABLES;";
+      markdown = await getTables();
+    } else {
+      sql = args.join(" ");
+      markdown = await queryToMarkdown(sql);
     }
 
-    const sql = args.join(" ");
-    const markdown = await queryToMarkdown(sql);
     const message = [
       // show query
       "```sql",

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -4,6 +4,7 @@ import { withConnection, insertJSON, QueryResult, query } from "./duckdb";
 
 /**
  * Extracts chatcraft schema table references from a SQL query
+ * TODO: Implement this function using json_serialize_sql and AST traversal
  * @param sql The SQL query to analyze
  * @returns Array of table names referenced in the chatcraft schema
  */
@@ -33,6 +34,8 @@ async function syncChatCraftTable(tableName: ChatCraftTableName): Promise<void> 
 
 /**
  * Enhanced query function that handles ChatCraft db data synchronization silently
+ * TODO: move lazy chatcraft table creation logic into queryToMarkdown so we could
+ * also add a message that we created these implicit tables and show their schema
  * @param sql The SQL query to execute
  * @param params Optional parameters for prepared statement
  * @returns Query results as an Arrow Table
@@ -45,6 +48,8 @@ export async function chatCraftQuery<T extends { [key: string]: DataType } = any
     // First attempt to execute the query
     return await query<T>(sql, params);
   } catch (error: unknown) {
+    // Rely on missing table error if if a user happens to want to create a called chatcraft.messages, we are fine with it
+    // this also reduces of risk of overhead of premature table creation
     // Check if error matches the catalog error pattern
     const catalogErrorPattern = /Catalog Error: Table with name (\w+) does not exist!/;
     const match = error instanceof Error && error.message.match(catalogErrorPattern);

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -45,32 +45,32 @@ export async function chatCraftQuery<T extends { [key: string]: DataType } = any
     // First attempt to execute the query
     return await query<T>(sql, params);
   } catch (error: unknown) {
+    // Get all chatcraft tables referenced in the query
+    const referencedTables = extractChatCraftTables(sql);
+    
     // Check if error matches the catalog error pattern
     const catalogErrorPattern = /Catalog Error: Table with name (\w+) does not exist!/;
     const match = error instanceof Error && error.message.match(catalogErrorPattern);
 
-    if (match) {
-      const tableName = match[1];
+    // If we have a catalog error and referenced tables
+    if (match || referencedTables.length > 0) {
+      // Create schema if needed
+      await withConnection(async (conn) => {
+        await conn.query(`CREATE SCHEMA IF NOT EXISTS chatcraft`);
+      });
 
-      // First check if the missing table is a ChatCraft table
-      if (isChatCraftTableName(tableName)) {
-        // Then verify it's referenced as chatcraft.table in the query
-        const referencedTables = extractChatCraftTables(sql);
-        if (referencedTables.includes(tableName)) {
-          // Create schema if needed
-          await withConnection(async (conn) => {
-            await conn.query(`CREATE SCHEMA IF NOT EXISTS chatcraft`);
-          });
-
+      // Sync all referenced chatcraft tables
+      for (const tableName of referencedTables) {
+        if (isChatCraftTableName(tableName)) {
           await syncChatCraftTable(tableName);
-
-          // Retry the query after syncing
-          return await query<T>(sql, params);
         }
       }
+
+      // Retry the query after syncing
+      return await query<T>(sql, params);
     }
 
-    // If not a catalog error, not a chatcraft table, or not referenced properly, rethrow
+    // If not a catalog error or no referenced tables, rethrow
     throw error;
   }
 }

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -1,0 +1,71 @@
+import { DataType } from "apache-arrow";
+import db, { CHATCRAFT_TABLES, ChatCraftTableName, isChatCraftTableName } from "./db";
+import { withConnection, insertJSON, QueryResult, query } from "./duckdb";
+
+/**
+ * Extracts chatcraft schema table references from a SQL query
+ * @param sql The SQL query to analyze
+ * @returns Array of table names referenced in the chatcraft schema
+ */
+function extractChatCraftTables(sql: string): string[] {
+  // Match "chatcraft.table_name" or "chatcraft.table_name;"
+  const regex = /chatcraft\.(\w+)(?:\s|;|$)/g;
+  const matches = [...sql.matchAll(regex)];
+  return [...new Set(matches.map((match) => match[1]))];
+}
+
+/**
+ * Synchronizes a single ChatCraft table to DuckDB
+ * @param tableName The name of the table to synchronize
+ * @returns Promise resolving when sync is complete
+ */
+async function syncChatCraftTable(tableName: ChatCraftTableName): Promise<void> {
+  const data = await db.byTableName(tableName).toArray();
+
+  // Convert dates to ISO strings for JSON serialization
+  const jsonData = data.map((record) => ({
+    ...record,
+    date: record.date instanceof Date ? record.date.toISOString() : record.date,
+  }));
+
+  await insertJSON(tableName, JSON.stringify(jsonData), { schema: "chatcraft" });
+}
+
+/**
+ * Enhanced query function that handles ChatCraft db data synchronization silently
+ * @param sql The SQL query to execute
+ * @param params Optional parameters for prepared statement
+ * @returns Query results as an Arrow Table
+ */
+export async function chatCraftQuery<T extends { [key: string]: DataType } = any>(
+  sql: string,
+  params?: any[]
+): Promise<QueryResult<T>> {
+  // Extract referenced chatcraft tables from the query
+  const chatcraftTables = extractChatCraftTables(sql);
+
+  // If we found any chatcraft tables, sync them first
+  if (chatcraftTables.length > 0) {
+    // Create schema if needed
+    await withConnection(async (conn) => {
+      await conn.query(`CREATE SCHEMA IF NOT EXISTS chatcraft`);
+    });
+
+    // Sync only the tables referenced in the query
+    for (const table of chatcraftTables) {
+      if (!isChatCraftTableName(table)) {
+        throw new Error(
+          `Unknown table "chatcraft.${table}". Valid tables are: ` +
+            `${CHATCRAFT_TABLES.map((t) => `chatcraft.${t}`).join(", ")}`
+        );
+      }
+      await syncChatCraftTable(table);
+    }
+  }
+
+  // Execute the original query
+  return query<T>(sql, params);
+}
+
+// Replace the original query export with the enhanced, ChatCraft version
+export { chatCraftQuery as query };

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -1,5 +1,5 @@
 import { DataType } from "apache-arrow";
-import db, { CHATCRAFT_TABLES, ChatCraftTableName, isChatCraftTableName } from "./db";
+import db, { ChatCraftTableName, isChatCraftTableName } from "./db";
 import { withConnection, insertJSON, QueryResult, query } from "./duckdb";
 
 /**

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -48,10 +48,10 @@ export async function chatCraftQuery<T extends { [key: string]: DataType } = any
     // Check if error matches the catalog error pattern
     const catalogErrorPattern = /Catalog Error: Table with name (\w+) does not exist!/;
     const match = error?.message?.match(catalogErrorPattern);
-    
+
     if (match) {
       const tableName = match[1];
-      
+
       // If the missing table is a chatcraft table, sync and retry
       if (isChatCraftTableName(tableName)) {
         // Create schema if needed
@@ -60,12 +60,12 @@ export async function chatCraftQuery<T extends { [key: string]: DataType } = any
         });
 
         await syncChatCraftTable(tableName);
-        
+
         // Retry the query after syncing
         return await query<T>(sql, params);
       }
     }
-    
+
     // If not a catalog error or not a chatcraft table, rethrow
     throw error;
   }

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -1,5 +1,5 @@
 import { DataType } from "apache-arrow";
-import db, { ChatCraftTableName, isChatCraftTableName } from "./db";
+import db, { CHATCRAFT_TABLES, ChatCraftTableName, isChatCraftTableName } from "./db";
 import {
   withConnection,
   insertJSON,
@@ -99,5 +99,19 @@ export { chatCraftQuery as query };
 export async function queryToMarkdown(sql: string, params?: any[]): Promise<string> {
   const result = await chatCraftQuery(sql, params);
   const json = queryResultToJson(result);
+  return jsonToMarkdownTable(json);
+}
+
+/**
+ * Get a list of all available tables, including the "virtual"
+ * chatcraft.* tables we can sync into duckdb on demand.
+ */
+export async function getTables() {
+  const result = await query("show tables");
+  const json = queryResultToJson(result);
+  // TODO: this isn't really accurate, since `show tables` only shows what's in the current schema (main)
+  CHATCRAFT_TABLES.forEach((table) => {
+    json.push({ name: `chatcraft.${table}` });
+  });
   return jsonToMarkdownTable(json);
 }

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -44,10 +44,10 @@ export async function chatCraftQuery<T extends { [key: string]: DataType } = any
   try {
     // First attempt to execute the query
     return await query<T>(sql, params);
-  } catch (error) {
+  } catch (error: unknown) {
     // Check if error matches the catalog error pattern
     const catalogErrorPattern = /Catalog Error: Table with name (\w+) does not exist!/;
-    const match = error?.message?.match(catalogErrorPattern);
+    const match = error instanceof Error && error.message.match(catalogErrorPattern);
 
     if (match) {
       const tableName = match[1];

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -54,7 +54,7 @@ export function queryResultToJson(result: QueryResult) {
 }
 
 // Manage connection lifecycle, closing when done
-async function withConnection<T>(
+export async function withConnection<T>(
   callback: (conn: AsyncDuckDBConnection, duckdb: AsyncDuckDB) => Promise<T>
 ): Promise<T> {
   let conn: AsyncDuckDBConnection | null = null;

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -9,7 +9,6 @@ import {
 // NOTE: duckdb-wasm uses v17.0.0 currently vs. v18.x, see:
 // https://github.com/duckdb/duckdb-wasm/blob/b42a8e78d60b30363139a966e42bd33a3dd305a5/packages/duckdb-wasm/package.json#L26C9-L26C34
 import * as arrow from "apache-arrow";
-import { jsonToMarkdownTable } from "./utils";
 
 async function init(logToConsole = true) {
   // NOTE: the wasm bundles are too large for CloudFlare pages, so we load externally
@@ -72,6 +71,7 @@ export async function withConnection<T>(
  * @param sql The SQL query to execute
  * @param params Optional parameters for prepared statement
  * @returns Promise resolving to an Arrow Table containing the results
+ * @throws {DuckDBCatalogError} If the query references a non-existent table
  * @throws {Error} If the query fails
  * @example
  * // Simple query
@@ -88,15 +88,22 @@ export async function query<T extends { [key: string]: arrow.DataType } = any>(
   params?: any[]
 ): Promise<QueryResult<T>> {
   return withConnection(async (conn) => {
-    if (!params?.length) {
-      return await conn.query<T>(sql);
-    }
-
-    const stmt = await conn.prepare<T>(sql);
     try {
-      return await stmt.query(...params);
-    } finally {
-      await stmt.close();
+      if (!params?.length) {
+        return await conn.query<T>(sql);
+      }
+
+      const stmt = await conn.prepare<T>(sql);
+      try {
+        return await stmt.query(...params);
+      } finally {
+        await stmt.close();
+      }
+    } catch (err) {
+      if (DuckDBCatalogError.isCatalogError(err)) {
+        throw new DuckDBCatalogError(err);
+      }
+      throw err;
     }
   });
 }
@@ -281,23 +288,47 @@ export async function insertJSON(
  * Resets the DuckDB instance, terminating the connection
  * @throws {Error} If termination fails
  */
-/**
- * Executes a SQL query and returns the results as a Markdown table
- * @param sql The SQL query to execute
- * @param params Optional parameters for prepared statement
- * @returns Promise resolving to a Markdown formatted table string
- * @throws {Error} If the query fails
- */
-export async function queryToMarkdown(sql: string, params?: any[]): Promise<string> {
-  const result = await query(sql, params);
-  const json = queryResultToJson(result);
-  return jsonToMarkdownTable(json);
-}
-
 export async function reset(): Promise<void> {
   if (_duckdb) {
     await _duckdb.dropFiles();
     await _duckdb.terminate();
     _duckdb = null;
+  }
+}
+
+/**
+ * Custom error for identifying DuckDB Catalog Errors with missing Table
+ */
+export class DuckDBCatalogError extends Error {
+  static readonly ERROR_NAME = "DuckDBCatalogError" as const;
+
+  private static readonly catalogErrorPattern =
+    /Catalog Error: Table with name (\w+) does not exist!/;
+
+  readonly tableName: string;
+
+  constructor(error: unknown) {
+    if (!DuckDBCatalogError.isCatalogError(error)) {
+      throw new Error("Not a DuckDB catalog error");
+    }
+
+    const tableName = DuckDBCatalogError.extractTableName(error);
+    if (!tableName) {
+      throw new Error("Failed to extract table name from error message");
+    }
+
+    super(`Table '${tableName}' does not exist in DuckDB catalog`);
+
+    this.tableName = tableName;
+    this.name = DuckDBCatalogError.ERROR_NAME;
+  }
+
+  static isCatalogError(error: unknown): error is Error {
+    return error instanceof Error && DuckDBCatalogError.extractTableName(error) !== null;
+  }
+
+  static extractTableName(error: Error): string | null {
+    const match = error.message.match(DuckDBCatalogError.catalogErrorPattern);
+    return match?.[1] ?? null;
   }
 }

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -1,5 +1,5 @@
 import esbuildWasmUrl from "esbuild-wasm/esbuild.wasm?url";
-import { queryToMarkdown } from "./duckdb";
+import { queryToMarkdown } from "./duckdb-chatcraft";
 
 // By default, we haven't loaded the esbuild wasm module, and
 // the esbuild module doesn't have a concept of checking if it's


### PR DESCRIPTION
This builds a bridge between the ChatCraft db and DuckDB by creating a "Just In Time" `chatcraft.*` schema.  When a SQL query is run, we look for references to tables like `chatcraft.chats` and pre-import them into DuckDB from Dexie before running the query.

A new `query()` function is exposed on the `duckdb-chatcraft.ts` file, which works just like `query()` from `duckdb.ts`, but it adds this extra automatic-table creation for the `chatcraft` schema.

Originally, I wanted to do this as a UDF, but the async binding for duckdb doesn't allow it.  So I've done this instead.  See what you think.

I think for the most part, we'd always want to use the enhanced `query()` from `duckdb-chatcraft.ts`, but I've kept both exposed in case there's some reason to get the raw one from DuckDB.