### PR TITLE
Use useChat in MessageBase.tsx

### DIFF
--- a/src/components/Message/MessageBase.tsx
+++ b/src/components/Message/MessageBase.tsx
@@ -59,15 +59,14 @@ import ImageModal from "../ImageModal";
 import Markdown from "../Markdown";
 
 // Styles for the message text are defined in CSS vs. Chakra-UI
-import { useLiveQuery } from "dexie-react-hooks";
 import useAudioPlayer from "../../hooks/use-audio-player";
 import useMobileBreakpoint from "../../hooks/use-mobile-breakpoint";
 import { useUser } from "../../hooks/use-user";
-import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { getSentenceChunksFrom } from "../../lib/summarize";
 import "./Message.css";
 import { useTextToSpeech } from "../../hooks/use-text-to-speech";
 import ModelSelectionMenuList from "../Menu/ModelSelectionMenuList";
+import { useChat } from "../../hooks/use-chat";
 
 export interface MessageBaseProps {
   message: ChatCraftMessage;
@@ -138,7 +137,7 @@ function MessageBase({
   const displaySummaryText = !isOpen && (summaryText || isLongMessage);
   const shouldShowDeleteMenu =
     Boolean(onDeleteBeforeClick || onDeleteClick || onDeleteAfterClick) && !disableEdit;
-  const chat = useLiveQuery(() => ChatCraftChat.find(chatId), [chatId]);
+  const { chat } = useChat();
   const { user } = useUser();
   const handleShareMessage = useCallback(async () => {
     if (!user) {


### PR DESCRIPTION
Fixes #835

The `useChat` hook can't be used in any components that are children of `ChatBase`. `ChatBase` receives the `chat` prop from it's parent components `LocalChat` and `RemoteChat`. These components retrieve `chat` using `useLoaderData()`, while the hook retrieves `chat` from the route parameter using `useParams()`. From what I understand, this means the hook can't replace the usage in `LocalChat` and `RemoteChat`.

This leaves `MessageBase` as the only component where `useChat` can be used in it's current implementation.

Using the hook in `LocalChat` and `RemoteChat` will require refactoring them and their usage in `router.tsx`. I'll try this and see if it makes sense to do this.