### PR TITLE
Hover over effect on sidebar items

### DIFF
--- a/src/components/Sidebar/SidebarContent.tsx
+++ b/src/components/Sidebar/SidebarContent.tsx
@@ -58,6 +58,7 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
   );
   const { error } = useAlert();
   const [isEditing, setIsEditing] = useState(false);
+  const [isHovering, setIsHovering] = useState(false);
   useKey("Escape", () => setIsEditing(false), { event: "keydown" }, [setIsEditing]);
   const selectedRef = useRef<HTMLDivElement>(null);
 
@@ -121,6 +122,15 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
       borderRadius={4}
       direction="column"
       ref={selectedRef}
+      style={{ transition: "background-color 0.2s ease, transform 0.2s ease" }}
+      _hover={{
+        bg: useColorModeValue(
+          !isSelected ? "gray.100" : undefined,
+          !isSelected ? "gray.700" : undefined
+        ),
+      }}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
     >
       <Flex justify="space-between" align="center" minH="32px" w="100%">
         <Link to={url} style={{ width: "100%" }}>
@@ -133,7 +143,7 @@ function ChatSidebarItem({ chat, url, isSelected, canEdit, onDelete }: ChatSideb
             </Text>
           </Flex>
         </Link>
-        {isSelected && !isEditing && (
+        {(isSelected || isHovering) && !isEditing && (
           <Flex>
             {canEdit && (
               <IconButton
@@ -228,6 +238,7 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
     isSelected ? "gray.900" : "gray.600"
   );
   const selectedRef = useRef<HTMLDivElement>(null);
+  const [isHovering, setIsHovering] = useState(false);
 
   // Scroll this item into view if selected
   useEffect(() => {
@@ -245,6 +256,14 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
       borderRadius={4}
       direction="column"
       ref={selectedRef}
+      _hover={{
+        bg: useColorModeValue(
+          !isSelected ? "gray.100" : undefined,
+          !isSelected ? "gray.700" : undefined
+        ),
+      }}
+      onMouseEnter={() => setIsHovering(true)}
+      onMouseLeave={() => setIsHovering(false)}
     >
       <Flex justify="space-between" align="center" minH="32px" w="100%">
         <Link to={url} style={{ width: "100%" }}>
@@ -257,7 +276,7 @@ function FunctionSidebarItem({ func, url, isSelected, onDelete }: FunctionSideba
             </Text>
           </Flex>
         </Link>
-        {isSelected && (
+        {(isSelected || isHovering) && (
           <IconButton
             variant="ghost"
             size="sm"


### PR DESCRIPTION
Issue: #786 

Added a hover over effect on the sidebar items to improve UX. Making it easy to identify which item is about to be selected.
Also show the edit and delete icons when hovering over to reduce the number of actions needed to either delete or edit the items. 

Demo:
![Recording 2025-01-20 at 14 32 23](https://github.com/user-attachments/assets/979d75c5-e195-4dc8-9f66-1b61715566cd)