### PR TITLE
Initial support for files table in Dexie and DuckDB

### DIFF
--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -5,6 +5,7 @@ import { ChatCraftHumanMessage } from "../lib/ChatCraftMessage";
 import { compressImageToBase64, formatAsCodeBlock } from "../lib/utils";
 import { getSettings } from "../lib/settings";
 import { JinaAIProvider, type JinaAiReaderResponse } from "../lib/providers/JinaAIProvider";
+import { ChatCraftFile } from "../lib/ChatCraftFile";
 
 function readTextFile(file: File) {
   return new Promise<string>((resolve, reject) => {
@@ -180,22 +181,30 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
   const settings = getSettings();
 
   const importFile = useCallback(
-    (file: File, contents: string | JinaAiReaderResponse) => {
+    async (file: File, contents: string | JinaAiReaderResponse) => {
+      let chatCraftFile: ChatCraftFile;
+
       if (file.type.startsWith("image/")) {
         const base64 = contents as string;
+        chatCraftFile = await ChatCraftFile.findOrCreate(file, { text: base64 });
         onImageImport(base64);
       } else if (file.type === "application/pdf") {
         const document = (contents as JinaAiReaderResponse).data;
-        chat.addMessage(new ChatCraftHumanMessage({ text: `${document.content}\n` }));
+        chatCraftFile = await ChatCraftFile.findOrCreate(file, { text: document.content });
+        await chat.addMessage(new ChatCraftHumanMessage({ text: `${document.content}\n` }));
       } else if (
         file.type === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
       ) {
         const document = contents as string;
-        chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
+        chatCraftFile = await ChatCraftFile.findOrCreate(file, { text: document });
+        await chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
       } else {
         const document = contents as string;
-        chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
+        chatCraftFile = await ChatCraftFile.findOrCreate(file, { text: document });
+        await chat.addMessage(new ChatCraftHumanMessage({ text: `${document}\n` }));
       }
+
+      await chat.addFile(chatCraftFile);
     },
     [chat, onImageImport]
   );

--- a/src/lib/ChatCraftFile.ts
+++ b/src/lib/ChatCraftFile.ts
@@ -1,0 +1,317 @@
+import db, { ChatCraftFileTable } from "./db";
+import { download } from "./utils";
+
+export type ChatCraftFileOptions = {
+  /** Filename */
+  name: string;
+  /** File type (mime-type) */
+  type: string;
+  /** File's content (binary) */
+  content: Blob;
+  /** Extracted/parsed text content, if any */
+  text?: string;
+  /** When the file expires, if ever */
+  expires?: Date;
+  /** Extra file metadata */
+  metadata?: Record<string, unknown>;
+};
+
+export class ChatCraftFile {
+  readonly id: string;
+  readonly name: string;
+  readonly type: string;
+  readonly size: number;
+  readonly content: Blob;
+  text?: string;
+  readonly created: Date;
+  expires?: Date;
+  metadata?: Record<string, unknown>;
+
+  private constructor(id: string, options: ChatCraftFileOptions) {
+    this.id = id;
+
+    // Validate that we get a filename
+    if (!options.name?.trim()) {
+      throw new Error("File name is required");
+    }
+    this.name = options.name;
+
+    // Validate the type
+    if (!/^[^/]+\/[^/]+/.test(options.type)) {
+      throw new Error("File type must be a valid mime-type");
+    }
+    this.type = options.type;
+
+    this.content = options.content;
+    this.size = options.content.size;
+    this.text = options.text;
+    this.created = new Date();
+    this.expires = options.expires;
+    this.metadata = options.metadata;
+  }
+
+  get extension(): string {
+    return this.name.split(".").pop() || "";
+  }
+
+  /**
+   * Calculate the sha-256 hash for file's content
+   * @param blob content of file
+   * @returns hex string with file hash
+   */
+  private static async calculateHash(blob: Blob): Promise<string> {
+    const buffer = await blob.arrayBuffer();
+    // Calculate SHA-256 hash
+    const hashBuffer = await crypto.subtle.digest("SHA-256", buffer);
+    // Convert to hex string
+    const hashArray = Array.from(new Uint8Array(hashBuffer));
+    const hashHex = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+    return hashHex;
+  }
+
+  /**
+   * Find an existing ChatCraftFile in the database or add a new one.
+   * @param input File or ChatCraftOptions
+   * @returns ChatCraftFile instance
+   */
+  static async findOrCreate(
+    input: File | ChatCraftFileOptions,
+    additionalOptions: Partial<ChatCraftFileOptions>
+  ): Promise<ChatCraftFile> {
+    let options: ChatCraftFileOptions;
+
+    if (input instanceof File) {
+      options = {
+        name: input.name,
+        type: input.type || "application/octet-stream",
+        content: input,
+        metadata: {
+          lastModified: new Date(input.lastModified),
+        },
+      };
+
+      // Merge any additional options provided
+      if (additionalOptions) {
+        options = {
+          ...options,
+          ...additionalOptions,
+          // Merge the two metadata properties
+          metadata: {
+            ...options.metadata,
+            ...additionalOptions.metadata,
+          },
+        };
+      }
+    } else {
+      options = input;
+    }
+
+    const id = await ChatCraftFile.calculateHash(options.content);
+
+    // Return existing file, if present in db
+    const existing = await ChatCraftFile.findById(id);
+    if (existing) {
+      return existing;
+    }
+
+    // Otherwise, create and store a new file
+    const file = new ChatCraftFile(id, options);
+    await db.files.add(file.toDB());
+    return file;
+  }
+
+  /**
+   * Find an existing file by its id
+   * @param fileId the file's id (hash)
+   * @returns the ChatCraftFile, if found
+   */
+  static async findById(fileId: string): Promise<ChatCraftFile | undefined> {
+    const existing = await db.files.get(fileId);
+    if (existing) {
+      return ChatCraftFile.fromDB(existing);
+    }
+  }
+
+  /**
+   * Find an existing file by its content hash
+   * @param content Blob or File to look up
+   * @returns Existing ChatCraftFile or null if not found
+   */
+  static async findByContent(content: Blob | File): Promise<ChatCraftFile | undefined> {
+    const id = await ChatCraftFile.calculateHash(content);
+    return ChatCraftFile.findById(id);
+  }
+
+  /**
+   * Delete an existing file from the database
+   * @param fileOrId the ChatCraftFile or ChatCraftFile id to delete
+   */
+  static async delete(fileOrId: string | ChatCraftFile) {
+    const fileId = typeof fileOrId === "string" ? fileOrId : fileOrId.id;
+    return db.files.delete(fileId);
+  }
+
+  /**
+   * Get metadata value with type safety
+   */
+  getMetadata<T>(key: string): T | undefined {
+    return this.metadata?.[key] as T;
+  }
+
+  /**
+   * Set metadata value
+   */
+  setMetadata(key: string, value: unknown): void {
+    if (!this.metadata) {
+      this.metadata = {};
+    }
+    this.metadata[key] = value;
+  }
+
+  /**
+   * Download the file
+   */
+  download() {
+    download(this.content, this.name, this.type);
+  }
+
+  /**
+   * Check if file has expired
+   */
+  isExpired(): boolean {
+    if (!this.expires) {
+      return false;
+    }
+    return new Date() > this.expires;
+  }
+
+  /**
+   * Helper methods for common mime types
+   */
+  isImage(): boolean {
+    return this.type.startsWith("image/");
+  }
+
+  isText(): boolean {
+    return this.type.startsWith("text/");
+  }
+
+  isJSON(): boolean {
+    return this.type.startsWith("application/json");
+  }
+
+  isCSV(): boolean {
+    return this.type.startsWith("text/csv");
+  }
+
+  isMarkdown(): boolean {
+    return this.type.startsWith("application/markdown");
+  }
+
+  isPDF(): boolean {
+    return this.type.startsWith("application/pdf");
+  }
+
+  isWord(): boolean {
+    return this.type.startsWith(
+      "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    );
+  }
+
+  /**
+   * Convert a ChatCraftFile to a File object
+   */
+  toFile(): File {
+    return new File([this.content], this.name, {
+      type: this.type,
+      lastModified: this.created.getTime(),
+    });
+  }
+
+  /**
+   * Get a URL Object for the file content. Callers are responsible
+   * for revoking this URL when done using it.
+   */
+  toURL(): string {
+    return URL.createObjectURL(this.content);
+  }
+
+  toDB(): ChatCraftFileTable {
+    return {
+      id: this.id,
+      name: this.name,
+      type: this.type,
+      size: this.size,
+      content: this.content,
+      text: this.text,
+      created: this.created,
+      expires: this.expires,
+      metadata: this.metadata,
+    };
+  }
+
+  static fromDB(file: ChatCraftFileTable) {
+    return new ChatCraftFile(file.id, file);
+  }
+}
+
+export type ListFilesOptions = {
+  /** Maximum number of files to return */
+  limit?: number;
+  /** Skip expired files */
+  skipExpired?: boolean;
+};
+
+/**
+ * List files in the database matching a glob pattern
+ *
+ * Supports common glob patterns:
+ * - * matches any number of characters (except /)
+ * - ? matches exactly one character
+ * - {pattern,pattern} matches any pattern in braces
+ *
+ * Examples:
+ * - *.csv           -> matches: test.csv, data.csv
+ * - data/*.json     -> matches: data/config.json, data/1.json
+ * - logs/????-*.log -> matches: logs/2023-01.log, logs/2024-02.log
+ *
+ * @param pattern Glob pattern (defaults to '*' for all files)
+ * @param options Listing options for sorting and filtering
+ * @returns Array of matching ChatCraftFile instances
+ */
+export async function ls(
+  pattern: string = "*",
+  options: ListFilesOptions = {}
+): Promise<ChatCraftFile[]> {
+  const opts = {
+    limit: 10,
+    skipExpired: true,
+    // Override defaults
+    ...options,
+  };
+
+  // Convert glob pattern to regex:
+  // 1. Escape special regex characters except * and ?
+  // 2. Convert * to match any chars except /
+  // 3. Convert ? to match exactly one char
+  // 4. Wrap in ^ and $ to match entire string
+  const regexPattern = pattern
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/\?/g, ".");
+
+  const regex = new RegExp(`^${regexPattern}$`);
+
+  let query = db.files.filter((file) => regex.test(file.name));
+
+  // Apply options
+  if (opts.skipExpired) {
+    query = query.filter((file) => !file.expires || file.expires > new Date());
+  }
+  if (options.limit) {
+    query = query.limit(options.limit);
+  }
+
+  const matches = await query.toArray();
+  return matches.map((file) => ChatCraftFile.fromDB(file));
+}

--- a/src/lib/ChatCraftFile.ts
+++ b/src/lib/ChatCraftFile.ts
@@ -10,8 +10,6 @@ export type ChatCraftFileOptions = {
   content: Blob;
   /** Extracted/parsed text content, if any */
   text?: string;
-  /** When the file expires, if ever */
-  expires?: Date;
   /** Extra file metadata */
   metadata?: Record<string, unknown>;
 };
@@ -24,7 +22,6 @@ export class ChatCraftFile {
   readonly content: Blob;
   text?: string;
   readonly created: Date;
-  expires?: Date;
   metadata?: Record<string, unknown>;
 
   private constructor(id: string, options: ChatCraftFileOptions) {
@@ -46,7 +43,6 @@ export class ChatCraftFile {
     this.size = options.content.size;
     this.text = options.text;
     this.created = new Date();
-    this.expires = options.expires;
     this.metadata = options.metadata;
   }
 
@@ -176,16 +172,6 @@ export class ChatCraftFile {
   }
 
   /**
-   * Check if file has expired
-   */
-  isExpired(): boolean {
-    if (!this.expires) {
-      return false;
-    }
-    return new Date() > this.expires;
-  }
-
-  /**
    * Helper methods for common mime types
    */
   isImage(): boolean {
@@ -245,7 +231,6 @@ export class ChatCraftFile {
       content: this.content,
       text: this.text,
       created: this.created,
-      expires: this.expires,
       metadata: this.metadata,
     };
   }
@@ -305,11 +290,8 @@ export async function ls(
   let query = db.files.filter((file) => regex.test(file.name));
 
   // Apply options
-  if (opts.skipExpired) {
-    query = query.filter((file) => !file.expires || file.expires > new Date());
-  }
   if (options.limit) {
-    query = query.limit(options.limit);
+    query = query.limit(opts.limit);
   }
 
   const matches = await query.toArray();

--- a/src/lib/commands/DuckCommand.ts
+++ b/src/lib/commands/DuckCommand.ts
@@ -1,33 +1,49 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
 import { ChatCraftHumanMessage } from "../ChatCraftMessage";
-import { getTables, queryToMarkdown } from "../duckdb-chatcraft";
+import { getFiles, getTables, queryToMarkdown } from "../duckdb-chatcraft";
 
 export class DuckCommand extends ChatCraftCommand {
   constructor() {
     super("duck", "/duck", "Do some SQL queries");
   }
 
-  async execute(chat: ChatCraftChat, _user: User | undefined, args?: string[]) {
-    let sql: string;
-    let markdown: string;
-
-    if (!args?.length) {
-      sql = "SHOW TABLES;";
-      markdown = await getTables();
-    } else {
-      sql = args.join(" ");
-      markdown = await queryToMarkdown(sql);
-    }
-
-    const message = [
+  private formatSqlQueryAndResult(sql: string, markdown: string) {
+    return [
       // show query
       "```sql",
       sql,
       "```",
       // show results
       markdown,
-    ].join("\n");
+    ];
+  }
+
+  async execute(chat: ChatCraftChat, _user: User | undefined, args?: string[]) {
+    let sql: string;
+    let markdown: string;
+    const messageParts: string[] = [];
+
+    if (!args?.length) {
+      // Show all the tables, as well as the chatcraft.* virtual tables
+      sql = "SHOW TABLES;";
+      markdown = await getTables();
+      messageParts.push(...this.formatSqlQueryAndResult(sql, markdown));
+
+      // Include files if there are any, including files in the chat
+      const files = await chat.files();
+      if (files.length) {
+        sql = "SELECT * FROM glob('*');";
+        const markdown = await getFiles(chat);
+        messageParts.push(...this.formatSqlQueryAndResult(sql, markdown));
+      }
+    } else {
+      sql = args.join(" ");
+      markdown = await queryToMarkdown(sql, { chat });
+      messageParts.push(...this.formatSqlQueryAndResult(sql, markdown));
+    }
+
+    const message = messageParts.join("\n");
     return chat.addMessage(new ChatCraftHumanMessage({ text: message }));
   }
 }

--- a/src/lib/commands/DuckCommand.ts
+++ b/src/lib/commands/DuckCommand.ts
@@ -27,15 +27,14 @@ export class DuckCommand extends ChatCraftCommand {
     if (!args?.length) {
       // Show all the tables, as well as the chatcraft.* virtual tables
       sql = "SHOW TABLES;";
-      markdown = await getTables();
-      messageParts.push(...this.formatSqlQueryAndResult(sql, markdown));
+      const tablesMarkdown = await getTables();
+      messageParts.push(...this.formatSqlQueryAndResult(sql, tablesMarkdown));
 
-      // Include files if there are any, including files in the chat
-      const files = await chat.files();
-      if (files.length) {
+      // Include files if there are any
+      const filesMarkdown = await getFiles(chat);
+      if (filesMarkdown) {
         sql = "SELECT * FROM glob('*');";
-        const markdown = await getFiles(chat);
-        messageParts.push(...this.formatSqlQueryAndResult(sql, markdown));
+        messageParts.push(...this.formatSqlQueryAndResult(sql, filesMarkdown));
       }
     } else {
       sql = args.join(" ");

--- a/src/lib/commands/ListFilesCommand.ts
+++ b/src/lib/commands/ListFilesCommand.ts
@@ -1,0 +1,34 @@
+import { ChatCraftCommand } from "../ChatCraftCommand";
+import { ChatCraftChat } from "../ChatCraftChat";
+import { ChatCraftHumanMessage } from "../ChatCraftMessage";
+import { formatNumber } from "../utils";
+
+export class ListFilesCommand extends ChatCraftCommand {
+  constructor() {
+    super("ls", "/ls", "List files attached to chat");
+  }
+
+  async execute(chat: ChatCraftChat) {
+    let markdown = "";
+
+    const files = await chat.files();
+    if (!files.length) {
+      markdown += "No files.";
+    } else {
+      markdown += `Found ${files.length} file(s):\n\n`;
+
+      for (const file of files) {
+        const { id, name, type, size } = file;
+        markdown += [
+          `- \`${name}\``,
+          `  - ID: \`${id}\``,
+          `  - Type: \`${type}\``,
+          `  - Size: \`${formatNumber(size)}\``,
+          "",
+        ].join("\n");
+      }
+    }
+
+    return chat.addMessage(new ChatCraftHumanMessage({ text: markdown }));
+  }
+}

--- a/src/lib/commands/index.ts
+++ b/src/lib/commands/index.ts
@@ -10,6 +10,7 @@ import { CommandsHelpCommand } from "./CommandsHelpCommand";
 import { ImageCommand } from "./ImageCommand";
 import { StatsCommand } from "./StatsCommand";
 import { DuckCommand } from "./DuckCommand";
+import { ListFilesCommand } from "./ListFilesCommand";
 
 // Register all our commands
 ChatCraftCommandRegistry.registerCommand(new NewCommand());
@@ -21,3 +22,4 @@ ChatCraftCommandRegistry.registerCommand(new ImportCommand());
 ChatCraftCommandRegistry.registerCommand(new ImageCommand());
 ChatCraftCommandRegistry.registerCommand(new StatsCommand());
 ChatCraftCommandRegistry.registerCommand(new DuckCommand());
+ChatCraftCommandRegistry.registerCommand(new ListFilesCommand());

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -73,7 +73,6 @@ export type ChatCraftFileTable = {
   content: Blob; // binary content of file
   text?: string; // extracted text of file, base64 encoded version, etc
   created: Date; // when the file was created
-  expires?: Date; // if/when the file expires and can be deleted
   metadata?: Record<string, unknown>; // extra metadata
 };
 
@@ -197,7 +196,7 @@ class ChatCraftDatabase extends Dexie {
     this.version(11).stores({
       // Remove imageUrls from index for messages
       messages: "id, date, chatId, type, model, user, text, versions",
-      files: "id, name, type, size, text, created, expires",
+      files: "id, name, type, size, text, created",
     });
 
     this.chats = this.table("chats");

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -4,7 +4,14 @@ import { ChatCraftChat, SerializedChatCraftChat } from "./ChatCraftChat";
 import type { MessageType, FunctionCallParams, FunctionCallResult } from "./ChatCraftMessage";
 
 // List of all known table names
-export const CHATCRAFT_TABLES = ["chats", "messages", "shared", "functions", "starred"] as const;
+export const CHATCRAFT_TABLES = [
+  "chats",
+  "messages",
+  "shared",
+  "functions",
+  "starred",
+  "files",
+] as const;
 export type ChatCraftTableName = (typeof CHATCRAFT_TABLES)[number];
 
 /**
@@ -19,6 +26,7 @@ export type ChatCraftChatTable = {
   date: Date;
   summary?: string;
   messageIds: string[];
+  fileIds?: string[];
 };
 
 export type ChatCraftMessageTable = {
@@ -57,12 +65,25 @@ export type ChatCraftStarredSystemPromptTable = {
   usage: number;
 };
 
+export type ChatCraftFileTable = {
+  id: string; // unique hash of the file contents, for deduping
+  name: string; // original file name
+  type: string; // mime-type of the file (e.g., "text/csv")
+  size: number; // size of file in bytes
+  content: Blob; // binary content of file
+  text?: string; // extracted text of file, base64 encoded version, etc
+  created: Date; // when the file was created
+  expires?: Date; // if/when the file expires and can be deleted
+  metadata?: Record<string, unknown>; // extra metadata
+};
+
 class ChatCraftDatabase extends Dexie {
   chats: Table<ChatCraftChatTable, string>;
   messages: Table<ChatCraftMessageTable, string>;
   shared: Table<SharedChatCraftChatTable, string>;
   functions: Table<ChatCraftFunctionTable, string>;
   starred: Table<ChatCraftStarredSystemPromptTable, string>;
+  files: Table<ChatCraftFileTable, string>;
 
   constructor() {
     super("ChatCraftDatabase");
@@ -171,12 +192,20 @@ class ChatCraftDatabase extends Dexie {
             delete message.starred;
           });
       });
+    // Version 11 Migration - add files table. NOTE: we are not migrating imageUrls over to
+    // files in this migration, though we may do that in the future.
+    this.version(11).stores({
+      // Remove imageUrls from index for messages
+      messages: "id, date, chatId, type, model, user, text, versions",
+      files: "id, name, type, size, text, created, expires",
+    });
 
     this.chats = this.table("chats");
     this.messages = this.table("messages");
     this.shared = this.table("shared");
     this.functions = this.table("functions");
     this.starred = this.table("starred");
+    this.files = this.table("files");
   }
 
   /**
@@ -194,6 +223,8 @@ class ChatCraftDatabase extends Dexie {
         return this.functions;
       case "starred":
         return this.starred;
+      case "files":
+        return this.files;
       default:
         throw new Error(`Unknown table name: ${tableName}`);
     }

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -55,7 +55,7 @@ async function syncChatCraftTable(tableName: ChatCraftTableName): Promise<void> 
   const data = await db.byTableName(tableName).toArray();
 
   const jsonData = data.map((record) => {
-    const dateFields = ["date", "created", "expires"];
+    const dateFields = ["date", "created"];
     return convertDatesToISOString({ ...record }, dateFields);
   });
 

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -7,8 +7,12 @@ import {
   query,
   DuckDBCatalogError,
   queryResultToJson,
+  insertCSV,
+  DuckDBFileError,
 } from "./duckdb";
 import { jsonToMarkdownTable } from "./utils";
+import { ChatCraftFile } from "./ChatCraftFile";
+import { ChatCraftChat } from "./ChatCraftChat";
 
 /**
  * Extracts chatcraft schema table references from a SQL query
@@ -17,11 +21,30 @@ import { jsonToMarkdownTable } from "./utils";
  * @returns Array of table names referenced in the chatcraft schema
  */
 function extractChatCraftTables(sql: string): string[] {
-  // Match "chatcraft.table_name" or "chatcraft.table_name;"
+  const tables = new Set<string>();
+
+  // Look for table names and match "chatcraft.table_name" or "chatcraft.table_name;"
   const regex = /chatcraft\.(\w+)(?:\s|;|$)/g;
   const matches = [...sql.matchAll(regex)];
-  return [...new Set(matches.map((match) => match[1]))];
+  matches.forEach((match) => {
+    tables.add(match[1]);
+  });
+
+  return [...tables];
 }
+
+// Convert dates to ISO strings for JSON serialization
+const convertDatesToISOString = (record: any, dateFields: string[]) => {
+  return dateFields.reduce((acc, field) => {
+    if (field in record && record[field] instanceof Date) {
+      return {
+        ...acc,
+        [field]: record[field].toISOString(),
+      };
+    }
+    return acc;
+  }, record);
+};
 
 /**
  * Synchronizes a single ChatCraft table to DuckDB
@@ -31,11 +54,10 @@ function extractChatCraftTables(sql: string): string[] {
 async function syncChatCraftTable(tableName: ChatCraftTableName): Promise<void> {
   const data = await db.byTableName(tableName).toArray();
 
-  // Convert dates to ISO strings for JSON serialization
-  const jsonData = data.map((record) => ({
-    ...record,
-    date: record.date instanceof Date ? record.date.toISOString() : record.date,
-  }));
+  const jsonData = data.map((record) => {
+    const dateFields = ["date", "created", "expires"];
+    return convertDatesToISOString({ ...record }, dateFields);
+  });
 
   await insertJSON(tableName, JSON.stringify(jsonData), { schema: "chatcraft" });
 }
@@ -44,18 +66,19 @@ async function syncChatCraftTable(tableName: ChatCraftTableName): Promise<void> 
  * Enhanced query function that handles ChatCraft db data synchronization silently
  * @param sql The SQL query to execute
  * @param params Optional parameters for prepared statement
+ * @param chat Optional ChatCraftChat context where this sql is being run
  * @returns Query results as an Arrow Table
  */
 async function chatCraftQuery<T extends { [key: string]: DataType } = any>(
   sql: string,
-  params?: any[]
+  { params, chat }: { params?: any[]; chat?: ChatCraftChat } = {}
 ): Promise<QueryResult<T>> {
   try {
     // First, attempt to execute the query assuming everything is already created
     return await query<T>(sql, params);
   } catch (error: unknown) {
     // If the query fails, see if the error is due to a missing table that we can provide
-    // by injecting ChatCraft data from Dexie. NOTE: if a user happens to create a tabled
+    // by injecting ChatCraft data from Dexie. NOTE: if a user happens to create a table
     // that shares the same name as our injected tables (e.g., chatcraft.messages), we'll
     // let them use theirs instead of generating a new one. This also reduces the risk of
     // overhead from premature table creation.
@@ -81,6 +104,26 @@ async function chatCraftQuery<T extends { [key: string]: DataType } = any>(
       }
     }
 
+    if (error instanceof DuckDBFileError) {
+      if (!chat) {
+        throw error;
+      }
+
+      const files = chat.files();
+      if (!files.length) {
+        throw error;
+      }
+
+      const filename = error.filePath;
+      const file = files.find((f) => f.id === filename || f.name === filename);
+      if (file) {
+        await copyFileToDuckDB(file, filename);
+      }
+
+      // Retry the query after syncing
+      return await query<T>(sql, params);
+    }
+
     // If not a catalog error or no referenced tables, rethrow
     throw error;
   }
@@ -93,18 +136,23 @@ export { chatCraftQuery as query };
  * Executes a SQL query and returns the results as a Markdown table
  * @param sql The SQL query to execute
  * @param params Optional parameters for prepared statement
+ * @param chat Optional ChatCraftChat, the context where this query is being run
  * @returns Promise resolving to a Markdown formatted table string
  * @throws {Error} If the query fails
  */
-export async function queryToMarkdown(sql: string, params?: any[]): Promise<string> {
-  const result = await chatCraftQuery(sql, params);
+export async function queryToMarkdown(
+  sql: string,
+  { params, chat }: { params?: any[]; chat?: ChatCraftChat } = {}
+): Promise<string> {
+  const result = await chatCraftQuery(sql, { params, chat });
   const json = queryResultToJson(result);
   return jsonToMarkdownTable(json);
 }
 
 /**
  * Get a list of all available tables, including the "virtual"
- * chatcraft.* tables we can sync into duckdb on demand.
+ * chatcraft.* tables we can sync into duckdb on demand. If a
+ * chat is included, get the list of files as well.
  */
 export async function getTables() {
   const result = await query("show tables");
@@ -114,4 +162,62 @@ export async function getTables() {
     json.push({ name: `chatcraft.${table}` });
   });
   return jsonToMarkdownTable(json);
+}
+
+/**
+ * Get a list of all files available in DuckDB's virtual
+ * filesystem, as well as any files that we could inject
+ * from the chat's files.
+ * @param chat the ChatCraftChat, potentially with files
+ */
+export async function getFiles(chat: ChatCraftChat) {
+  const result = await query("SELECT * FROM glob('*');");
+  const json = queryResultToJson(result);
+  // Add all the files that we *could* add from the chat
+  const files = await chat.files();
+  files.forEach((file) => {
+    // Make sure we don't add a virtual file if the actual file already exists
+    const exists = json.some((entry) => entry.file === file.name);
+    if (!exists) {
+      json.push({ file: file.name });
+    }
+  });
+
+  return jsonToMarkdownTable(json);
+}
+
+/**
+ * Copies a ChatCraftFile into the DuckDB virtual filesystem
+ * @param file the ChatCraftFile to copy
+ * @param virtualPath an optional filename to use instead of the file's name
+ */
+export async function copyFileToDuckDB(file: ChatCraftFile, virtualPath?: string) {
+  // Use provided virtual path or original filename
+  const path = virtualPath || file.name;
+
+  // Convert Blob to Uint8Array
+  const buffer = new Uint8Array(await file.content.arrayBuffer());
+
+  await withConnection(async (_, duckdb) => {
+    // Register the file in DuckDB's virtual filesystem
+    await duckdb.registerFileBuffer(path, buffer);
+  });
+}
+
+/**
+ * Attempts to create a new Table in DuckDB for the ChatCraftFile's contents
+ * Currently only CSV and JSON files are supported.
+ * @param file the file to use for the table's content
+ * @param tableName the name of the table to create
+ */
+export async function fileToDuckDBTable(file: ChatCraftFile, tableName: string) {
+  if (file.isCSV()) {
+    return await insertCSV(tableName, file.content);
+  }
+
+  if (file.isJSON()) {
+    return await insertJSON(tableName, file.content);
+  }
+
+  throw new Error(`Unable to create DuckDB Table from file type ${file.type}`);
 }

--- a/src/lib/duckdb-chatcraft.ts
+++ b/src/lib/duckdb-chatcraft.ts
@@ -167,7 +167,8 @@ export async function getTables() {
 /**
  * Get a list of all files available in DuckDB's virtual
  * filesystem, as well as any files that we could inject
- * from the chat's files.
+ * from the chat's files. If there are no files, we return
+ * the empty string
  * @param chat the ChatCraftChat, potentially with files
  */
 export async function getFiles(chat: ChatCraftChat) {
@@ -183,7 +184,7 @@ export async function getFiles(chat: ChatCraftChat) {
     }
   });
 
-  return jsonToMarkdownTable(json);
+  return json.length ? jsonToMarkdownTable(json) : "";
 }
 
 /**

--- a/src/lib/run-code.ts
+++ b/src/lib/run-code.ts
@@ -201,6 +201,7 @@ export async function toJavaScript(tsCode: string) {
 
 async function runSQL(sql: string): Promise<ExecutionResult> {
   try {
+    // TODO: need to plumb the chat through to here, so we can inject files when we query...
     const result = await queryToMarkdown(sql);
     return { ret: result, logs: undefined };
   } catch (error) {


### PR DESCRIPTION
This begins the journey to implement #788.  I've done the minimum to get a workable thing.  There is lots more to do, but it's already amazing!

- Added a new `files` table, which tracks files by their hashed content id and includes metadata
- Added a `ChatCraftFile` class to make it easier to work with files and convert to/from various things
- Added `fileIds` Array to the `chats` table to track files associated with a chat
- Connected `ChatCraftFile` and `files` to the `use-file-import.ts` hook so attaching, pasting, dragging files into a chat all add them to the `files` table and associate with the current chat's files.
- Extended `duckdb-chatcraft.ts` to know about `ChatCraftFile`, bridging the filesystem from Dexie -> DuckDB (we still need to go the other way).
- Similar to what we do with `chatcraft.*` tables, auto-injects files into DuckDB when they are referenced in a SQL query (by name or id). Ive you go to `Options > Attach Files...` and add a CSV file, doing something like `select * from 'some-file-name.csv'` just works.
- Enhanced `/duck` command to be able to show all tables and all files, including virtual files in the chat we could inject.
- Added `/ls` slash command to list files in a chat
- Always store files in Dexie files table when imported.  Currently I'm not changing how the `imageUrls` work at all.

For follow-ups--I don't want to bother with this stuff now, but so I don't forget:

- I haven't got the `runCode` working with file injection yet, since it requires the `chat` to be passed all the way through to the inner component.  We should probably make a React Context and Hook for this, so you can do `const chat = useChat()`
- File expiry.  Currently I only have an optional field.
- Start moving `imageUrls` out of `messages` and into `files`
- Figure out when to embed a file's content in the chat (e.g., based on type, size, etc).
- We need some preference UI for signalling how to handle things with files (e.g., expiry, sizes when to inject)
- Think about how to handle sharing.  Currently I don't try to serialize files into shared chats.
- Add support for using partial versions of file hashes (like short SHAs in GitHub) so you don't have paste the whole thing into a SQL statement
- Think about file deduping (e.g., we store by hash id) and how that affects file names.  I could add the same file more than once, and the original filename might differ from the new one.  Do we care?