### PR TITLE
Fix extra UI text getting mixed with message content

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -674,27 +674,29 @@ function MessageBase({
                   </VStack>
                 </form>
               ) : (
-                <Box ref={messageContent} p={1}>
-                  {imageUrls.map((imageUrl, index) => (
-                    <Box key={`${id}-${index}`}>
-                      <Image
-                        src={imageUrl}
-                        alt={`Images# ${index}`}
-                        margin={"auto"}
-                        maxWidth={"100%"}
-                        cursor={"pointer"}
-                        onClick={() => openModalWithImage(imageUrl)}
-                      />
-                    </Box>
-                  ))}
-                  <Markdown
-                    previewCode={!hidePreviews && !displaySummaryText}
-                    isLoading={isLoading}
-                    onPrompt={onPrompt}
-                    className={displaySummaryText ? "message-text message-text-blur" : undefined}
-                  >
-                    {displaySummaryText ? summaryText || text.slice(0, 500).trim() : text}
-                  </Markdown>
+                <Box>
+                  <Box ref={messageContent} p={1}>
+                    {imageUrls.map((imageUrl, index) => (
+                      <Box key={`${id}-${index}`}>
+                        <Image
+                          src={imageUrl}
+                          alt={`Images# ${index}`}
+                          margin={"auto"}
+                          maxWidth={"100%"}
+                          cursor={"pointer"}
+                          onClick={() => openModalWithImage(imageUrl)}
+                        />
+                      </Box>
+                    ))}
+                    <Markdown
+                      previewCode={!hidePreviews && !displaySummaryText}
+                      isLoading={isLoading}
+                      onPrompt={onPrompt}
+                      className={displaySummaryText ? "message-text message-text-blur" : undefined}
+                    >
+                      {displaySummaryText ? summaryText || text.slice(0, 500).trim() : text}
+                    </Markdown>
+                  </Box>
                   <Flex w="100%" justify="space-between" align="center">
                     <Button
                       hidden={!isLongMessage || editing}


### PR DESCRIPTION
This fixes a bug where some UI text gets mixed up with the message content, leading to undesired results when exporting messages in different formats.

I've adjusted the `messageContent` ref to be on a more specific `div` to avoid the above happening.

This closes #824 