### PR TITLE
Add useChat() hook and ChatProvider context

### DIFF
--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -111,7 +111,7 @@ function CodeHeader({
     } finally {
       setIsRunning(false);
     }
-  }, [onPrompt, code, language]);
+  }, [onPrompt, code, language, chat]);
 
   const toUrl = (code: string) =>
     URL.createObjectURL(new Blob([code], { type: "text/plain;charset=utf-8" }));

--- a/src/components/CodeHeader.tsx
+++ b/src/components/CodeHeader.tsx
@@ -15,6 +15,7 @@ import { TbCopy, TbDownload, TbExternalLink, TbRun } from "react-icons/tb";
 import { download, formatAsCodeBlock } from "../lib/utils";
 import { useAlert } from "../hooks/use-alert";
 import { isRunnableInBrowser, runCode } from "../lib/run-code";
+import { useChat } from "../hooks/use-chat";
 
 type PreHeaderProps = {
   language: string;
@@ -38,6 +39,7 @@ function CodeHeader({
   const [isRunning, setIsRunning] = useState(false);
   // Only show the "Run" button for JS code blocks, and only when we aren't already loading
   const shouldShowRunButton = isRunnableInBrowser(language) && onPrompt;
+  const { chat } = useChat();
 
   const handleCopy = useCallback(() => {
     onCopy();
@@ -62,7 +64,7 @@ function CodeHeader({
     setIsRunning(true);
 
     try {
-      let { logs, ret } = await runCode(code, language);
+      let { logs, ret } = await runCode(code, language, chat);
 
       if (typeof ret === "string") {
         // catch corner cases with strings

--- a/src/hooks/use-chat.tsx
+++ b/src/hooks/use-chat.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useState, useEffect } from "react";
+import { useParams } from "react-router-dom";
+import { ChatCraftChat } from "../lib/ChatCraftChat";
+
+interface ChatContextType {
+  chat: ChatCraftChat | undefined;
+  setChat: (chat: ChatCraftChat | undefined) => void;
+}
+
+const ChatContext = createContext<ChatContextType | undefined>(undefined);
+
+export function ChatProvider({ children }: { children: React.ReactNode }) {
+  const [chat, setChat] = useState<ChatCraftChat | undefined>(undefined);
+  const { id } = useParams();
+
+  useEffect(() => {
+    async function loadChat() {
+      if (!id) {
+        setChat(undefined);
+        return;
+      }
+
+      try {
+        const loadedChat = await ChatCraftChat.find(id);
+        setChat(loadedChat);
+      } catch (err) {
+        console.error("Error loading chat:", err);
+        setChat(undefined);
+      }
+    }
+
+    loadChat();
+  }, [id]);
+
+  return <ChatContext.Provider value={{ chat, setChat }}>{children}</ChatContext.Provider>;
+}
+
+export function useChat() {
+  const context = useContext(ChatContext);
+  if (context === undefined) {
+    throw new Error("useChat must be used within a ChatProvider");
+  }
+  return context;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -11,6 +11,7 @@ import { ModelsProvider } from "./hooks/use-models";
 import { CostProvider } from "./hooks/use-cost";
 import { AudioPlayerProvider } from "./hooks/use-audio-player";
 import { WebHandlersProvider } from "./hooks/use-web-handlers";
+import { ChatProvider } from "./hooks/use-chat";
 
 ReactDOM.createRoot(document.querySelector("main") as HTMLElement).render(
   <React.StrictMode>
@@ -21,8 +22,10 @@ ReactDOM.createRoot(document.querySelector("main") as HTMLElement).render(
             <CostProvider>
               <ModelsProvider>
                 <UserProvider>
-                  <ColorModeScript initialColorMode={theme.config.initialColorMode} />
-                  <RouterProvider router={router} />
+                  <ChatProvider>
+                    <ColorModeScript initialColorMode={theme.config.initialColorMode} />
+                    <RouterProvider router={router} />
+                  </ChatProvider>
                 </UserProvider>
               </ModelsProvider>
             </CostProvider>


### PR DESCRIPTION
Fixes #818, adding a new `<ChatProvider />` context and associated `useChat()` hook.  We can use this to access the current `chat` anywhere in the React tree without props.

After this lands, it would be nice to refactor our code to not bother passing the chat via props all the time.

You can test this by trying to have the LLM write SQL that references one of the files or tables in DuckDB (e.g., `select * from chatcraft.chats`) and then clicking the run button to execute it.