### PR TITLE
[BUG] Mic's Flickering Problem Fixed

### DIFF
--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -33,10 +33,6 @@ export default function MicIcon({
 
   const { getSpeechToTextClient, isSpeechToTextSupported, allProvidersWithModels } = useModels();
 
-  if (!isSpeechToTextSupported) {
-    return <></>;
-  }
-
   const onRecordingStart = async () => {
     clearAudioQueue();
 
@@ -137,7 +133,7 @@ export default function MicIcon({
     <Tooltip label={isRecording ? "Finish Recording" : "Start Recording"} placement="top">
       <IconButton
         isRound
-        isDisabled={isDisabled}
+        isDisabled={!isSpeechToTextSupported || isDisabled}
         icon={<TbMicrophone />}
         variant={isRecording ? "solid" : isMobile ? "outline" : "ghost"}
         colorScheme={isRecording ? "red" : "blue"}

--- a/src/components/PromptForm/MicIcon.tsx
+++ b/src/components/PromptForm/MicIcon.tsx
@@ -1,6 +1,6 @@
 import { useModels } from "../../hooks/use-models";
 import { IconButton, Tooltip } from "@chakra-ui/react";
-import { useRef, useState } from "react";
+import { useRef, useState, useMemo } from "react";
 import { TbMicrophone } from "react-icons/tb";
 
 import { useAlert } from "../../hooks/use-alert";
@@ -129,8 +129,18 @@ export default function MicIcon({
     }
   };
 
+  const tooltipLabel = useMemo(
+    () =>
+      !isSpeechToTextSupported
+        ? "No configured provider supports speech to text conversion!"
+        : isRecording
+          ? "Finish Recording"
+          : "Start Recording",
+    [isRecording, isSpeechToTextSupported]
+  );
+
   return (
-    <Tooltip label={isRecording ? "Finish Recording" : "Start Recording"} placement="top">
+    <Tooltip label={tooltipLabel} placement="top">
       <IconButton
         isRound
         isDisabled={!isSpeechToTextSupported || isDisabled}


### PR DESCRIPTION
Closes #811 

## Description

Currently, once page opened or reloaded, it is checking for speech support before initialization and returns empty if unsupported, it causes the flickering since the component remounts the mic icon once supported. 

The new solution uses `isSpeechToTextSupported` in `isDisabled` prop instead, that is eliminating the flickering. 