### PR TITLE
Use React DataTable for Markdown table rendering

### DIFF
--- a/src/components/Markdown.tsx
+++ b/src/components/Markdown.tsx
@@ -7,6 +7,7 @@ import rehypeExternalLinks from "rehype-external-links";
 import rehypeKatex from "rehype-katex";
 import rehypeRaw from "rehype-raw";
 import rehypeSanitize from "rehype-sanitize";
+import MarkdownTable from "./MarkdownTable";
 import "katex/dist/katex.min.css";
 
 // Use highlight.js (via lowlight) vs. prism.js (via refractor) due to
@@ -162,6 +163,7 @@ function Markdown({
             </>
           );
         },
+        table: ({ children }) => <MarkdownTable children={children} />,
       }}
     />
   );

--- a/src/components/MarkdownTable.tsx
+++ b/src/components/MarkdownTable.tsx
@@ -1,0 +1,89 @@
+import { Children, isValidElement, ReactNode } from "react";
+import { Card } from "@chakra-ui/react";
+import DataTable, { TableColumn } from "react-data-table-component";
+
+type TableElement = React.ReactElement & {
+  props: {
+    children?: React.ReactNode;
+  };
+};
+
+interface TableData {
+  [key: string]: string;
+}
+
+const extractTextContent = (node: ReactNode): string => {
+  if (typeof node === "string") return node;
+  if (Array.isArray(node)) return node.map(extractTextContent).join("");
+  if (isValidElement(node)) {
+    return extractTextContent(node.props.children);
+  }
+  return "";
+};
+
+interface MarkdownTableProps {
+  children: ReactNode;
+}
+
+const MarkdownTable = ({ children }: MarkdownTableProps) => {
+  try {
+    const [thead, tbody] = Children.toArray(children) as TableElement[];
+    if (!thead?.props?.children || !tbody?.props?.children) {
+      throw new Error("Invalid table structure");
+    }
+
+    const headerRow = Children.toArray(thead.props.children)[0] as TableElement;
+    if (!headerRow?.props?.children) {
+      throw new Error("No header row found");
+    }
+
+    // Extract headers
+    const headerCells = Children.toArray(headerRow.props.children) as TableElement[];
+    const headers: TableColumn<TableData>[] = headerCells.map((cell) => {
+      const headerText = extractTextContent(cell.props.children);
+      return {
+        name: headerText,
+        selector: (row: TableData) => row[headerText] || "",
+        sortable: true,
+        wrap: true,
+      };
+    });
+
+    // Extract data rows
+    const bodyRows = Children.toArray(tbody.props.children) as TableElement[];
+    const data: TableData[] = bodyRows.map((row) => {
+      const rowData: TableData = {};
+      const cells = Children.toArray(row.props.children) as TableElement[];
+
+      headers.forEach((header, index) => {
+        const cell = cells[index];
+        const columnName = header.name as string;
+        rowData[columnName] = extractTextContent(cell?.props?.children || "");
+      });
+
+      return rowData;
+    });
+
+    return (
+      <Card my={4}>
+        <DataTable
+          columns={headers}
+          data={data}
+          dense
+          persistTableHead
+          pagination
+          paginationPerPage={10}
+          paginationRowsPerPageOptions={[10, 25, 50, 100]}
+          highlightOnHover
+          responsive
+          noDataComponent={<div className="p-4">No data available</div>}
+        />
+      </Card>
+    );
+  } catch (error) {
+    console.error("Error rendering table:", error);
+    return <div className="table-error">Error rendering table: {(error as Error).message}</div>;
+  }
+};
+
+export default MarkdownTable;


### PR DESCRIPTION
Quick experiment to see what it would be like to render Markdown tables as rich UI, with paging, sorting, responsive display, etc.  I'm using https://github.com/jbetancur/react-data-table-component which is highly customizable, see https://react-data-table-component.netlify.app/?path=/docs/getting-started-intro--docs

I've wanted to be able to do paging especially when querying massive amounts of data into the DOM.

This doesn't perform amazing for streaming, but works well for the db query case.

Not sure what I think.  Maybe this could be how we render long Markdown tables?  Or make this an option in prefs?

<img width="610" alt="Screenshot 2025-01-15 at 7 33 37 PM" src="https://github.com/user-attachments/assets/1a411cb3-5fa5-4cb9-82f6-59cd2a3133ba" />
