### PR TITLE
Migration for files to extract fileRefs (id, name)

### DIFF
--- a/src/lib/ChatCraftFile.ts
+++ b/src/lib/ChatCraftFile.ts
@@ -50,6 +50,14 @@ export class ChatCraftFile {
     return this.name.split(".").pop() || "";
   }
 
+  // When we store files in a chat, we can use a different name (e.g., the same
+  // file contents stored in multiple chats, but in between each chat we've renamed
+  // the file). This is the original filename that was used when the file's contents
+  // were first stored.
+  get originalName(): string {
+    return this.name;
+  }
+
   /**
    * Calculate the sha-256 hash for file's content
    * @param blob content of file

--- a/src/lib/commands/ListFilesCommand.ts
+++ b/src/lib/commands/ListFilesCommand.ts
@@ -11,7 +11,7 @@ export class ListFilesCommand extends ChatCraftCommand {
   async execute(chat: ChatCraftChat) {
     let markdown = "";
 
-    const files = await chat.files();
+    const files = chat.files();
     if (!files.length) {
       markdown += "No files.";
     } else {

--- a/src/lib/duckdb.ts
+++ b/src/lib/duckdb.ts
@@ -240,6 +240,25 @@ export async function insertCSV(
 }
 
 /**
+ * Insert arbitrary data as a DuckDB File
+ * @param name the name of the file
+ * @param data the file data
+ * @throws {Error} If the insertion fails
+ */
+export async function insertFile(name: string, source: string | File | Blob): Promise<void> {
+  return withConnection(async (_conn, duckdb) => {
+    let buf: Uint8Array;
+    if (typeof source === "string") {
+      buf = new TextEncoder().encode(source);
+    } else {
+      buf = new Uint8Array(await source.arrayBuffer());
+    }
+
+    await duckdb.registerFileBuffer(name, buf);
+  });
+}
+
+/**
  * Options for JSON file imports, see docs:
  * https://duckdb.org/docs/data/json/loading_json#parameters
  */

--- a/src/lib/fs.ts
+++ b/src/lib/fs.ts
@@ -168,7 +168,7 @@ export async function ls(chat: ChatCraftChat): Promise<VirtualFile[]> {
   }
 
   // Add ChatCraftFiles from Dexie, overwriting any dupes
-  const chatCraftFiles = await chat.files();
+  const chatCraftFiles = chat.files();
   chatCraftFiles.forEach((file) => {
     fileMap.set(file.name, new ChatCraftFileAdapter(file));
   });


### PR DESCRIPTION
This PR migrates the `files` table such that you can have the same file referenced in multiple chats, but with different filenames:

## Mermaid Diagram of DB

```mermaid
erDiagram
    chats ||--o{ messages : contains
    chats ||--o{ files : references

    chats {
        string id PK
        date date
        string summary
        string[] messageIds
        FileRef[] fileRefs
    }

    messages {
        string id PK
        date date
        string chatId FK
        string type
        string model
        object user
        string text
        object func
        object[] versions
    }

    shared {
        string id PK
        string url
        string summary
        date date
        object chat
    }

    functions {
        string id PK
        date date
        string name
        string description
        object parameters
        string code
    }

    starred {
        string text PK
        date date
        number usage
    }

    files {
        string id PK
        string name
        string type
        number size
        blob content
        string text
        date created
        object metadata
    }
```

## Major Changes
1. **New File Naming System**
   - Introduced `FileRef` type to allow files to have different names in different chat contexts. A `FileRef` is `{ id, name }`
   - Files can now be renamed within a chat while maintaining the original file content
   - Added `originalName` property to `ChatCraftFile` to track the initial filename

2. **Improved File Storage**
   - Replaced array-based file storage with Map-based system
   - Files are now stored with both content (`ChatCraftFile`) and reference (`FileRef`) information

3. **Database Updates**
   - Added migration (v12) to convert old `fileIds` to new `fileRefs` system
   - Updated chat table schema to use `fileRefs` instead of `fileIds`

4. **New File Operations on ChatCraftChat**
   - Added `renameFile` method to change file names within a chat context
   - Enhanced `addFile` to support custom file names
   - Updated `removeFile` to handle both file and ID inputs

5. **Improved Data Consistency**
   - Enhanced file cleanup during chat deletion to prevent orphaned files
   - Added transaction-based operations for safer database updates

## API Changes
- `addFile` now accepts an optional name parameter
- `removeFile` now accepts either a `ChatCraftFile` or string ID
- Added `renameFile` method
- File names can now differ between chats while maintaining content identity

I'd appreciate some help testing this (i.e., export your db, import it to this preview branch and report back).  Should all be fine, but migrations are always scary.