### PR TITLE
Update API key field to not erase key when it does not validate

### DIFF
--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -674,7 +674,7 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                                 paddingRight={"2rem"}
                                 paddingLeft={"0.5rem"}
                                 fontSize="md"
-                                value={provider.apiKey || ""}
+                                value={provider.apiKey}
                                 onChange={(e) => handleApiKeyChange(provider, e.target.value)}
                                 onFocus={() => setFocusedProvider(provider)}
                                 isDisabled={provider instanceof FreeModelProvider}


### PR DESCRIPTION
fixed #851 

Update ModelsSettings.tsx to keep the API key value.
![image](https://github.com/user-attachments/assets/f35634a1-ec15-4b56-8329-52c41be85730)
