### PR TITLE
Fix #833 - don't run live queries in hidden tabs

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -59,7 +59,7 @@ import ImageModal from "../ImageModal";
 import Markdown from "../Markdown";
 
 // Styles for the message text are defined in CSS vs. Chakra-UI
-import { useLiveQuery } from "dexie-react-hooks";
+import { useLiveQueryTraced } from "../../lib/performance";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useUser } from "../../hooks/use-user";
@@ -138,7 +138,9 @@ function MessageBase({
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
   const shouldShowDeleteMenu =
     Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;
-  const chat = useLiveQuery(() => ChatCraftChat.find(chatId), [chatId]);
+  const chat = useLiveQueryTraced("message-base-find-chat", () => ChatCraftChat.find(chatId), [
+    chatId,
+  ]);
   const { user } = useUser();
   const handleShareMessage = useCallback(async () => {
     if (!user) {


### PR DESCRIPTION
Fixes #833.  This updates our traced `useLiveQuery` hook to respect page visibility, ignoring queries that try to run when the page isn't visible.

@tarasglek can you test?