### PR TITLE
Don't assume all chats have fileRefs when deleting

### DIFF
--- a/src/lib/ChatCraftChat.ts
+++ b/src/lib/ChatCraftChat.ts
@@ -12,7 +12,6 @@ import {
 import db, {
   ChatCraftFileTable,
   FileRef,
-  isFileRef,
   type ChatCraftChatTable,
   type ChatCraftMessageTable,
 } from "./db";
@@ -543,7 +542,7 @@ export class ChatCraftChat {
       .transaction("rw", [db.chats, db.messages, db.files], async () => {
         // Lock the chat record first
         const chat = await db.chats.get(id);
-        if (!chat?.fileRefs?.every(isFileRef)) {
+        if (!chat) {
           throw new Error("Missing or invalid chat");
         }
 


### PR DESCRIPTION
```
index-CF-5gb3v.js:1352 Unable to delete chat Error: Failed to delete chat bcreFaicu7iAt90EDrwsu. Some data may be in an inconsistent state.
    at index-CF-5gb3v.js:644:2544
    at index-CF-5gb3v.js:422:9568
    at Po (index-CF-5gb3v.js:422:4506)
    at Oi (index-CF-5gb3v.js:422:4911)
    at index-CF-5gb3v.js:422:4763
    at ge (index-CF-5gb3v.js:422:9439)
    at Yo (index-CF-5gb3v.js:422:4740)
```

This is due to us assuming that a chat always has `fileRef`s when we try to delete a chat, and older chats don't necessarily.  We only need to check for the presence of the `chat` itself.