### PR TITLE
In User Settings > Models > LLM Providers, show "Get OpenRouter Key" button even when OpenRouter is not selected

### DIFF
--- a/src/components/Preferences/ModelsSettings.tsx
+++ b/src/components/Preferences/ModelsSettings.tsx
@@ -700,17 +700,11 @@ function ModelsSettings(isOpen: ModelsSettingsProps) {
                                     : "API Key is required."}
                                 </FormErrorMessage>
                               )}
-                              {provider instanceof OpenRouterProvider &&
-                                provider.name === focusedProvider?.name &&
-                                !provider.apiKey && (
-                                  <Button
-                                    mt="3"
-                                    size="xs"
-                                    onClick={provider.openRouterPkceRedirect}
-                                  >
-                                    Get OpenRouter key{" "}
-                                  </Button>
-                                )}
+                              {provider instanceof OpenRouterProvider && !provider.apiKey && (
+                                <Button mt="3" size="xs" onClick={provider.openRouterPkceRedirect}>
+                                  Get OpenRouter key{" "}
+                                </Button>
+                              )}
                             </FormControl>
                           )}
                         </Td>


### PR DESCRIPTION
Related: #848

Button still doesn't actually get the key but I figured this might be worth landing separately