### PR TITLE
Use unique names for screenshots pasted into chat

### DIFF
--- a/src/hooks/use-chat.tsx
+++ b/src/hooks/use-chat.tsx
@@ -1,38 +1,21 @@
-import { createContext, useContext, useState, useEffect } from "react";
+import { createContext, useContext } from "react";
 import { useParams } from "react-router-dom";
 import { ChatCraftChat } from "../lib/ChatCraftChat";
+import { useLiveQueryTraced } from "../lib/performance";
 
 interface ChatContextType {
   chat: ChatCraftChat | undefined;
-  setChat: (chat: ChatCraftChat | undefined) => void;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
 export function ChatProvider({ children }: { children: React.ReactNode }) {
-  const [chat, setChat] = useState<ChatCraftChat | undefined>(undefined);
   const { id } = useParams();
+  const chat = useLiveQueryTraced("find-chat", () => (id ? ChatCraftChat.find(id) : undefined), [
+    id,
+  ]);
 
-  useEffect(() => {
-    async function loadChat() {
-      if (!id) {
-        setChat(undefined);
-        return;
-      }
-
-      try {
-        const loadedChat = await ChatCraftChat.find(id);
-        setChat(loadedChat);
-      } catch (err) {
-        console.error("Error loading chat:", err);
-        setChat(undefined);
-      }
-    }
-
-    loadChat();
-  }, [id]);
-
-  return <ChatContext.Provider value={{ chat, setChat }}>{children}</ChatContext.Provider>;
+  return <ChatContext.Provider value={{ chat }}>{children}</ChatContext.Provider>;
 }
 
 export function useChat() {


### PR DESCRIPTION
MacOS uses `image.png` for all screenshots you paste.