### PR TITLE
[RAG] Stage - 3: Embeddings Generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@emotion/styled": "^11.14.0",
     "@eslint/compat": "^1.2.7",
     "@szhsin/react-menu": "^4.3.1",
+    "@tensorflow-models/universal-sentence-encoder": "^1.3.3",
+    "@tensorflow/tfjs": "^4.22.0",
     "@uiw/react-codemirror": "^4.23.10",
     "apache-arrow": "^17.0.0",
     "browser-image-compression": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,12 @@ importers:
       '@szhsin/react-menu':
         specifier: ^4.3.1
         version: 4.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tensorflow-models/universal-sentence-encoder':
+        specifier: ^1.3.3
+        version: 1.3.3(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs':
+        specifier: ^4.22.0
+        version: 4.22.0(seedrandom@3.0.5)
       '@uiw/react-codemirror':
         specifier: ^4.23.10
         version: 4.23.10(@babel/runtime@7.27.0)(@codemirror/autocomplete@6.18.6)(@codemirror/language@6.11.0)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.6)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.5)(codemirror@6.0.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1912,6 +1918,48 @@ packages:
       react: '>=16.14.0'
       react-dom: '>=16.14.0'
 
+  '@tensorflow-models/universal-sentence-encoder@1.3.3':
+    resolution: {integrity: sha512-mipL7ad0CW6uQ68FUkNgkNj/zgA4qgBnNcnMMkNTdL9MUMnzCxu3AE8pWnx2ReKHwdqEG4e8IpaYKfH4B8bojg==}
+    peerDependencies:
+      '@tensorflow/tfjs-converter': ^3.6.0
+      '@tensorflow/tfjs-core': ^3.6.0
+
+  '@tensorflow/tfjs-backend-cpu@4.22.0':
+    resolution: {integrity: sha512-1u0FmuLGuRAi8D2c3cocHTASGXOmHc/4OvoVDENJayjYkS119fcTcQf4iHrtLthWyDIPy3JiPhRrZQC9EwnhLw==}
+    engines: {yarn: '>= 1.3.2'}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-backend-webgl@4.22.0':
+    resolution: {integrity: sha512-H535XtZWnWgNwSzv538czjVlbJebDl5QTMOth4RXr2p/kJ1qSIXE0vZvEtO+5EC9b00SvhplECny2yDewQb/Yg==}
+    engines: {yarn: '>= 1.3.2'}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-converter@4.22.0':
+    resolution: {integrity: sha512-PT43MGlnzIo+YfbsjM79Lxk9lOq6uUwZuCc8rrp0hfpLjF6Jv8jS84u2jFb+WpUeuF4K33ZDNx8CjiYrGQ2trQ==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-core@4.22.0':
+    resolution: {integrity: sha512-LEkOyzbknKFoWUwfkr59vSB68DMJ4cjwwHgicXN0DUi3a0Vh1Er3JQqCI1Hl86GGZQvY8ezVrtDIvqR1ZFW55A==}
+    engines: {yarn: '>= 1.3.2'}
+
+  '@tensorflow/tfjs-data@4.22.0':
+    resolution: {integrity: sha512-dYmF3LihQIGvtgJrt382hSRH4S0QuAp2w1hXJI2+kOaEqo5HnUPG0k5KA6va+S1yUhx7UBToUKCBHeLHFQRV4w==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      seedrandom: ^3.0.5
+
+  '@tensorflow/tfjs-layers@4.22.0':
+    resolution: {integrity: sha512-lybPj4ZNj9iIAPUj7a8ZW1hg8KQGfqWLlCZDi9eM/oNKCCAgchiyzx8OrYoWmRrB+AM6VNEeIT+2gZKg5ReihA==}
+    peerDependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs@4.22.0':
+    resolution: {integrity: sha512-0TrIrXs6/b7FLhLVNmfh8Sah6JgjBPH4mZ8JGb7NU6WW+cx00qK5BcAZxw7NCzxj6N8MRAIfHq+oNbPUNG5VAg==}
+    hasBin: true
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -2071,6 +2119,9 @@ packages:
   '@types/lodash@4.17.16':
     resolution: {integrity: sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
@@ -2088,6 +2139,12 @@ packages:
 
   '@types/node@22.13.14':
     resolution: {integrity: sha512-Zs/Ollc1SJ8nKUAgc7ivOEdIBM8JAKgrqqUYi2J997JuKO7/tpQC+WCetQ1sypiKCQWHdvdg9wBNpUPEWZae7w==}
+
+  '@types/offscreencanvas@2019.3.0':
+    resolution: {integrity: sha512-esIJx9bQg+QYF0ra8GnvfianIY8qWB0GBx54PK5Eps6m+xTj86KLavHv6qDhzKcu5UUOgNfJ2pWaIIV7TRUd9Q==}
+
+  '@types/offscreencanvas@2019.7.3':
+    resolution: {integrity: sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -2111,6 +2168,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/seedrandom@2.4.34':
+    resolution: {integrity: sha512-ytDiArvrn/3Xk6/vtylys5tlY6eo7Ane0hvcx++TKo6RxQXuVfW0AF/oeWqAj9dN29SyhtawuXstgmPlwNcv/A==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -2227,6 +2287,9 @@ packages:
 
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@webgpu/types@0.1.38':
+    resolution: {integrity: sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==}
 
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
@@ -2603,6 +2666,9 @@ packages:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
     engines: {node: '>=18'}
 
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2705,6 +2771,9 @@ packages:
 
   core-js-compat@3.41.0:
     resolution: {integrity: sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==}
+
+  core-js@3.29.1:
+    resolution: {integrity: sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
@@ -4125,6 +4194,9 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -4410,6 +4482,15 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+
+  node-fetch@2.6.13:
+    resolution: {integrity: sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -4873,6 +4954,9 @@ packages:
   regenerate@1.4.2:
     resolution: {integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
@@ -5037,6 +5121,9 @@ packages:
   screenfull@5.2.0:
     resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==}
     engines: {node: '>=0.10.0'}
+
+  seedrandom@3.0.5:
+    resolution: {integrity: sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -5971,9 +6058,17 @@ packages:
     engines: {node: '>= 14'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
 
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
@@ -7661,6 +7756,72 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-transition-state: 2.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
+  '@tensorflow-models/universal-sentence-encoder@1.3.3(@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0))(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-backend-cpu@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/seedrandom': 2.4.34
+      seedrandom: 3.0.5
+
+  '@tensorflow/tfjs-backend-webgl@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/offscreencanvas': 2019.3.0
+      '@types/seedrandom': 2.4.34
+      seedrandom: 3.0.5
+
+  '@tensorflow/tfjs-converter@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs-core@4.22.0':
+    dependencies:
+      '@types/long': 4.0.2
+      '@types/offscreencanvas': 2019.7.3
+      '@types/seedrandom': 2.4.34
+      '@webgpu/types': 0.1.38
+      long: 4.0.0
+      node-fetch: 2.6.13
+      seedrandom: 3.0.5
+    transitivePeerDependencies:
+      - encoding
+
+  '@tensorflow/tfjs-data@4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+      '@types/node-fetch': 2.6.12
+      node-fetch: 2.6.13
+      seedrandom: 3.0.5
+      string_decoder: 1.3.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@tensorflow/tfjs-layers@4.22.0(@tensorflow/tfjs-core@4.22.0)':
+    dependencies:
+      '@tensorflow/tfjs-core': 4.22.0
+
+  '@tensorflow/tfjs@4.22.0(seedrandom@3.0.5)':
+    dependencies:
+      '@tensorflow/tfjs-backend-cpu': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-backend-webgl': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-converter': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      '@tensorflow/tfjs-core': 4.22.0
+      '@tensorflow/tfjs-data': 4.22.0(@tensorflow/tfjs-core@4.22.0)(seedrandom@3.0.5)
+      '@tensorflow/tfjs-layers': 4.22.0(@tensorflow/tfjs-core@4.22.0)
+      argparse: 1.0.10
+      chalk: 4.1.2
+      core-js: 3.29.1
+      regenerator-runtime: 0.13.11
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - encoding
+      - seedrandom
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.27.0
@@ -7853,6 +8014,8 @@ snapshots:
 
   '@types/lodash@4.17.16': {}
 
+  '@types/long@4.0.2': {}
+
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -7876,6 +8039,10 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/offscreencanvas@2019.3.0': {}
+
+  '@types/offscreencanvas@2019.7.3': {}
+
   '@types/parse-json@4.0.2': {}
 
   '@types/prop-types@15.7.14': {}
@@ -7896,6 +8063,8 @@ snapshots:
   '@types/remove-markdown@0.3.4': {}
 
   '@types/resolve@1.20.2': {}
+
+  '@types/seedrandom@2.4.34': {}
 
   '@types/trusted-types@2.0.7': {}
 
@@ -8059,6 +8228,8 @@ snapshots:
       '@vitest/pretty-format': 2.1.9
       loupe: 3.1.3
       tinyrainbow: 1.2.0
+
+  '@webgpu/types@0.1.38': {}
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -8491,6 +8662,12 @@ snapshots:
       slice-ansi: 5.0.0
       string-width: 7.2.0
 
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -8592,6 +8769,8 @@ snapshots:
   core-js-compat@3.41.0:
     dependencies:
       browserslist: 4.24.4
+
+  core-js@3.29.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -10264,6 +10443,8 @@ snapshots:
       strip-ansi: 7.1.0
       wrap-ansi: 9.0.0
 
+  long@4.0.0: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -10812,6 +10993,10 @@ snapshots:
 
   node-domexception@1.0.0: {}
 
+  node-fetch@2.6.13:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
@@ -11356,6 +11541,8 @@ snapshots:
 
   regenerate@1.4.2: {}
 
+  regenerator-runtime@0.13.11: {}
+
   regenerator-runtime@0.14.1: {}
 
   regenerator-transform@0.15.2:
@@ -11597,6 +11784,8 @@ snapshots:
       loose-envify: 1.4.0
 
   screenfull@5.2.0: {}
+
+  seedrandom@3.0.5: {}
 
   semver@6.3.1: {}
 
@@ -12636,7 +12825,19 @@ snapshots:
 
   yaml@2.7.1: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:

--- a/src/components/Preferences/PreferencesModal.tsx
+++ b/src/components/Preferences/PreferencesModal.tsx
@@ -24,12 +24,14 @@ import ModelsSettings from "./ModelsSettings";
 import WebHandlersConfig from "./WebHandlersConfig";
 import DefaultSystemPrompt from "./DefaultSystemPrompt";
 import CustomizationSettings from "./CustomizationSettings";
+import RagSettings from "./RagSettings";
 import Database from "./Database";
 import { MdOutlineDashboardCustomize, MdSignalCellularAlt } from "react-icons/md";
 import { IconType } from "react-icons";
 import { TbPrompt } from "react-icons/tb";
 import { FaRobot } from "react-icons/fa";
 import { FaDatabase } from "react-icons/fa";
+import { GiBladeDrag } from "react-icons/gi";
 
 type PreferencesModalProps = {
   isOpen: boolean;
@@ -56,6 +58,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
     { name: "Web Handlers", icon: MdSignalCellularAlt },
     { name: "Customization", icon: MdOutlineDashboardCustomize },
     { name: "Database", icon: FaDatabase },
+    { name: "RAG (Experimental)", icon: GiBladeDrag },
   ];
 
   const handleSettingClick = (setting: Setting) => {
@@ -193,6 +196,7 @@ function PreferencesModal({ isOpen, onClose, finalFocusRef }: PreferencesModalPr
               {selectedSetting.name === "Web Handlers" && <WebHandlersConfig />}
               {selectedSetting.name === "Customization" && <CustomizationSettings />}
               {selectedSetting.name === "Database" && <Database />}
+              {selectedSetting.name === "RAG (Experimental)" && <RagSettings />}
             </Box>
           </Flex>
         </ModalBody>

--- a/src/components/Preferences/RagSettings.tsx
+++ b/src/components/Preferences/RagSettings.tsx
@@ -2,7 +2,6 @@ import {
   Checkbox,
   FormControl,
   FormErrorMessage,
-  FormHelperText,
   FormLabel,
   Radio,
   RadioGroup,

--- a/src/components/Preferences/RagSettings.tsx
+++ b/src/components/Preferences/RagSettings.tsx
@@ -1,0 +1,69 @@
+import {
+  Checkbox,
+  FormControl,
+  FormErrorMessage,
+  FormHelperText,
+  FormLabel,
+  Radio,
+  RadioGroup,
+  Slider,
+  SliderFilledTrack,
+  SliderThumb,
+  SliderTrack,
+  Stack,
+  VStack,
+} from "@chakra-ui/react";
+import { useSettings } from "../../hooks/use-settings";
+import { EmbeddingProviderType } from "../../lib/embeddings";
+
+function RagSettings() {
+  const { settings, setSettings } = useSettings();
+
+  return (
+    <VStack gap={6} my={3}>
+      <FormControl>
+        <FormLabel>RAG - Autogeneration Preference</FormLabel>
+        <Checkbox
+          isChecked={settings.autogenerateEmbeddings}
+          onChange={(e) => setSettings({ ...settings, autogenerateEmbeddings: e.target.checked })}
+        >
+          Autogenerate Chunks and Embeddings
+        </Checkbox>
+      </FormControl>
+      <FormControl>
+        <FormLabel>Embedding Strategy:</FormLabel>
+        <RadioGroup
+          value={settings.embeddingProvider}
+          onChange={(nextValue) =>
+            setSettings({ ...settings, embeddingProvider: nextValue as EmbeddingProviderType })
+          }
+          isDisabled={!settings.autogenerateEmbeddings}
+        >
+          <Stack>
+            <Radio value="openai">Open-AI (Requires API KEY!)</Radio>
+            <Radio value="tensorflow">Tensorflow</Radio>
+          </Stack>
+        </RadioGroup>
+      </FormControl>
+      <FormControl>
+        <FormLabel>Embedding Batch Size {settings.embeddingBatchSize} Chunks</FormLabel>
+        <Slider
+          value={settings.embeddingBatchSize}
+          onChange={(value) => setSettings({ ...settings, embeddingBatchSize: value })}
+          min={20}
+          max={80}
+          step={20}
+          isDisabled={!settings.autogenerateEmbeddings}
+        >
+          <SliderTrack>
+            <SliderFilledTrack />
+          </SliderTrack>
+          <SliderThumb />
+        </Slider>
+        <FormErrorMessage>Maximum batch size must be between 20 and 80 chunks</FormErrorMessage>
+      </FormControl>
+    </VStack>
+  );
+}
+
+export default RagSettings;

--- a/src/components/Preferences/RagSettings.tsx
+++ b/src/components/Preferences/RagSettings.tsx
@@ -33,8 +33,12 @@ function RagSettings() {
         <FormLabel>Embedding Strategy:</FormLabel>
         <RadioGroup
           value={settings.embeddingProvider}
-          onChange={(nextValue) =>
-            setSettings({ ...settings, embeddingProvider: nextValue as EmbeddingProviderType })
+          onChange={(value) =>
+            setSettings({
+              ...settings,
+              embeddingProvider: value as EmbeddingProviderType,
+              embeddingMaxBatchSize: value === "openai" ? 4000 : 256,
+            })
           }
           isDisabled={!settings.autogenerateEmbeddings}
         >
@@ -45,13 +49,13 @@ function RagSettings() {
         </RadioGroup>
       </FormControl>
       <FormControl>
-        <FormLabel>Embedding Batch Size {settings.embeddingBatchSize} Chunks</FormLabel>
+        <FormLabel>Embedding Batch Size {settings.embeddingMaxBatchSize} Chunks</FormLabel>
         <Slider
-          value={settings.embeddingBatchSize}
-          onChange={(value) => setSettings({ ...settings, embeddingBatchSize: value })}
-          min={20}
-          max={80}
-          step={20}
+          value={settings.embeddingMaxBatchSize}
+          onChange={(value) => setSettings({ ...settings, embeddingMaxBatchSize: value })}
+          min={settings.embeddingProvider === "openai" ? 500 : 16}
+          max={settings.embeddingProvider === "openai" ? 4000 : 256}
+          step={settings.embeddingMaxBatchSize > 256 ? 500 : 16}
           isDisabled={!settings.autogenerateEmbeddings}
         >
           <SliderTrack>

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -217,14 +217,14 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
       await chat.addFile(chatCraftFile);
 
       // Generate chunks for the file if its size > 300
-      if (!chatCraftFile.hasChunks()) {
+      if (!chatCraftFile.hasChunks() && settings.autogenerateEmbeddings) {
         try {
           await chatCraftFile.generateChunks();
           console.log(
             `Generated ${chatCraftFile.chunks?.length || 0} chunks for file: ${chatCraftFile.name}`
           );
 
-          if (settings.autogenerateEmbeddings && chatCraftFile.hasChunks()) {
+          if (!chatCraftFile.hasEmbeddings()) {
             try {
               await chatCraftFile.generateEmbeddings();
             } catch (err) {

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -216,7 +216,8 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
       const chatCraftFile = await ChatCraftFile.findOrCreate(file, { text });
       await chat.addFile(chatCraftFile);
 
-      // Generate chunks for the file if its size > 300
+      // generates chunks and embeddings only when user decided to turn on
+      // experimental feature
       if (!chatCraftFile.hasChunks() && settings.autogenerateEmbeddings) {
         try {
           await chatCraftFile.generateChunks();

--- a/src/hooks/use-file-import.tsx
+++ b/src/hooks/use-file-import.tsx
@@ -223,6 +223,16 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
           console.log(
             `Generated ${chatCraftFile.chunks?.length || 0} chunks for file: ${chatCraftFile.name}`
           );
+
+          if (settings.autogenerateEmbeddings && chatCraftFile.hasChunks()) {
+            try {
+              await chatCraftFile.generateEmbeddings();
+            } catch (err) {
+              throw new Error(
+                `Error generating embeddings: ${err}, continue without embeddings...`
+              );
+            }
+          }
         } catch (err) {
           throw new Error(`Error generating chunks: ${err}, continue without chunking...`);
         }
@@ -241,7 +251,7 @@ export function useFileImport({ chat, onImageImport }: UseFileImportOptions) {
         await chat.addMessage(new ChatCraftHumanMessage({ text: `${text}\n` }));
       }
     },
-    [chat, onImageImport]
+    [chat, onImageImport, settings]
   );
 
   const importFiles = useCallback(

--- a/src/lib/ChatCraftFile.ts
+++ b/src/lib/ChatCraftFile.ts
@@ -282,7 +282,7 @@ export class ChatCraftFile {
     }
     this.setMetadata("embeddingProvider", provider.id);
     this.setMetadata("embeddingDimensions", provider.dimensions);
-    this.setMetadata("embeddingData", new Date().toISOString());
+    this.setMetadata("embeddingDate", new Date().toISOString());
     await this.setChunks(chunks);
     console.log(`Successfully generated embeddings for all ${chunks.length} chunks`);
   }

--- a/src/lib/ChatCraftFile.ts
+++ b/src/lib/ChatCraftFile.ts
@@ -258,7 +258,7 @@ export class ChatCraftFile {
 
     console.log(`Generating embeddings for ${chunks.length} chunks using ${provider.name}...`);
 
-    const BATCH_SIZE = settings.embeddingBatchSize || 20;
+    const BATCH_SIZE = settings.embeddingMaxBatchSize || 128;
 
     for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
       const batch = chunks.slice(i, i + BATCH_SIZE);

--- a/src/lib/embeddings/EmbeddingProvider.ts
+++ b/src/lib/embeddings/EmbeddingProvider.ts
@@ -23,6 +23,11 @@ export interface EmbeddingProvider {
   readonly dimensions: number;
 
   /**
+   * Maximum batch size of the provider
+   */
+  readonly maxBatchSize: number;
+
+  /**
    * Generate an embedding vector for a single text
    * @param text The text to embed
    * @returns A promise resolving to a vector of numbers

--- a/src/lib/embeddings/EmbeddingProvider.ts
+++ b/src/lib/embeddings/EmbeddingProvider.ts
@@ -1,7 +1,7 @@
 /**
  * Base interface for embedding providers
  */
-export interface EmbeddingProvider {
+export interface EmbeddingsProvider {
   /**
    * Unique identifier for the provider
    */
@@ -28,11 +28,21 @@ export interface EmbeddingProvider {
   readonly maxBatchSize: number;
 
   /**
+   * Minimum batch size of the provider
+   */
+  readonly minBatchSize: number;
+
+  /**
+   * Default batch size of the provider
+   */
+  readonly defaultBatchSize: number;
+
+  /**
    * Generate an embedding vector for a single text
    * @param text The text to embed
    * @returns A promise resolving to a vector of numbers
    */
-  generateEmbedding(text: string): Promise<number[]>;
+  generateEmbeddings(text: string): Promise<number[]>;
 
   /**
    * Generate embedding vectors for multiple texts in batch

--- a/src/lib/embeddings/EmbeddingProvider.ts
+++ b/src/lib/embeddings/EmbeddingProvider.ts
@@ -1,0 +1,38 @@
+/**
+ * Base interface for embedding providers
+ */
+export interface EmbeddingProvider {
+  /**
+   * Unique identifier for the provider
+   */
+  readonly id: string;
+
+  /**
+   * Display name of the provider
+   */
+  readonly name: string;
+
+  /**
+   * Description of the embedding model
+   */
+  readonly description: string;
+
+  /**
+   * Number of dimensions in the embedding vectors
+   */
+  readonly dimensions: number;
+
+  /**
+   * Generate an embedding vector for a single text
+   * @param text The text to embed
+   * @returns A promise resolving to a vector of numbers
+   */
+  generateEmbedding(text: string): Promise<number[]>;
+
+  /**
+   * Generate embedding vectors for multiple texts in batch
+   * @param texts Array of texts to embed
+   * @returns A promise resolving to an array of embedding vectors
+   */
+  generateBatchEmbeddings(texts: string[]): Promise<number[][]>;
+}

--- a/src/lib/embeddings/OpenAIEmbedding.ts
+++ b/src/lib/embeddings/OpenAIEmbedding.ts
@@ -1,0 +1,46 @@
+import { EmbeddingProvider } from "./EmbeddingProvider";
+import OpenAI from "openai";
+
+/**
+ * OpenAI embedding provider - uses the OpenAI API to generate embeddings
+ */
+export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+  readonly id = "openai-text-embedding-3-small";
+  readonly name = "OpenAI text-embedding-3-small";
+  readonly description = "OpenAI's text-embedding-3-small model (1536 dimensions)";
+  readonly dimensions = 1536;
+
+  private apiKey: string;
+  private openai: OpenAI;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+    this.openai = new OpenAI({ apiKey });
+  }
+
+  /**
+   * Generate an embedding vector for a single text
+   */
+  async generateEmbedding(text: string): Promise<number[]> {
+    const result = await this.generateBatchEmbeddings([text]);
+    return result[0];
+  }
+
+  /**
+   * Generate embedding vectors for multiple texts in batch
+   */
+  async generateBatchEmbeddings(texts: string[]): Promise<number[][]> {
+    try {
+      const response = await this.openai.embeddings.create({
+        model: "text-embedding-3-small",
+        input: texts,
+        encoding_format: "float",
+      });
+
+      return response.data.map((item) => item.embedding);
+    } catch (error: any) {
+      console.error("Error generating OpenAI embeddings:", error);
+      throw new Error(`OpenAI API error: ${error.message || "Unknown error"}`);
+    }
+  }
+}

--- a/src/lib/embeddings/OpenAIEmbedding.ts
+++ b/src/lib/embeddings/OpenAIEmbedding.ts
@@ -1,5 +1,5 @@
-import { getSettings } from "../settings";
 import { EmbeddingProvider } from "./EmbeddingProvider";
+import OpenAI from "openai";
 
 /**
  * OpenAI embedding provider - uses the OpenAI API to generate embeddings
@@ -11,10 +11,10 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly dimensions = 1536;
   readonly url = `https://api.openai.com/v1/embeddings`;
 
-  private apiKey: string;
+  private openai: OpenAI;
 
   constructor(apiKey: string) {
-    this.apiKey = apiKey;
+    this.openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
   }
 
   /**
@@ -30,26 +30,13 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
    */
   async generateBatchEmbeddings(texts: string[]): Promise<number[][]> {
     try {
-      const settings = getSettings();
-      const response = await fetch(`${this.url}`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${settings.currentProvider.apiKey}`,
-        },
-        body: JSON.stringify({
-          model: `text-embedding-3-small`,
-          input: texts,
-          encoding_format: "float",
-        }),
+      const response = await this.openai.embeddings.create({
+        model: "text-embedding-3-small",
+        input: texts,
+        encoding_format: "float",
       });
 
-      if (!response.ok) {
-        const errorData = await response.json().catch(() => ({}));
-        throw new Error(`OpenAI API error: ${errorData.error?.message || response.statusText}`);
-      }
-      const res = await response.json();
-      return res.data.map((item: any) => item.embedding);
+      return response.data.map((item) => item.embedding);
     } catch (error: any) {
       console.error("Error generating OpenAI embeddings:", error);
       throw new Error(`OpenAI API error: ${error.message || "Unknown error"}`);

--- a/src/lib/embeddings/OpenAIEmbedding.ts
+++ b/src/lib/embeddings/OpenAIEmbedding.ts
@@ -10,6 +10,7 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   readonly description = "OpenAI's text-embedding-3-small model (1536 dimensions)";
   readonly dimensions = 1536;
   readonly url = `https://api.openai.com/v1/embeddings`;
+  readonly maxBatchSize = 4000;
 
   private openai: OpenAI;
 

--- a/src/lib/embeddings/OpenAIEmbedding.ts
+++ b/src/lib/embeddings/OpenAIEmbedding.ts
@@ -31,7 +31,6 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
   async generateBatchEmbeddings(texts: string[]): Promise<number[][]> {
     try {
       const settings = getSettings();
-      console.log(`Current API KEY is: ${settings.currentProvider.apiKey}`);
       const response = await fetch(`${this.url}`, {
         method: "POST",
         headers: {

--- a/src/lib/embeddings/OpenAIEmbedding.ts
+++ b/src/lib/embeddings/OpenAIEmbedding.ts
@@ -1,27 +1,39 @@
-import { EmbeddingProvider } from "./EmbeddingProvider";
+import { EmbeddingsProvider } from "./EmbeddingProvider";
 import OpenAI from "openai";
 
 /**
  * OpenAI embedding provider - uses the OpenAI API to generate embeddings
  */
-export class OpenAIEmbeddingProvider implements EmbeddingProvider {
+export class OpenAIEmbeddingsProvider implements EmbeddingsProvider {
   readonly id = "openai-text-embedding-3-small";
   readonly name = "OpenAI text-embedding-3-small";
   readonly description = "OpenAI's text-embedding-3-small model (1536 dimensions)";
   readonly dimensions = 1536;
   readonly url = `https://api.openai.com/v1/embeddings`;
   readonly maxBatchSize = 4000;
+  readonly defaultBatchSize = 2000;
+  readonly minBatchSize = 500;
+
+  static readonly CONFIG = {
+    dimensions: 1536,
+    maxBatchSize: 4000,
+    defaultBatchSize: 2000,
+    minBatchSize: 500,
+  };
 
   private openai: OpenAI;
 
   constructor(apiKey: string) {
     this.openai = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
   }
+  get CONFIG(): void {
+    throw new Error("Method not implemented.");
+  }
 
   /**
    * Generate an embedding vector for a single text
    */
-  async generateEmbedding(text: string): Promise<number[]> {
+  async generateEmbeddings(text: string): Promise<number[]> {
     const result = await this.generateBatchEmbeddings([text]);
     return result[0];
   }

--- a/src/lib/embeddings/TensorflowEmbedding.ts
+++ b/src/lib/embeddings/TensorflowEmbedding.ts
@@ -1,0 +1,78 @@
+import { EmbeddingProvider } from "./EmbeddingProvider";
+
+/**
+ * TensorFlow.js-based embedding provider
+ * Uses Universal Sentence Encoder for local embedding generation
+ */
+export class TensorflowEmbeddingProvider implements EmbeddingProvider {
+  readonly id = "tensorflow-use";
+  readonly name = "TensorFlow Universal Sentence Encoder";
+  readonly description = "Local embedding model using TensorFlow.js (512 dimensions)";
+  readonly dimensions = 512;
+
+  private model: any = null;
+  private isLoading: boolean = false;
+  private loadPromise: Promise<void> | null = null;
+
+  constructor() {}
+
+  /**
+   * Load the model if it hasn't been loaded yet
+   */
+  private async loadModelIfNeeded(): Promise<void> {
+    if (this.model) return;
+
+    if (!this.loadPromise) {
+      this.isLoading = true;
+
+      this.loadPromise = (async () => {
+        try {
+          console.log("Loading Universal Sentence Encoder model...");
+
+          await import("@tensorflow/tfjs");
+
+          const use = await import("@tensorflow-models/universal-sentence-encoder");
+
+          this.model = await use.load();
+          console.log("Universal Sentence Encoder loaded successfully");
+        } catch (err) {
+          console.error("Failed to load Universal Sentence Encoder:", err);
+          this.loadPromise = null;
+          throw err;
+        } finally {
+          this.isLoading = false;
+        }
+      })();
+    }
+
+    return this.loadPromise;
+  }
+
+  /**
+   * Generate an embedding vector for a single text
+   */
+  async generateEmbedding(text: string): Promise<number[]> {
+    const result = await this.generateBatchEmbeddings([text]);
+    return result[0];
+  }
+
+  /**
+   * Generate embedding vectors for multiple texts in batch
+   */
+  async generateBatchEmbeddings(texts: string[]): Promise<number[][]> {
+    try {
+      await this.loadModelIfNeeded();
+
+      const embeddings = await this.model.embed(texts);
+
+      const arrays = await embeddings.array();
+
+      embeddings.dispose();
+
+      return arrays;
+    } catch (error: any) {
+      console.error("Error generating TensorFlow embeddings:", error);
+      throw new Error(`TensorFlow embedding error: ${error.message || "Unknown error"}`);
+    }
+  }
+}

--- a/src/lib/embeddings/TensorflowEmbedding.ts
+++ b/src/lib/embeddings/TensorflowEmbedding.ts
@@ -1,22 +1,33 @@
-import { EmbeddingProvider } from "./EmbeddingProvider";
+import { EmbeddingsProvider } from "./EmbeddingProvider";
 
 /**
  * TensorFlow.js-based embedding provider
  * Uses Universal Sentence Encoder for local embedding generation
  */
-export class TensorflowEmbeddingProvider implements EmbeddingProvider {
+export class TensorflowEmbeddingsProvider implements EmbeddingsProvider {
   readonly id = "tensorflow-use";
   readonly name = "TensorFlow Universal Sentence Encoder";
   readonly description = "Local embedding model using TensorFlow.js (512 dimensions)";
   readonly dimensions = 512;
   readonly maxBatchSize = 256;
+  readonly defaultBatchSize = 128;
+  readonly minBatchSize = 16;
+
+  static readonly CONFIG = {
+    dimensions: 512,
+    maxBatchSize: 256,
+    defaultBatchSize: 128,
+    minBatchSize: 16,
+  };
 
   private model: any = null;
   private isLoading: boolean = false;
   private loadPromise: Promise<void> | null = null;
 
   constructor() {}
-
+  get CONFIG(): void {
+    throw new Error("Method not implemented.");
+  }
   /**
    * Load the model if it hasn't been loaded yet
    */
@@ -54,7 +65,7 @@ export class TensorflowEmbeddingProvider implements EmbeddingProvider {
   /**
    * Generate an embedding vector for a single text
    */
-  async generateEmbedding(text: string): Promise<number[]> {
+  async generateEmbeddings(text: string): Promise<number[]> {
     const result = await this.generateBatchEmbeddings([text]);
     return result[0];
   }

--- a/src/lib/embeddings/TensorflowEmbedding.ts
+++ b/src/lib/embeddings/TensorflowEmbedding.ts
@@ -9,6 +9,7 @@ export class TensorflowEmbeddingProvider implements EmbeddingProvider {
   readonly name = "TensorFlow Universal Sentence Encoder";
   readonly description = "Local embedding model using TensorFlow.js (512 dimensions)";
   readonly dimensions = 512;
+  readonly maxBatchSize = 256;
 
   private model: any = null;
   private isLoading: boolean = false;

--- a/src/lib/embeddings/TensorflowEmbedding.ts
+++ b/src/lib/embeddings/TensorflowEmbedding.ts
@@ -62,19 +62,22 @@ export class TensorflowEmbeddingProvider implements EmbeddingProvider {
    * Generate embedding vectors for multiple texts in batch
    */
   async generateBatchEmbeddings(texts: string[]): Promise<number[][]> {
+    let embeddings;
     try {
       await this.loadModelIfNeeded();
 
-      const embeddings = await this.model.embed(texts);
+      embeddings = await this.model.embed(texts);
 
       const arrays = await embeddings.array();
-
-      embeddings.dispose();
 
       return arrays;
     } catch (error: any) {
       console.error("Error generating TensorFlow embeddings:", error);
       throw new Error(`TensorFlow embedding error: ${error.message || "Unknown error"}`);
+    } finally {
+      if (embeddings) {
+        embeddings.dispose();
+      }
     }
   }
 }

--- a/src/lib/embeddings/TensorflowEmbedding.ts
+++ b/src/lib/embeddings/TensorflowEmbedding.ts
@@ -20,7 +20,9 @@ export class TensorflowEmbeddingProvider implements EmbeddingProvider {
    * Load the model if it hasn't been loaded yet
    */
   private async loadModelIfNeeded(): Promise<void> {
-    if (this.model) return;
+    if (this.model) {
+      return;
+    }
 
     if (!this.loadPromise) {
       this.isLoading = true;

--- a/src/lib/embeddings/index.ts
+++ b/src/lib/embeddings/index.ts
@@ -1,0 +1,50 @@
+import { EmbeddingProvider } from "./EmbeddingProvider";
+import { OpenAIEmbeddingProvider } from "./OpenAIEmbedding";
+import { TensorflowEmbeddingProvider } from "./TensorflowEmbedding";
+import { getSettings } from "../settings";
+
+/**
+ * Supported embedding provider types
+ */
+export type EmbeddingProviderType = "openai" | "tensorflow";
+
+const providers: Record<EmbeddingProviderType, EmbeddingProvider | null> = {
+  openai: null,
+  tensorflow: null,
+};
+
+/**
+ * Get an embedding provider instance
+ */
+export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProvider {
+  const settings = getSettings();
+
+  if (!providers[type]) {
+    switch (type) {
+      case "openai":
+        if (!settings.currentProvider.apiKey) {
+          throw new Error("OpenAI API key is required for embeddings");
+        }
+        providers[type] = new OpenAIEmbeddingProvider(settings.currentProvider.apiKey);
+        break;
+
+      case "tensorflow":
+        providers[type] = new TensorflowEmbeddingProvider();
+        break;
+
+      default:
+        throw new Error(`Unknown embedding provider type: ${type}`);
+    }
+  }
+
+  return providers[type]!;
+}
+
+/**
+ * Clear provider cache - useful for testing or when API keys change
+ */
+export function clearEmbeddingProviders(): void {
+  Object.keys(providers).forEach((key) => {
+    providers[key as EmbeddingProviderType] = null;
+  });
+}

--- a/src/lib/embeddings/index.ts
+++ b/src/lib/embeddings/index.ts
@@ -1,14 +1,19 @@
-import { EmbeddingProvider } from "./EmbeddingProvider";
-import { OpenAIEmbeddingProvider } from "./OpenAIEmbedding";
-import { TensorflowEmbeddingProvider } from "./TensorflowEmbedding";
+import { EmbeddingsProvider } from "./EmbeddingProvider";
+import { OpenAIEmbeddingsProvider } from "./OpenAIEmbedding";
+import { TensorflowEmbeddingsProvider } from "./TensorflowEmbedding";
 import { getSettings } from "../settings";
 
 /**
  * Supported embedding provider types
  */
-export type EmbeddingProviderType = "openai" | "tensorflow";
+export type EmbeddingsProviderType = "openai" | "tensorflow";
 
-const providers: Record<EmbeddingProviderType, EmbeddingProvider | null> = {
+export const EMBEDDINGS_PROVIDER_CONFIG = {
+  openai: OpenAIEmbeddingsProvider.CONFIG,
+  tensorflow: TensorflowEmbeddingsProvider.CONFIG,
+};
+
+const providers: Record<EmbeddingsProviderType, EmbeddingsProvider | null> = {
   openai: null,
   tensorflow: null,
 };
@@ -16,7 +21,7 @@ const providers: Record<EmbeddingProviderType, EmbeddingProvider | null> = {
 /**
  * Get an embedding provider instance
  */
-export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProvider {
+export function getEmbeddingsProvider(type: EmbeddingsProviderType): EmbeddingsProvider {
   const settings = getSettings();
 
   if (!providers[type]) {
@@ -25,22 +30,22 @@ export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProv
         if (!settings.currentProvider.apiKey) {
           throw new Error("OpenAI API key is required for embeddings");
         }
-        providers[type] = new OpenAIEmbeddingProvider(settings.currentProvider.apiKey);
+        providers[type] = new OpenAIEmbeddingsProvider(settings.currentProvider.apiKey);
 
         break;
 
       case "tensorflow":
-        providers[type] = new TensorflowEmbeddingProvider();
+        providers[type] = new TensorflowEmbeddingsProvider();
         break;
 
       default:
         throw new Error(`Unknown embedding provider type: ${type}`);
     }
 
-    settings.embeddingMaxBatchSize = providers[type].maxBatchSize;
+    settings.embeddingsBatchSize = providers[type].defaultBatchSize;
   }
 
-  return providers[type]!;
+  return providers[type];
 }
 
 /**
@@ -48,6 +53,6 @@ export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProv
  */
 export function clearEmbeddingProviders(): void {
   Object.keys(providers).forEach((key) => {
-    providers[key as EmbeddingProviderType] = null;
+    providers[key as EmbeddingsProviderType] = null;
   });
 }

--- a/src/lib/embeddings/index.ts
+++ b/src/lib/embeddings/index.ts
@@ -26,6 +26,7 @@ export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProv
           throw new Error("OpenAI API key is required for embeddings");
         }
         providers[type] = new OpenAIEmbeddingProvider(settings.currentProvider.apiKey);
+
         break;
 
       case "tensorflow":
@@ -35,6 +36,8 @@ export function getEmbeddingProvider(type: EmbeddingProviderType): EmbeddingProv
       default:
         throw new Error(`Unknown embedding provider type: ${type}`);
     }
+
+    settings.embeddingMaxBatchSize = providers[type].maxBatchSize;
   }
 
   return providers[type]!;

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,7 +9,7 @@ import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { ChatCraftProvider, NonLLMProviderData, ProviderData } from "../lib/ChatCraftProvider";
 import { providerFromJSON, providerFromUrl } from "./providers";
 import { FreeModelProvider } from "./providers/DefaultProvider/FreeModelProvider";
-import { EmbeddingProviderType } from "./embeddings";
+import { EmbeddingsProviderType } from "./embeddings";
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
@@ -44,9 +44,9 @@ export type Settings = {
   compressionFactor: number;
   maxCompressedFileSizeMB: number;
   maxImageDimension: number;
-  embeddingProvider: EmbeddingProviderType;
+  embeddingsProvider: EmbeddingsProviderType;
   autogenerateEmbeddings: boolean;
-  embeddingMaxBatchSize: number;
+  embeddingsBatchSize: number;
 };
 
 export const defaults: Settings = {
@@ -68,9 +68,9 @@ export const defaults: Settings = {
   compressionFactor: 1,
   maxCompressedFileSizeMB: 20,
   maxImageDimension: 2048,
-  embeddingProvider: "tensorflow",
+  embeddingsProvider: "tensorflow",
   autogenerateEmbeddings: false,
-  embeddingMaxBatchSize: 256,
+  embeddingsBatchSize: 128,
 };
 
 export const key = "settings";

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,6 +9,7 @@ import { ChatCraftModel } from "../lib/ChatCraftModel";
 import { ChatCraftProvider, NonLLMProviderData, ProviderData } from "../lib/ChatCraftProvider";
 import { providerFromJSON, providerFromUrl } from "./providers";
 import { FreeModelProvider } from "./providers/DefaultProvider/FreeModelProvider";
+import { EmbeddingProviderType } from "./embeddings";
 /**
  * We can use models from OpenAI or OpenRouter (https://openrouter.ai/docs).
  * If using the latter, we need to override the basePath to use the OpenRouter URL.
@@ -43,6 +44,9 @@ export type Settings = {
   compressionFactor: number;
   maxCompressedFileSizeMB: number;
   maxImageDimension: number;
+  embeddingProvider: EmbeddingProviderType;
+  autogenerateEmbeddings: boolean;
+  embeddingBatchSize: number;
 };
 
 export const defaults: Settings = {
@@ -64,6 +68,9 @@ export const defaults: Settings = {
   compressionFactor: 1,
   maxCompressedFileSizeMB: 20,
   maxImageDimension: 2048,
+  embeddingProvider: "tensorflow",
+  autogenerateEmbeddings: true,
+  embeddingBatchSize: 20,
 };
 
 export const key = "settings";

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -69,7 +69,7 @@ export const defaults: Settings = {
   maxCompressedFileSizeMB: 20,
   maxImageDimension: 2048,
   embeddingProvider: "tensorflow",
-  autogenerateEmbeddings: true,
+  autogenerateEmbeddings: false,
   embeddingBatchSize: 20,
 };
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -46,7 +46,7 @@ export type Settings = {
   maxImageDimension: number;
   embeddingProvider: EmbeddingProviderType;
   autogenerateEmbeddings: boolean;
-  embeddingBatchSize: number;
+  embeddingMaxBatchSize: number;
 };
 
 export const defaults: Settings = {
@@ -70,7 +70,7 @@ export const defaults: Settings = {
   maxImageDimension: 2048,
   embeddingProvider: "tensorflow",
   autogenerateEmbeddings: false,
-  embeddingBatchSize: 20,
+  embeddingMaxBatchSize: 256,
 };
 
 export const key = "settings";


### PR DESCRIPTION
## Description

This is **stage 3** of #868. We are adding the capability of generation and storage vector embeddings for document chunks. It introduces modular embedding provider archtecture, and supports:
* OpenAI's **text-embedding-3-small** API
* Local **tensorflow.js** alternative

[ChatCraftFile](https://github.com/tarasglek/chatcraft.org/blob/mulla028/868-3/src/lib/ChatCraftFile.ts) has been extended with methods to:

- generate embeddings
- store embeddings
- manage embeddings

Integrated embedding generation with the [use-file-import](https://github.com/tarasglek/chatcraft.org/blob/mulla028/868-3/src/hooks/use-file-import.tsx) to **automatically create embeddings after chunking**. 

**New settings added** to control:
- the embedding provider
- batch size
- automatic generation preference

> [!IMPORTANT]
> UI for the embedding preferences required! Therefore, we must land this PR with the updated Settings UI...

## Test It

>[!TIP]
> You may want to test it. In order to do so follow the steps below!

1. Open `CloudFlare` deployment below
2. Upload File **>=300KB**
3. Go to **DevTools**
4. `Application` → `Storage` → `IndexedDB` → `ChatCraftDatabase` → `files`
5. Wuolah! You can see the generated embeddings! (I HOPE :D) 

## Screenshot

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/36fd071c-6a07-48f7-9a54-6918ab954045" />


#### Question 

Maybe we could reduce the size of the minimum chunking size from 300KB → 100 KB. Therefore, the minimum character per chunk is from 1000 → 300. 

