### PR TITLE
[FIX] Unique File Name

### DIFF
--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -14,8 +14,6 @@ import ShareModal from "./ShareModal";
 import { download } from "../lib/utils";
 import { Menu, MenuDivider, MenuItem, MenuItemLink, SubMenu } from "./Menu";
 import { acceptableFileFormats } from "../hooks/use-file-import";
-import { generateUniqueFilename } from "../lib/utils";
-import { useFiles } from "../hooks/use-fs";
 
 function ShareMenuItem({ chat }: { chat: ChatCraftChat }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -31,7 +29,7 @@ function ShareMenuItem({ chat }: { chat: ChatCraftChat }) {
 }
 
 type OptionsButtonProps = {
-  chat: ChatCraftChat;
+  chat?: ChatCraftChat;
   forkUrl?: string;
   variant?: "outline" | "solid" | "ghost";
   iconOnly?: boolean;
@@ -52,25 +50,17 @@ function OptionsButton({
   const [, copyToClipboard] = useCopyToClipboard();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { settings } = useSettings();
-  const { refreshFiles, files } = useFiles(chat);
 
   const handleFileChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       if (!onAttachFiles || !event.target.files?.length) {
         return;
       }
-
-      const newFiles = Array.from(event.target.files);
-      const uniqueFiles = newFiles.map((file) => {
-        const uniqueName = generateUniqueFilename(file.name, files);
-        return new File([file], uniqueName, { type: file.type });
-      });
-
-      await onAttachFiles(uniqueFiles)
-        .then(() => refreshFiles)
-        .catch((err) => error({ title: "Unable to Attach Files", message: err.message }));
+      await onAttachFiles(Array.from(event.target.files)).catch((err) =>
+        error({ title: "Unable to Attach Files", message: err.message })
+      );
     },
-    [onAttachFiles, error, refreshFiles, files]
+    [onAttachFiles, error]
   );
 
   const handleAttachFiles = useCallback(() => {

--- a/src/components/OptionsButton.tsx
+++ b/src/components/OptionsButton.tsx
@@ -14,6 +14,8 @@ import ShareModal from "./ShareModal";
 import { download } from "../lib/utils";
 import { Menu, MenuDivider, MenuItem, MenuItemLink, SubMenu } from "./Menu";
 import { acceptableFileFormats } from "../hooks/use-file-import";
+import { generateUniqueFilename } from "../lib/utils";
+import { useFiles } from "../hooks/use-fs";
 
 function ShareMenuItem({ chat }: { chat: ChatCraftChat }) {
   const { isOpen, onOpen, onClose } = useDisclosure();
@@ -29,7 +31,7 @@ function ShareMenuItem({ chat }: { chat: ChatCraftChat }) {
 }
 
 type OptionsButtonProps = {
-  chat?: ChatCraftChat;
+  chat: ChatCraftChat;
   forkUrl?: string;
   variant?: "outline" | "solid" | "ghost";
   iconOnly?: boolean;
@@ -50,17 +52,25 @@ function OptionsButton({
   const [, copyToClipboard] = useCopyToClipboard();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const { settings } = useSettings();
+  const { refreshFiles, files } = useFiles(chat);
 
   const handleFileChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>) => {
       if (!onAttachFiles || !event.target.files?.length) {
         return;
       }
-      await onAttachFiles(Array.from(event.target.files)).catch((err) =>
-        error({ title: "Unable to Attach Files", message: err.message })
-      );
+
+      const newFiles = Array.from(event.target.files);
+      const uniqueFiles = newFiles.map((file) => {
+        const uniqueName = generateUniqueFilename(file.name, files);
+        return new File([file], uniqueName, { type: file.type });
+      });
+
+      await onAttachFiles(uniqueFiles)
+        .then(() => refreshFiles)
+        .catch((err) => error({ title: "Unable to Attach Files", message: err.message }));
     },
-    [onAttachFiles, error]
+    [onAttachFiles, error, refreshFiles, files]
   );
 
   const handleAttachFiles = useCallback(() => {

--- a/src/components/PromptForm/PaperclipIcon.tsx
+++ b/src/components/PromptForm/PaperclipIcon.tsx
@@ -68,7 +68,7 @@ function PaperclipIcon({ chat, onAttachFiles }: PaperClipProps) {
 
   const handleDeleteAll = async () => {
     try {
-      await Promise.all(files.map((file) => removeFile(file.id, chat)));
+      await Promise.all(files.map((file) => removeFile(file.name, chat)));
       refreshFiles();
       onClose();
     } catch (error) {

--- a/src/components/PromptForm/PaperclipIcon.tsx
+++ b/src/components/PromptForm/PaperclipIcon.tsx
@@ -22,6 +22,7 @@ import { useCallback, useRef, useState } from "react";
 import { acceptableFileFormats } from "../../hooks/use-file-import";
 import FileIcon from "../FileIcon";
 import { removeFile } from "../../lib/fs";
+import { generateUniqueFilename } from "../../lib/utils";
 
 type PaperClipProps = {
   chat: ChatCraftChat;
@@ -42,11 +43,19 @@ function PaperclipIcon({ chat, onAttachFiles }: PaperClipProps) {
       if (!onAttachFiles || !event.target.files?.length) {
         return;
       }
-      await onAttachFiles(Array.from(event.target.files))
+
+      const newFiles = Array.from(event.target.files);
+      const uniqueFiles = newFiles.map((file) => {
+        // Create a new File object with potentially modified name
+        const uniqueName = generateUniqueFilename(file.name, files);
+        return new File([file], uniqueName, { type: file.type });
+      });
+
+      await onAttachFiles(uniqueFiles)
         .then(() => refreshFiles)
         .catch((err) => alertError({ title: "Unable to Attach Files", message: err.message }));
     },
-    [onAttachFiles, alertError, refreshFiles]
+    [onAttachFiles, alertError, refreshFiles, files]
   );
 
   const handleAttachFiles = useCallback(() => {
@@ -59,7 +68,7 @@ function PaperclipIcon({ chat, onAttachFiles }: PaperClipProps) {
 
   const handleDeleteAll = async () => {
     try {
-      await Promise.all(files.map((file) => removeFile(file.name, chat)));
+      await Promise.all(files.map((file) => removeFile(file.id, chat)));
       refreshFiles();
       onClose();
     } catch (error) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -17,6 +17,31 @@ export const formatSeconds = (seconds: number) => {
   return `${minutesString}:${secondsString}`;
 };
 
+export const generateUniqueFilename = (
+  filename: string,
+  existingFiles: { name: string }[]
+): string => {
+  const lastDotIndex = filename.lastIndexOf(".");
+  const baseName = lastDotIndex === -1 ? filename : filename.slice(0, lastDotIndex);
+  const extension = lastDotIndex === -1 ? "" : filename.slice(lastDotIndex);
+
+  // If no duplicate exists, return original filename
+  if (!existingFiles.some((file) => file.name === filename)) {
+    return filename;
+  }
+
+  let counter = 1;
+  let newName: string;
+
+  // Keep incrementing counter until we find a unique name
+  do {
+    newName = `${baseName}-${counter}${extension}`;
+    counter++;
+  } while (existingFiles.some((file) => file.name === newName));
+
+  return newName;
+};
+
 export const formatFileSize = (bytes: number) => {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -35,7 +35,7 @@ export const generateUniqueFilename = (
 
   // Keep incrementing counter until we find a unique name
   do {
-    newName = `${baseName}-${counter}${extension}`;
+    newName = `${baseName}(${counter})${extension}`;
     counter++;
   } while (existingFiles.some((file) => file.name === newName));
 


### PR DESCRIPTION
Closes #829 

## Description

As per linked issue, we have a problem. If we try to attach file with the same name as the file in our file system, we wouldn't able to see new file, but we would see it in local storage. This PR fixes it by generating a unique name(-1, -2 etc.) to the end of file name, in case when we have file names duplication. 

## Screenshot 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/7bd88ddb-dfac-4cd3-b6ae-bd400eae78b7" />
