### PR TITLE
Add `CTRL+L` shortcut to clear the chat

### DIFF
--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -12,9 +12,9 @@ function getCommandsHelpText(supportedCommands: ChatCraftCommand[]) {
   with a "/" (e.g., "/help") will be interpreted as a command that ChatCraft should run.
   Some commands accept arguments as well.
 
-  | Command | Description |
-  |-----|------|
-  ${supportedCommands.map((command) => `| ${command.helpTitle} | ${command.helpDescription} |`).join("\n")}
+  | Command | Description | Keyboard Shortcut |
+  |-----|------|------|
+  ${supportedCommands.map((command) => `| ${command.helpTitle} | ${command.helpDescription} |  ${command.keyboardShortcutDescription || "N/A"} |`).join("\n")}
   `;
 }
 

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -1,4 +1,12 @@
-import { FormEvent, KeyboardEvent, type RefObject, useEffect, useMemo, useState } from "react";
+import {
+  FormEvent,
+  KeyboardEvent,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import {
   Box,
   Card,
@@ -159,64 +167,78 @@ function DesktopPromptForm({
   }, []);
 
   // Handle prompt form submission
-  const handlePromptSubmit = (e: FormEvent) => {
-    e.preventDefault();
-    const textValue = inputPromptRef.current?.value.trim() || "";
-    // Clone the current image urls so we don't lose them when we update state below
-    const currentImageUrls = [...inputImageUrls];
+  const handlePromptSubmit = useCallback(
+    (e: FormEvent) => {
+      e.preventDefault();
+      const textValue = inputPromptRef.current?.value.trim() || "";
+      // Clone the current image urls so we don't lose them when we update state below
+      const currentImageUrls = [...inputImageUrls];
 
-    if (inputPromptRef.current) {
-      inputPromptRef.current.value = "";
-    }
-    setIsPromptEmpty(true);
-    setInputImageUrls([]);
+      if (inputPromptRef.current) {
+        inputPromptRef.current.value = "";
+      }
+      setIsPromptEmpty(true);
+      setInputImageUrls([]);
 
-    onSendClick(textValue, currentImageUrls);
-  };
+      onSendClick(textValue, currentImageUrls);
+    },
+    [inputImageUrls, inputPromptRef, onSendClick]
+  );
 
   const handleMetaEnter = useKeyDownHandler<HTMLTextAreaElement>({
     onMetaEnter: handlePromptSubmit,
   });
 
-  const handleKeyDown = async (e: KeyboardEvent<HTMLTextAreaElement>) => {
-    switch (e.key) {
-      // Allow the user to cursor-up to repeat last prompt
-      case "ArrowUp":
-        if (isPromptEmpty && previousMessage && inputPromptRef.current) {
-          e.preventDefault();
-          inputPromptRef.current.value = previousMessage;
-          setIsPromptEmpty(false);
-        }
-        break;
-
-      // Prevent blank submissions and allow for multiline input.
-      case "Enter":
-        if (settings.enterBehaviour === "newline") {
-          handleMetaEnter(e);
-        } else if (settings.enterBehaviour === "send") {
-          if (!e.shiftKey && !isPromptEmpty) {
-            handlePromptSubmit(e);
+  const handleKeyDown = useCallback(
+    async (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      switch (e.key) {
+        // Allow the user to cursor-up to repeat last prompt
+        case "ArrowUp":
+          if (isPromptEmpty && previousMessage && inputPromptRef.current) {
+            e.preventDefault();
+            inputPromptRef.current.value = previousMessage;
+            setIsPromptEmpty(false);
           }
-        }
-        break;
+          break;
 
-      // Shortcut to "/clear" the chat
-      case "l":
-        if (e.ctrlKey) {
-          e.preventDefault();
-          const clearCommand = ChatCraftCommandRegistry.getCommand("/clear");
-
-          if (!clearCommand) {
-            return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
+        // Prevent blank submissions and allow for multiline input.
+        case "Enter":
+          if (settings.enterBehaviour === "newline") {
+            handleMetaEnter(e);
+          } else if (settings.enterBehaviour === "send") {
+            if (!e.shiftKey && !isPromptEmpty) {
+              handlePromptSubmit(e);
+            }
           }
-          await clearCommand(chat, undefined);
-        }
-        break;
+          break;
 
-      default:
-        return;
-    }
-  };
+        // Shortcut to "/clear" the chat
+        case "l":
+          if (e.ctrlKey) {
+            e.preventDefault();
+            const clearCommand = ChatCraftCommandRegistry.getCommand("/clear");
+
+            if (!clearCommand) {
+              return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
+            }
+            await clearCommand(chat, undefined);
+          }
+          break;
+
+        default:
+          return;
+      }
+    },
+    [
+      chat,
+      handleMetaEnter,
+      handlePromptSubmit,
+      inputPromptRef,
+      isPromptEmpty,
+      previousMessage,
+      settings.enterBehaviour,
+    ]
+  );
 
   const handlePaste = (e: ClipboardEvent) => {
     const { clipboardData } = e;

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -442,7 +442,7 @@ function DesktopPromptForm({
                         _dark={{ bg: "gray.700" }}
                         placeholder={
                           !isLoading && !isRecording && !isTranscribing
-                            ? "Ask a question or use /help to learn more ('CTRL+L' to clear chat)"
+                            ? "Ask a question or use /help to learn more ('CTRL+l' to clear chat)"
                             : undefined
                         }
                         overflowY="auto"

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -30,6 +30,7 @@ import ImageModal from "../ImageModal";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { useFileImport } from "../../hooks/use-file-import";
 import PaperclipIcon from "./PaperclipIcon";
+import { ChatCraftCommandRegistry } from "../../lib/ChatCraftCommandRegistry";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -177,7 +178,7 @@ function DesktopPromptForm({
     onMetaEnter: handlePromptSubmit,
   });
 
-  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+  const handleKeyDown = async (e: KeyboardEvent<HTMLTextAreaElement>) => {
     switch (e.key) {
       // Allow the user to cursor-up to repeat last prompt
       case "ArrowUp":
@@ -196,6 +197,19 @@ function DesktopPromptForm({
           if (!e.shiftKey && !isPromptEmpty) {
             handlePromptSubmit(e);
           }
+        }
+        break;
+
+      // Shortcut to "/clear" the chat
+      case "l":
+        if (e.ctrlKey) {
+          e.preventDefault();
+          const clearCommand = ChatCraftCommandRegistry.getCommand("/clear");
+
+          if (!clearCommand) {
+            return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
+          }
+          await clearCommand(chat, undefined);
         }
         break;
 
@@ -406,7 +420,7 @@ function DesktopPromptForm({
                         _dark={{ bg: "gray.700" }}
                         placeholder={
                           !isLoading && !isRecording && !isTranscribing
-                            ? "Ask a question or use /help to learn more"
+                            ? "Ask a question or use /help to learn more ('CTRL+L' to clear chat)"
                             : undefined
                         }
                         overflowY="auto"

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -10,7 +10,8 @@ export abstract class ChatCraftCommand {
   constructor(
     public command: string,
     public helpTitle: string,
-    public helpDescription: string
+    public helpDescription: string,
+    public keyboardShortcutDescription?: string
   ) {}
 
   // This method should be overridden by subclasses to implement the command

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -3,7 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear", "/clear", "Erases all messages in the current chat.");
+    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+L");
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -3,7 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+L");
+    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+l");
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -10,7 +10,7 @@ export class ImageCommand extends ChatCraftCommand {
     super(
       "image",
       "/image [layout-option]<prompt>",
-      "/image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`"
+      "/image&nbsp;[layout-option]<prompt> \\| Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`"
     );
   }
 


### PR DESCRIPTION
I've done some work to implement `CTRL+L` shortcut and close #826 

This PR:
1. Implements the keyboard shortcut for users to clear the chat using `CTRL+L`, which is commonly used to clear the screen in Unix like terminals.
2. Adds a new column to the **commands table** displaying the keyboard shortcut help text for relevant commands, falling back to `N/A` for the rest.
3. Updated the placeholder text of the Desktop Prompt to include "('CTRL+L' to clear chat)" at the end, so its easier for users to discover.

**Note:** One problem that I see with adding `keyboardShortcutDescription` to `ChatCraftCommand` is that the developers need to remember to keep the **description** and **behaviour** in sync, as both things reside at different places.

Here's what the new table looks like:
![message](https://github.com/user-attachments/assets/9176f36a-e17a-43fe-8c32-964a6aacb9dd)



