### PR TITLE
Sidebar's accordion state saved after reloading the page

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -302,15 +302,7 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
 
   const handleAccordionChange = (expandedIndex: number | number[] | undefined) => {
     // Check if expandedIndex isn't undefined and set index to this value, otherwise set index to 0
-    try {
-      if (expandedIndex !== undefined) {
-        setOpenIndex(expandedIndex);
-      } else {
-        setOpenIndex(0);
-      }
-    } catch (err) {
-      console.warn("Unable to save accordion state", err);
-    }
+    setOpenIndex(expandedIndex ?? 0);
   };
 
   const chatsTotal = useLiveQueryTraced<number, number>(

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -301,14 +301,11 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
   );
 
   const handleAccordionChange = (expandedIndex: number | number[] | undefined) => {
-    // Use 0 if index undefined (all accordions closed, but first by default opened)
-    setOpenIndex(expandedIndex ?? 0);
-
+    // Check if expandedIndex isn't undefined and set index to this value, otherwise set index to 0
     try {
       if (expandedIndex !== undefined) {
         setOpenIndex(expandedIndex);
       } else {
-        // Set accordion state to default '0', so Saved Chats opens
         setOpenIndex(0);
       }
     } catch (err) {

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -294,6 +294,38 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
   const navigate = useNavigate();
   const [recentCount, setRecentCount] = useState(10);
 
+  const ACCORDION_STATE_KEY = "sidebar-accordion-index";
+
+  const getSavedAccordionIndex = () => {
+    try {
+      const saved = localStorage.getItem(ACCORDION_STATE_KEY);
+      return saved ? parseInt(saved) : 0;
+    } catch (err) {
+      console.warn("Unable to get accordion state: ", err);
+      return 0;
+    }
+  };
+
+  const [openIndex, setOpenIndex] = useState<number | number[] | undefined>(
+    getSavedAccordionIndex()
+  );
+
+  const handleAccordionChange = (expandedIndex: number | number[] | undefined) => {
+    // Use 0 if index undefined (all accordions closed, but first by default opened)
+    setOpenIndex(expandedIndex ?? 0);
+
+    try {
+      if (expandedIndex !== undefined) {
+        localStorage.setItem(ACCORDION_STATE_KEY, JSON.stringify(expandedIndex));
+      } else {
+        // Set accordion state to default '0', so Saved Chats opens
+        localStorage.setItem(ACCORDION_STATE_KEY, "0");
+      }
+    } catch (err) {
+      console.warn("Unable to save accordion state", err);
+    }
+  };
+
   const chatsTotal = useLiveQueryTraced<number, number>(
     "count-chats",
     () => db.chats.count(),
@@ -385,7 +417,7 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
 
   return (
     <Flex direction="column" h="100%" p={2} gap={4}>
-      <Accordion allowToggle defaultIndex={0}>
+      <Accordion allowToggle index={openIndex} onChange={handleAccordionChange}>
         <AccordionItem>
           <AccordionButton p={2} minH={10}>
             <Heading as="h3" size="xs">

--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -34,6 +34,7 @@ import { useUser } from "../../hooks/use-user";
 import { ChatCraftFunction } from "../../lib/ChatCraftFunction";
 import { useAlert } from "../../hooks/use-alert";
 import { convertToShareUrl } from "../../lib/share";
+import { useLocalStorage } from "react-use";
 
 /**
  * Chat Sidebar Items
@@ -294,20 +295,9 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
   const navigate = useNavigate();
   const [recentCount, setRecentCount] = useState(10);
 
-  const ACCORDION_STATE_KEY = "sidebar-accordion-index";
-
-  const getSavedAccordionIndex = () => {
-    try {
-      const saved = localStorage.getItem(ACCORDION_STATE_KEY);
-      return saved ? parseInt(saved) : 0;
-    } catch (err) {
-      console.warn("Unable to get accordion state: ", err);
-      return 0;
-    }
-  };
-
-  const [openIndex, setOpenIndex] = useState<number | number[] | undefined>(
-    getSavedAccordionIndex()
+  const [openIndex, setOpenIndex] = useLocalStorage<number | number[] | undefined>(
+    "sidebar-accordion-index",
+    0
   );
 
   const handleAccordionChange = (expandedIndex: number | number[] | undefined) => {
@@ -316,10 +306,10 @@ function SidebarContent({ selectedChat, selectedFunction }: SidebarContentProps)
 
     try {
       if (expandedIndex !== undefined) {
-        localStorage.setItem(ACCORDION_STATE_KEY, JSON.stringify(expandedIndex));
+        setOpenIndex(expandedIndex);
       } else {
         // Set accordion state to default '0', so Saved Chats opens
-        localStorage.setItem(ACCORDION_STATE_KEY, "0");
+        setOpenIndex(0);
       }
     } catch (err) {
       console.warn("Unable to save accordion state", err);


### PR DESCRIPTION
Closes #782

## Description 

Accordion saves item's index in the `localStorage`, so every time user deletes chat or refreshes the page he doesn't need to re-open appropriate tab. However, default value of index is still `0` which is `Saved Chats` Accordion Item. Therefore, if user opens sidebar first time for the session, the accordion will open `Saved Chats` item.

## Preview
![ScreenRecording2025-01-21at4 58 18PM-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/f3ba48a8-9712-433e-b572-6522a153e149)
