### PR TITLE
Support of `.jsonl` files implemented

### DIFF
--- a/src/components/FileIcon.tsx
+++ b/src/components/FileIcon.tsx
@@ -47,6 +47,7 @@ const FILE_ICON_MAP: Record<string, IconType> = {
   xlsx: BsFiletypeXls,
   // Code
   json: BsFiletypeJson,
+  jsonl: BsFiletypeJson,
   md: BsFiletypeMd,
 };
 

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -81,6 +81,7 @@ const FILE_EXTENSIONS: Record<string, string> = {
   yaml: "yaml",
   yml: "yaml",
   json: "json",
+  jsonl: "json",
   xml: "xml",
   r: "r",
   csv: "csv",
@@ -109,6 +110,8 @@ const MIME_TYPES: Record<string, string> = {
   "application/json": "json",
   "text/xml": "xml",
   "application/xml": "xml",
+  "application/x-jsonlines": "json",
+  "text/x-jsonlines": "json",
 };
 
 function detectLanguage(filename: string, mimeType: string): string | undefined {
@@ -150,6 +153,12 @@ async function processFile(
     const contents = await JinaAIProvider.pdfToMarkdown(file);
     assertContents(contents);
     return contents;
+  }
+
+  if (file.name.endsWith(".jsonl")) {
+    const text = await readTextFile(file);
+    assertContents(text);
+    return formatTextContent(file.name, "application/x-jsonlines", text);
   }
 
   if (file.type === "application/markdown" || file.type === "text/markdown") {


### PR DESCRIPTION
Closes #810 

## Description 

In #804 @tarasglek found out that we don't have a support of `.jsonl` files attachments, and we obviously needed to do something with it! I decided to step up and provide a support of `.jsonl` files, and I have no clue what else to write here because it is a tiny change, but description required :D 

## Result 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8c97e3fc-057b-41a6-9062-226692d501a6" />
