### PR TITLE
Revert `CTRL+l` shortcut to clear chats

### DIFF
--- a/src/components/Message/AppMessage/Help.tsx
+++ b/src/components/Message/AppMessage/Help.tsx
@@ -12,9 +12,9 @@ function getCommandsHelpText(supportedCommands: ChatCraftCommand[]) {
   with a "/" (e.g., "/help") will be interpreted as a command that ChatCraft should run.
   Some commands accept arguments as well.
 
-  | Command | Description | Keyboard Shortcut |
-  |-----|------|------|
-  ${supportedCommands.map((command) => `| ${command.helpTitle} | ${command.helpDescription} |  ${command.keyboardShortcutDescription || "N/A"} |`).join("\n")}
+  | Command | Description |
+  |-----|------|
+  ${supportedCommands.map((command) => `| ${command.helpTitle} | ${command.helpDescription} |`).join("\n")}
   `;
 }
 

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -221,9 +221,7 @@ function DesktopPromptForm({
             if (!clearCommand) {
               return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
             }
-            if (ClearCommand.isShortcutEnabled()) {
-              await clearCommand(chat, undefined);
-            }
+            await clearCommand(chat, undefined);
           }
           break;
 

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -39,6 +39,7 @@ import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { useFileImport } from "../../hooks/use-file-import";
 import PaperclipIcon from "./PaperclipIcon";
 import { ChatCraftCommandRegistry } from "../../lib/ChatCraftCommandRegistry";
+import { ClearCommand } from "../../lib/commands/ClearCommand";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -442,7 +443,7 @@ function DesktopPromptForm({
                         _dark={{ bg: "gray.700" }}
                         placeholder={
                           !isLoading && !isRecording && !isTranscribing
-                            ? "Ask a question or use /help to learn more ('CTRL+l' to clear chat)"
+                            ? `Ask a question or use /help to learn more${ClearCommand.isShortcutEnabled() ? " ('CTRL+l' to clear chat)" : ""}`
                             : undefined
                         }
                         overflowY="auto"

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -39,7 +39,6 @@ import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { useFileImport } from "../../hooks/use-file-import";
 import PaperclipIcon from "./PaperclipIcon";
 import { ChatCraftCommandRegistry } from "../../lib/ChatCraftCommandRegistry";
-import { ClearCommand } from "../../lib/commands/ClearCommand";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -445,7 +444,7 @@ function DesktopPromptForm({
                         _dark={{ bg: "gray.700" }}
                         placeholder={
                           !isLoading && !isRecording && !isTranscribing
-                            ? `Ask a question or use /help to learn more${ClearCommand.isShortcutEnabled() ? " ('CTRL+l' to clear chat)" : ""}`
+                            ? "Ask a question or use /help to learn more ('CTRL+l' to clear chat)"
                             : undefined
                         }
                         overflowY="auto"

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -1,12 +1,4 @@
-import {
-  FormEvent,
-  KeyboardEvent,
-  type RefObject,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
+import { FormEvent, KeyboardEvent, type RefObject, useEffect, useMemo, useState } from "react";
 import {
   Box,
   Card,
@@ -38,7 +30,6 @@ import ImageModal from "../ImageModal";
 import { ChatCraftChat } from "../../lib/ChatCraftChat";
 import { useFileImport } from "../../hooks/use-file-import";
 import PaperclipIcon from "./PaperclipIcon";
-import { ChatCraftCommandRegistry } from "../../lib/ChatCraftCommandRegistry";
 
 type KeyboardHintProps = {
   isVisible: boolean;
@@ -167,78 +158,51 @@ function DesktopPromptForm({
   }, []);
 
   // Handle prompt form submission
-  const handlePromptSubmit = useCallback(
-    (e: FormEvent) => {
-      e.preventDefault();
-      const textValue = inputPromptRef.current?.value.trim() || "";
-      // Clone the current image urls so we don't lose them when we update state below
-      const currentImageUrls = [...inputImageUrls];
+  const handlePromptSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const textValue = inputPromptRef.current?.value.trim() || "";
+    // Clone the current image urls so we don't lose them when we update state below
+    const currentImageUrls = [...inputImageUrls];
 
-      if (inputPromptRef.current) {
-        inputPromptRef.current.value = "";
-      }
-      setIsPromptEmpty(true);
-      setInputImageUrls([]);
+    if (inputPromptRef.current) {
+      inputPromptRef.current.value = "";
+    }
+    setIsPromptEmpty(true);
+    setInputImageUrls([]);
 
-      onSendClick(textValue, currentImageUrls);
-    },
-    [inputImageUrls, inputPromptRef, onSendClick]
-  );
+    onSendClick(textValue, currentImageUrls);
+  };
 
   const handleMetaEnter = useKeyDownHandler<HTMLTextAreaElement>({
     onMetaEnter: handlePromptSubmit,
   });
 
-  const handleKeyDown = useCallback(
-    async (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      switch (e.key) {
-        // Allow the user to cursor-up to repeat last prompt
-        case "ArrowUp":
-          if (isPromptEmpty && previousMessage && inputPromptRef.current) {
-            e.preventDefault();
-            inputPromptRef.current.value = previousMessage;
-            setIsPromptEmpty(false);
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    switch (e.key) {
+      // Allow the user to cursor-up to repeat last prompt
+      case "ArrowUp":
+        if (isPromptEmpty && previousMessage && inputPromptRef.current) {
+          e.preventDefault();
+          inputPromptRef.current.value = previousMessage;
+          setIsPromptEmpty(false);
+        }
+        break;
+
+      // Prevent blank submissions and allow for multiline input.
+      case "Enter":
+        if (settings.enterBehaviour === "newline") {
+          handleMetaEnter(e);
+        } else if (settings.enterBehaviour === "send") {
+          if (!e.shiftKey && !isPromptEmpty) {
+            handlePromptSubmit(e);
           }
-          break;
+        }
+        break;
 
-        // Prevent blank submissions and allow for multiline input.
-        case "Enter":
-          if (settings.enterBehaviour === "newline") {
-            handleMetaEnter(e);
-          } else if (settings.enterBehaviour === "send") {
-            if (!e.shiftKey && !isPromptEmpty) {
-              handlePromptSubmit(e);
-            }
-          }
-          break;
-
-        // Shortcut to "/clear" the chat
-        case "l":
-          if (e.ctrlKey) {
-            e.preventDefault();
-            const clearCommand = ChatCraftCommandRegistry.getCommand("/clear");
-
-            if (!clearCommand) {
-              return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
-            }
-            await clearCommand(chat, undefined);
-          }
-          break;
-
-        default:
-          return;
-      }
-    },
-    [
-      chat,
-      handleMetaEnter,
-      handlePromptSubmit,
-      inputPromptRef,
-      isPromptEmpty,
-      previousMessage,
-      settings.enterBehaviour,
-    ]
-  );
+      default:
+        return;
+    }
+  };
 
   const handlePaste = (e: ClipboardEvent) => {
     const { clipboardData } = e;
@@ -442,7 +406,7 @@ function DesktopPromptForm({
                         _dark={{ bg: "gray.700" }}
                         placeholder={
                           !isLoading && !isRecording && !isTranscribing
-                            ? "Ask a question or use /help to learn more ('CTRL+l' to clear chat)"
+                            ? "Ask a question or use /help to learn more"
                             : undefined
                         }
                         overflowY="auto"

--- a/src/components/PromptForm/DesktopPromptForm.tsx
+++ b/src/components/PromptForm/DesktopPromptForm.tsx
@@ -222,7 +222,9 @@ function DesktopPromptForm({
             if (!clearCommand) {
               return console.error("Could not find '/clear' command in ChatCraftCommandRegistry!");
             }
-            await clearCommand(chat, undefined);
+            if (ClearCommand.isShortcutEnabled()) {
+              await clearCommand(chat, undefined);
+            }
           }
           break;
 

--- a/src/lib/ChatCraftCommand.ts
+++ b/src/lib/ChatCraftCommand.ts
@@ -10,8 +10,7 @@ export abstract class ChatCraftCommand {
   constructor(
     public command: string,
     public helpTitle: string,
-    public helpDescription: string,
-    public keyboardShortcutDescription?: string
+    public helpDescription: string
   ) {}
 
   // This method should be overridden by subclasses to implement the command

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -7,6 +7,8 @@ export class ClearCommand extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat) {
-    return chat.resetMessages();
+    if (ClearCommand.isShortcutEnabled()) {
+      return chat.resetMessages();
+    }
   }
 }

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -1,23 +1,12 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
-import { isWindows } from "../utils";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    const keyboardShortcutDescription = `CTRL+l${!ClearCommand.isShortcutEnabled() ? " (Unavailable in Windows)" : ""}`;
-    super(
-      "clear",
-      "/clear",
-      "Erases all messages in the current chat.",
-      keyboardShortcutDescription
-    );
+    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+l");
   }
 
   async execute(chat: ChatCraftChat) {
     return chat.resetMessages();
-  }
-
-  static isShortcutEnabled() {
-    return !isWindows();
   }
 }

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -14,9 +14,7 @@ export class ClearCommand extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat) {
-    if (ClearCommand.isShortcutEnabled()) {
-      return chat.resetMessages();
-    }
+    return chat.resetMessages();
   }
 
   static isShortcutEnabled() {

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -1,12 +1,25 @@
 import { ChatCraftCommand } from "../ChatCraftCommand";
 import { ChatCraftChat } from "../ChatCraftChat";
+import { isWindows } from "../utils";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+l");
+    const keyboardShortcutDescription = `CTRL+l${!ClearCommand.isShortcutEnabled() ? " (Unavailable in Windows)" : ""}`;
+    super(
+      "clear",
+      "/clear",
+      "Erases all messages in the current chat.",
+      keyboardShortcutDescription
+    );
   }
 
   async execute(chat: ChatCraftChat) {
-    return chat.resetMessages();
+    if (ClearCommand.isShortcutEnabled()) {
+      return chat.resetMessages();
+    }
+  }
+
+  static isShortcutEnabled() {
+    return !isWindows();
   }
 }

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -3,7 +3,7 @@ import { ChatCraftChat } from "../ChatCraftChat";
 
 export class ClearCommand extends ChatCraftCommand {
   constructor() {
-    super("clear", "/clear", "Erases all messages in the current chat.", "CTRL+l");
+    super("clear", "/clear", "Erases all messages in the current chat.");
   }
 
   async execute(chat: ChatCraftChat) {

--- a/src/lib/commands/ClearCommand.ts
+++ b/src/lib/commands/ClearCommand.ts
@@ -7,8 +7,6 @@ export class ClearCommand extends ChatCraftCommand {
   }
 
   async execute(chat: ChatCraftChat) {
-    if (ClearCommand.isShortcutEnabled()) {
-      return chat.resetMessages();
-    }
+    return chat.resetMessages();
   }
 }

--- a/src/lib/commands/ImageCommand.ts
+++ b/src/lib/commands/ImageCommand.ts
@@ -10,7 +10,7 @@ export class ImageCommand extends ChatCraftCommand {
     super(
       "image",
       "/image [layout-option]<prompt>",
-      "/image&nbsp;[layout-option]<prompt> \\| Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`"
+      "/image&nbsp;[layout-option]<prompt> | Creates an image using the provided prompt. By default, the image will be square, and you can also change the layout to landscape or portrait by specifying `layout=[l\\|landscape\\|p\\|portrait]`"
     );
   }
 


### PR DESCRIPTION
This disables the `CTRL+l` shortcut for the `clear` command on windows so users don't lose their chats accidentally, as it is originally used for focusing on url bar.

I think a proper fix would be the ability for users to toggle shortcuts as per their convenience, and disable them by default. Will file a follow up for further discussion.

![OSSpecificShortcut](https://github.com/user-attachments/assets/7480b331-9e9c-40d7-8595-b9a18e3f76a2)


Fixes #858 